### PR TITLE
Semantics4

### DIFF
--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -621,14 +621,14 @@
 
       <p>An <dfn>RDF* simple interpretation</dfn> |I| is a structure consisting of:</p>
       <ol>
-        <li>A non-empty set |IR| of resources, called the domain or universe of |I|, and containing all <a>ground RDF* terms</a>.</li>
+        <li>A non-empty set |IR| of resources, called the domain or universe of |I|, and containing all <a>RDF* terms</a>.</li>
         <li>A set |IP|, called the set of properties of |I|.</li>
         <li>A mapping |IEXT| from |IP| into the powerset of |IR|×|IR| i.e. the set of sets of pairs (|x|,|y|) with |x| and |y| in |IR|.</li>
         <li>A mapping |IS| from <a>IRIs</a> into |IR|∪|IP|.</li>
         <li>A partial mapping |IL| from <a>literals</a> into |IR|.</li>
       </ol>
 
-      <p>This definition is identical to the definition of <dfn data-cite="RDF11-MT#dfn-simple-interpretation">simple interpretation</dfn> [[RDF11-MT]], except for the requirement on |I| to contain all <a>RDF* ground terms</a>. Any <a>RDF* simple interpretation</a> is therefore also an RDF <a>simple interpretation</a>, and any RDF <a>simple interpretation</a> can be extended into an <a>RDF* simple interpretation</a> simply by adding all <a>ground RDF* terms</a> in |I|.</p>
+      <p>This definition is identical to the definition of <dfn data-cite="RDF11-MT#dfn-simple-interpretation">simple interpretation</dfn> [[RDF11-MT]], except for the requirement on |IR| to contain all <a>RDF* terms</a>. Any <a>RDF* simple interpretation</a> is therefore also an RDF <a>simple interpretation</a>, and any RDF <a>simple interpretation</a> can be extended into an <a>RDF* simple interpretation</a> simply by adding all <a>RDF* terms</a> in |IR|.</p>
 
       <section>
         <h2>Semantic condition for ground graphs</h2>
@@ -654,32 +654,32 @@
       <section>
         <h2>Semantic condition with blank nodes</h2>
         
-        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="abn">asserted blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>asserted triple</a>. Note that the intersection of <a>ebn</a> and <a>abn</a> is not necessarily empty.</p>
+        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="abn">asserted blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>asserted triple</a>. Note that the intersection of <a>ebn</a> and <a>abn</a> may be non-empty.</p>
 
-        <p>Suppose |I| is an <a>RDF* simple interpretation</a>,|A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|, and <var>Γ</var> is a mapping from a set of <a>blank nodes</a> to the set of <a>ground RDF* terms</a> (which is also a subset of |IR|). Define the mappings [|I|+|A|+<var>Γ</var>] and [|I|+<var>Γ</var>] of <a>RDF* terms</a> into |IR| as follows.</p>
+        <p>Suppose |I| is an <a>RDF* simple interpretation</a>, |A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|, and <var>Γ</var> is a mapping from a set of <a>blank nodes</a> to the set of <a>RDF* terms</a> (which is also a subset of |IR|). Define the mappings [|I|+|A|/<var>Γ</var>] and [|I|+<var>Γ</var>] of <a>RDF* terms</a> into |IR| as follows.</p>
         
         <ul>
-          <li>if |E| is a <a>blank node</a> then [|I|+|A|+<var>Γ</var>](|E|) = |A|(|E|) if it is defined, |E| otherwise</li>
-          <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+|A|+<var>Γ</var>](|E|) = |E|</li>
-          <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+|A|+<var>Γ</var>](|E|) = ([|I|+<var>Γ</var>](|s|),[|I|+<var>Γ</var>](|p|),[|I|+<var>Γ</var>](|o|))</li>
+          <li>if |E| is a <a>blank node</a> then [|I|+|A|/<var>Γ</var>](|E|) = |A|(|E|) if it is defined, |E| otherwise</li>
+          <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+|A|/<var>Γ</var>](|E|) = |E|</li>
+          <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+|A|/<var>Γ</var>](|E|) = ([|I|+<var>Γ</var>](|s|),[|I|+<var>Γ</var>](|p|),[|I|+<var>Γ</var>](|o|))</li>
           <li>if |E| is a <a>blank node</a> then [|I|+<var>Γ</var>](|E|) = <var>Γ</var>(|E|) if it is defined, |E| otherwise</li>
           <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+<var>Γ</var>](|E|) = |E|</li>
           <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+<var>Γ</var>](|E|) = ([|I|+<var>Γ</var>](|s|),[|I|+<var>Γ</var>](|p|),[|I|+<var>Γ</var>](|o|))</li>
         </ul>
         
-        <p>Extend the mapping [|I|+|A|+<var>Γ</var>] to <a>RDF* graphs</a> using <a href="#semantic-condition-ground-graphs">the rules given above for ground graphs</a>. Then the denotation of any <a>RDF* graph</a> in |I| is given by:</p>
+        <p>Extend the mapping [|I|+|A|/<var>Γ</var>] to <a>RDF* graphs</a> using <a href="#semantic-condition-ground-graphs">the rules given above for ground graphs</a>. Then the denotation of any <a>RDF* graph</a> in |I| is given by:</p>
 
         <ul>
           <li>If |E| is an <a>RDF* graph</a>, |I|(|E|)=<ul>
             <li>true if there exists
               <ul>
                 <li>a mapping |A| from <a>abn</a>(|E|) into |IR|, and</li>
-                <li>a mapping <var>Γ</var> from <a>ebn</a>(|E|) into <a>ground RDF* terms</a></li>
+                <li>a mapping <var>Γ</var> from <a>ebn</a>(|E|) into <a>RDF* terms</a></li>
               </ul>
               such that
               <ul>
-                <li>for all |b| in <a>abn</a>(|E|) ∩ <a>ebn</a>(|E|), |I|(<var>Γ</var>(|b|) = |A|(|b|), and</li>
-                <li>[|I|+|A|+<var>Γ</var>]((|E|))=true</li>
+                <li>for all |b| in <a>abn</a>(|E|) ∩ <a>ebn</a>(|E|), |I|(<var>Γ</var>(|b|)) = |A|(|b|), and</li>
+                <li>[|I|+|A|/<var>Γ</var>]((|E|))=true</li>
               </ul>
             </li>
             <li>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -630,61 +630,68 @@
 
       <p>This definition is identical to the definition of <dfn data-cite="RDF11-MT#dfn-simple-interpretation">simple interpretation</dfn> [[RDF11-MT]], except for the requirement on |IR| to contain all <a>RDF* terms</a>. Any <a>RDF* simple interpretation</a> is therefore also an RDF <a>simple interpretation</a>, and any RDF <a>simple interpretation</a> can be extended into an <a>RDF* simple interpretation</a> simply by adding all <a>RDF* terms</a> in |IR|.</p>
 
+      <p>The denotation of an <a>RDF* term</a> in an <a>RDF* simple interpretation</a> |I| is then given by the following rules, where the interpretation is also treated as a function:</p>
+
+      <ul id="semantic-condition-terms">
+        <li>if |E| is a <a>literal</a> then |I|(|E|) = |IL|(|E|)</li>
+        <li>if |E| is an <a>IRI</a> then |I|(|E|) = |IS|(|E|)</li>
+        <li>if |E| is an <a>RDF* triple</a> then |I|(|E|) = |E|</li>
+      </ul>
+
+      <p>Notice that <a>blank nodes</a> have no defined denotation in a <a>simple interpretation</a>. Note however that any <a>RDF* triple</a>, including non-<a>ground</a> triples, have a denotation (which is themselves).</p>
+
       <section>
         <h2>Semantic condition for ground graphs</h2>
-        <p>The denotation of a <a>ground RDF* graph</a> in an <a>RDF* simple interpretation</a> |I| is then given by the following rules, where the interpretation is also treated as a function from expressions (terms, triples and graphs) to elements of the universe and truth values:</p>
+        <p>The above rules for denotation are extended for <a>ground RDF* graphs</a>, that are considered to denote a truth value:</p>
 
         <ul id="semantic-condition-ground-graphs">
-          <li>if |E| is a <a>literal</a> then |I|(|E|) = |IL|(|E|)</li>
-          <li>if |E| is an <a>IRI</a> then |I|(|E|) = |IS|(|E|)</li>
-          <li>if |E| is a <a>ground RDF* triple</a> then |I|(|E|) = |E|</li>
           <li>if |E| is an <a>RDF* graph</a> then |I|(|E|) =<ul>
             <li>true if for every <a>asserted triple</a> (|s|,|p|,|o|) ∈ |E|, (|I|(|s|),|I|(|o|)) ∈ |IEXT|(|I|(|p|))</li>
             <li>false otherwise</li>
           </ul>
         </ul>
 
-        <p>Since |IL| is a partial mapping, |I|(|E|) may be undefined for some <a>literal</a> |E|. In that case, |E| has no semantic value in |I|, so any <a>asserted triple</a> having E as <a>object</a> it will fail to satisfy the condition above, hence any <a>graph</a> containing such <a>asserted triple</a> will be false. Note however that <a>embedded triples</a> containing |E| do not prevent that triple from having a semantic value, nor the graph from being true.</p>
+        <p>Since |IL| is a partial mapping, |I|(|E|) may be undefined for some <a>literal</a> |E|. In that case, |E| has no semantic value in |I|, so any <a>asserted triple</a> having E as <a>object</a> will fail to satisfy the condition above, hence any <a>graph</a> containing such <a>asserted triples</a> will be false. Note however that <a>embedded triples</a> containing |E| do not prevent that triple from having a semantic value, nor the graph from being true.</p>
 
         <div class="note">
-          In the <a data-cite="RDF11-MT#semantic-condition-for-ground-graphs">original condition for simple entailment</a> [[RDF11-MT]], the denotation of an <a>RDF triple</a> is a boolean, while above we define the denotation of an <a>RDF* triple</a> to be an element of the universe. However, the denotation of any <a>RDF graph</a> is always the same under the original condition and the condition above. Therefore, the condition above can be considered as an extension of the original one to support any <a>RDF* graph</a>.
+          In the <a data-cite="RDF11-MT#semantic-condition-for-ground-graphs">original condition for simple entailment</a> [[RDF11-MT]], the denotation of an <a>RDF triple</a> is a boolean, while above we define the denotation of an <a>RDF* triple</a> to be an element of the universe. However, the denotation of any <a>RDF graph</a> is always the same under the original condition and the condition above. Therefore, the condition above can be considered as an extension of the original one to support any <a>ground RDF* graph</a>.
         </div>
       </section>
 
       <section>
         <h2>Semantic condition with blank nodes</h2>
         
-        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="abn">asserted blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>asserted triple</a>. Note that the intersection of <a>ebn</a> and <a>abn</a> may be non-empty.</p>
+        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in the <a>constituent terms</a> of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="abn">asserted blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>asserted triple</a>. Note that the intersection of <a>ebn</a> and <a>abn</a> may be non-empty.</p>
 
-        <p>Suppose |I| is an <a>RDF* simple interpretation</a>, |A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|, and <var>Γ</var> is a mapping from a set of <a>blank nodes</a> to the set of <a>RDF* terms</a> (which is also a subset of |IR|). Define the mappings [|I|+|A|/<var>Γ</var>] and [<var>Γ</var>] of <a>RDF* terms</a> into |IR| as follows.</p>
+        <p>Suppose |I| is an <a>RDF* simple interpretation</a>, |A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|, and |B| is a mapping from a set of <a>blank nodes</a> to the set of <a>RDF* terms</a> (which is also a subset of |IR|). Define the mappings [|I|+|A|+|B|] and [|B|] of <a>RDF* terms</a> into |IR| as follows.</p>
         
         <ul>
-          <li>[|I|+|A|/<var>Γ</var>]:<ul>
+          <li>[|I|+|A|+|B|]:<ul>
 
-            <li>if |E| is a <a>blank node</a> then [|I|+|A|/<var>Γ</var>](|E|) = |A|(|E|) if it is defined, |E| otherwise</li>
-            <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+|A|/<var>Γ</var>](|E|) = I(|E|)</li>
-            <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+|A|/<var>Γ</var>](|E|) = ([<var>Γ</var>](|s|),[<var>Γ</var>](|p|),[<var>Γ</var>](|o|))</li>
+            <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+|A|+|B|](|E|) = |I|(|E|)</li>
+            <li>if |E| is a <a>blank node</a> then [|I|+|A|+|B|](|E|) = |A|(|E|)</li>
+            <li>if |E| is an <a>RDF* triple</a>, then [|I|+|A|+|B|](|E|) = [|B|](|E|)
           </ul></li>
-          <li>[<var>Γ</var>]:<ul>
-            <li>if |E| is a <a>blank node</a> then [<var>Γ</var>](|E|) = <var>Γ</var>(|E|) if it is defined, |E| otherwise</li>
-            <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [<var>Γ</var>](|E|) = |E|</li>
-            <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [<var>Γ</var>](|E|) = ([<var>Γ</var>](|s|),[<var>Γ</var>](|p|),[<var>Γ</var>](|o|))</li>
+          <li>[|B|]:<ul>
+            <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|B|](|E|) = |E|</li>
+            <li>if |E| is a <a>blank node</a> then [|B|](|E|) = |B|(|E|)</li>
+            <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|B|](|E|) = ([|B|](|s|),[|B|](|p|),[|B|](|o|))</li>
           </ul></li>
         </ul>
         
-        <p>Extend the mapping [|I|+|A|/<var>Γ</var>] to <a>RDF* graphs</a> using <a href="#semantic-condition-ground-graphs">the rules given above for ground graphs</a>. Then the denotation of any <a>RDF* graph</a> in |I| is given by:</p>
+        <p>Extend the mapping [|I|+|A|+|B|] to <a>RDF* graphs</a> using <a href="#semantic-condition-ground-graphs">the rules given above for ground graphs</a>. Then the denotation of any <a>RDF* graph</a> in |I| is given by:</p>
 
         <ul>
           <li>If |E| is an <a>RDF* graph</a>, |I|(|E|)=<ul>
             <li>true if there exists
               <ul>
                 <li>a mapping |A| from <a>abn</a>(|E|) into |IR|, and</li>
-                <li>a mapping <var>Γ</var> from <a>ebn</a>(|E|) into <a>RDF* terms</a></li>
+                <li>a mapping |B| from <a>ebn</a>(|E|) into <a>RDF* terms</a></li>
               </ul>
               such that
               <ul>
-                <li>for all |b| in <a>abn</a>(|E|) ∩ <a>ebn</a>(|E|), |I|(<var>Γ</var>(|b|)) = |A|(|b|), and</li>
-                <li>[|I|+|A|/<var>Γ</var>]((|E|))=true</li>
+                <li>for all |b| ∈ <a>abn</a>(|E|) ∩ <a>ebn</a>(|E|), |B|(|b|) is not a blank node and |I|(|B|(|b|)) = |A|(|b|), and</li>
+                <li>[|I|+|A|+|B|](|E|)=true</li>
               </ul>
             </li>
             <li>
@@ -694,8 +701,9 @@
         </ul>
 
         <div class="note">
-          For the special case of a standard <a>RDF graph</a> and an RDF <a>simple interpretation</a>, the condition above is equivalent to the one defined in [[[RDF11-MT]]], which only requires a mapping |A|. Indeed, since <a>RDF graphs</a> have no <a>embedded triples</a>, the empty mapping is the only possible choice for <var>Γ</var>, and it trivially satisfies the dependency condition on |A| and <var>Γ</var>.
+          For the special case of a standard <a>RDF graph</a> and an RDF <a>simple interpretation</a>, the condition above is equivalent to the one defined in [[[RDF11-MT]]], which only requires a mapping |A|. Indeed, since <a>RDF graphs</a> have no <a>embedded triples</a>, <a>ebn</a>(|E|) is empty, |B| can only be the empty mapping, and [|I|+|A|+|B|] is equivalent [|I|+|A|].
         </div>
+
       </section>
 
       <section>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -705,6 +705,8 @@
     <section class="informative">
       <h2>Design Rationale</h2>
 
+      <div class="issue">This section is not up-to-date with the previous one.</div>
+
       <p>In this section, we discuss a number of desired features of RDF* semantics in order to shed light on the design choices made in the previous section</p>
 
       <section>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -621,14 +621,14 @@
 
       <p>An <dfn>RDF* simple interpretation</dfn> |I| is a structure consisting of:</p>
       <ol>
-        <li>A non-empty set |IR| of resources, called the domain or universe of |I|, and containing all RDF* <a>ground</a> triples.</li>
+        <li>A non-empty set |IR| of resources, called the domain or universe of |I|, and containing all <a>ground RDF* terms</a>.</li>
         <li>A set |IP|, called the set of properties of |I|.</li>
         <li>A mapping |IEXT| from |IP| into the powerset of |IR|×|IR| i.e. the set of sets of pairs (|x|,|y|) with |x| and |y| in |IR|.</li>
         <li>A mapping |IS| from <a>IRIs</a> into |IR|∪|IP|.</li>
         <li>A partial mapping |IL| from <a>literals</a> into |IR|.</li>
       </ol>
 
-      <p>This definition is identical to the definition of <dfn data-cite="RDF11-MT#dfn-simple-interpretation">simple interpretation</dfn> [[RDF11-MT]], except for the requirement on |I| to contain all RDF* <a>ground</a> triples. Any RDF <a>simple interpretation</a> can therefore be exteneded into an <a>RDF* simple interpretation</a> by adding all RDF* <a>ground</a> triples in |I|.</p>
+      <p>This definition is identical to the definition of <dfn data-cite="RDF11-MT#dfn-simple-interpretation">simple interpretation</dfn> [[RDF11-MT]], except for the requirement on |I| to contain all <a>RDF* ground terms</a>. Any <a>RDF* simple interpretation</a> is therefore also an RDF <a>simple interpretation</a>, and any RDF <a>simple interpretation</a> can be extended into an <a>RDF* simple interpretation</a> simply by adding all <a>ground RDF* terms</a> in |I|.</p>
 
       <section>
         <h2>Semantic condition for ground graphs</h2>
@@ -654,27 +654,33 @@
       <section>
         <h2>Semantic condition with blank nodes</h2>
         
-        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="obn">open blank nodes</dfn> of |E| all the other blank nodes appearing in |E| (that is, those appearing only as the subject or object of asserted triples).</p>
+        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="abn">asserted blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>asserted triple</a>. Note that the intersection of <a>ebn</a> and <a>abn</a> is not necessarily empty.</p>
 
-        <p>A mapping from a set of <a>blank nodes</a> into a set of <a>ground RDF* terms</a> is called a <dfn>grounding function</dfn>. We define the extended application of a <a>grounding function</a> <var>Γ</var> to other <a>RDF* terms</a> and to <a>RDF* graphs</a> as follows:</p>
-
+        <p>Suppose |I| is an <a>RDF* simple interpretation</a>,|A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|, and <var>Γ</var> is a mapping from a set of <a>blank nodes</a> to the set of <a>ground RDF* terms</a> (which is also a subset of |IR|). Define the mappings [|I|+|A|+<var>Γ</var>] and [|I|+<var>Γ</var>] of <a>RDF* terms</a> into |IR| as follows.</p>
+        
         <ul>
-          <li>if |E| is a <a>blank node</a> then <var>Γ</var>*(|E|) = <var>Γ</var>(|E|) if it is defined, |E| otherwise</li>
-          <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then <var>Γ</var>*(|E|) = |E|</li>
-          <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then <var>Γ</var>*(|E|) = (<var>Γ</var>*(|s|),<var>Γ</var>*(|p|),<var>Γ</var>*(|o|))</li>
-          <li>if |E| is an <a>RDF* graph</a>, then <var>Γ</var>*(|E|) = {<var>Γ</var>*(|t|) for all |t| ∈ |E|} </li>
+          <li>if |E| is a <a>blank node</a> then [|I|+|A|+<var>Γ</var>](|E|) = |A|(|E|) if it is defined, |E| otherwise</li>
+          <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+|A|+<var>Γ</var>](|E|) = |E|</li>
+          <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+|A|+<var>Γ</var>](|E|) = ([|I|+<var>Γ</var>](|s|),[|I|+<var>Γ</var>](|p|),[|I|+<var>Γ</var>](|o|))</li>
+          <li>if |E| is a <a>blank node</a> then [|I|+<var>Γ</var>](|E|) = <var>Γ</var>(|E|) if it is defined, |E| otherwise</li>
+          <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+<var>Γ</var>](|E|) = |E|</li>
+          <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+<var>Γ</var>](|E|) = ([|I|+<var>Γ</var>](|s|),[|I|+<var>Γ</var>](|p|),[|I|+<var>Γ</var>](|o|))</li>
         </ul>
-
-        <p>Suppose |I| is an <a>RDF* simple interpretation</a> and |A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|. Define the mapping [|I|+|A|] of <a>RDF* terms</a> into |IR| to be |A| on blank nodes of the set, and |I| on any other term; and extend this mapping to <a>RDF* triples</a> and <a>RDF* graphs</a> using <a href="#semantic-condition-ground-graphs">the rules given above for ground graphs</a>. Then the denotation of any <a>RDF* graph</a> in |I| is given by:</p>
+        
+        <p>Extend the mapping [|I|+|A|+<var>Γ</var>] to <a>RDF* graphs</a> using <a href="#semantic-condition-ground-graphs">the rules given above for ground graphs</a>. Then the denotation of any <a>RDF* graph</a> in |I| is given by:</p>
 
         <ul>
           <li>If |E| is an <a>RDF* graph</a>, |I|(|E|)=<ul>
             <li>true if there exists
               <ul>
-                <li>a mapping |A| from <a>obn</a>(|E|) into |IR|, and</li>
-                <li>a <a>grounding function</a> <var>Γ</var> from <a>ebn</a>(|E|) into <a>ground RDF* terms</a></li>
+                <li>a mapping |A| from <a>abn</a>(|E|) into |IR|, and</li>
+                <li>a mapping <var>Γ</var> from <a>ebn</a>(|E|) into <a>ground RDF* terms</a></li>
               </ul>
-              such that [|I|+|A|](<var>Γ</var>*(|E|))=true
+              such that
+              <ul>
+                <li>for all |b| in <a>abn</a>(|E|) ∩ <a>ebn</a>(|E|), |I|(<var>Γ</var>(|b|) = |A|(|b|), and</li>
+                <li>[|I|+|A|+<var>Γ</var>]((|E|))=true</li>
+              </ul>
             </li>
             <li>
               false otherwise
@@ -683,7 +689,7 @@
         </ul>
 
         <div class="note">
-          For the special case of a standard <a>RDF graph</a> and an RDF <a>simple interpretation</a>, the condition above is equivalent to the one defined in [[[RDF11-MT]]], which only requires a mapping |A|, but no <a>grounding function</a>. Indeed, since <a>RDF graphs</a> have no <a>embedded triples</a>, the empty mapping is the only possible choice for <var>Γ</var>, and <var>Γ</var>* maps the graph to itself.
+          For the special case of a standard <a>RDF graph</a> and an RDF <a>simple interpretation</a>, the condition above is equivalent to the one defined in [[[RDF11-MT]]], which only requires a mapping |A|. Indeed, since <a>RDF graphs</a> have no <a>embedded triples</a>, the empty mapping is the only possible choice for <var>Γ</var>, and it trivially satisfies the dependency condition on |A| and <var>Γ</var>.
         </div>
       </section>
 

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -690,7 +690,10 @@
               </ul>
               such that
               <ul>
-                <li>for all |b| ∈ <a>abn</a>(|E|) ∩ <a>ebn</a>(|E|), |B|(|b|) is not a blank node and |I|(|B|(|b|)) = |A|(|b|), and</li>
+                <li>for all |b| ∈ <a>abn</a>(|E|) ∩ <a>ebn</a>(|E|), either<ul>
+                  <li>|B|(|b|) is not a blank node and |I|(|B|(|b|)) = |A|(|b|), or</li>
+                  <li>|B|(|b|) is a blank node and |A|(|B|(|b|)) = |A|(|b|),</li>
+                </ul>and,</li>
                 <li>[|I|+|A|+|B|](|E|)=true</li>
               </ul>
             </li>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -621,15 +621,14 @@
 
       <p>An <dfn>RDF* simple interpretation</dfn> |I| is a structure consisting of:</p>
       <ol>
-        <li>A non-empty set |IR| of resources, called the domain or universe of |I|.</li>
+        <li>A non-empty set |IR| of resources, called the domain or universe of |I|, and containing all RDF* <a>ground</a> triples.</li>
         <li>A set |IP|, called the set of properties of |I|.</li>
         <li>A mapping |IEXT| from |IP| into the powerset of |IR|×|IR| i.e. the set of sets of pairs (|x|,|y|) with |x| and |y| in |IR|.</li>
         <li>A mapping |IS| from <a>IRIs</a> into |IR|∪|IP|.</li>
         <li>A partial mapping |IL| from <a>literals</a> into |IR|.</li>
-        <li>A partial mapping |IT| from <a>ground RDF* triples</a> into |IR|, such that for any two <a>triples</a> (|s1|,|p1|,|o1|) and (|s2|,|p2|,|o2|), |IT|(|s1|,|p1|,|o1|)=|IT|(|s2|,|p2|,|o2|) implies |IG|(|s1|)=|IG|(|s2|), |IG|(|p1|)=|IG|(|p2|) and |IG|(|o1|)=|IG|(|o2|), where |IG|=|IS|∪|IL|∪|IT|.</li>
       </ol>
 
-      <p>This definition is identical to the definition of <dfn data-cite="RDF11-MT#dfn-simple-interpretation">simple interpretation</dfn> [[RDF11-MT]] up to item 5 included. Item 6 extends it to support <a>RDF* triples</a>. Any RDF <a>simple interpretation</a> can be considered as an <a>RDF* simple interpretation</a> with |IT|=∅.</p>
+      <p>This definition is identical to the definition of <dfn data-cite="RDF11-MT#dfn-simple-interpretation">simple interpretation</dfn> [[RDF11-MT]], except for the requirement on |I| to contain all RDF* <a>ground</a> triples. Any RDF <a>simple interpretation</a> can therefore be exteneded into an <a>RDF* simple interpretation</a> by adding all RDF* <a>ground</a> triples in |I|.</p>
 
       <section>
         <h2>Semantic condition for ground graphs</h2>
@@ -638,14 +637,14 @@
         <ul id="semantic-condition-ground-graphs">
           <li>if |E| is a <a>literal</a> then |I|(|E|) = |IL|(|E|)</li>
           <li>if |E| is an <a>IRI</a> then |I|(|E|) = |IS|(|E|)</li>
-          <li>if |E| is a <a>ground RDF* triple</a> then |I|(|E|) = |IT|(|E|)</li>
+          <li>if |E| is a <a>ground RDF* triple</a> then |I|(|E|) = |E|</li>
           <li>if |E| is an <a>RDF* graph</a> then |I|(|E|) =<ul>
             <li>true if for every <a>asserted triple</a> (|s|,|p|,|o|) ∈ |E|, (|I|(|s|),|I|(|o|)) ∈ |IEXT|(|I|(|p|))</li>
             <li>false otherwise</li>
           </ul>
         </ul>
 
-        <p>Since |IL| and |IT| are partial mappings, |I|(|E|) may be undefined for some <a>literal</a> or <a>triple</a> |E|. In that case, |E| has no semantic value in |I|, so any <a>asserted triple</a> having E as <a>subject</a> or <a>object</a> it will fail to satisfy the condition above, hence any <a>graph</a> containing such <a>asserted triple</a> will be false.</p>
+        <p>Since |IL| is a partial mapping, |I|(|E|) may be undefined for some <a>literal</a> |E|. In that case, |E| has no semantic value in |I|, so any <a>asserted triple</a> having E as <a>object</a> it will fail to satisfy the condition above, hence any <a>graph</a> containing such <a>asserted triple</a> will be false. Note however that <a>embedded triples</a> containing |E| do not prevent that triple from having a semantic value, nor the graph from being true.</p>
 
         <div class="note">
           In the <a data-cite="RDF11-MT#semantic-condition-for-ground-graphs">original condition for simple entailment</a> [[RDF11-MT]], the denotation of an <a>RDF triple</a> is a boolean, while above we define the denotation of an <a>RDF* triple</a> to be an element of the universe. However, the denotation of any <a>RDF graph</a> is always the same under the original condition and the condition above. Therefore, the condition above can be considered as an extension of the original one to support any <a>RDF* graph</a>.
@@ -655,9 +654,9 @@
       <section>
         <h2>Semantic condition with blank nodes</h2>
         
-        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="obn">open blank nodes</dfn> of |E| all the other blank nodes appearing in |E|.</p>
+        <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="obn">open blank nodes</dfn> of |E| all the other blank nodes appearing in |E| (that is, those appearing only as the subject or object of asserted triples).</p>
 
-        <p>A mapping from a set <a>blank nodes</a> into a set of <a>ground RDF* terms</a> is called a <dfn>grounding function</dfn>. We define the extended application of a <a>grounding function</a> <var>Γ</var> to other <a>RDF* terms</a> and to <a>RDF* graphs</a> as follows:</p>
+        <p>A mapping from a set of <a>blank nodes</a> into a set of <a>ground RDF* terms</a> is called a <dfn>grounding function</dfn>. We define the extended application of a <a>grounding function</a> <var>Γ</var> to other <a>RDF* terms</a> and to <a>RDF* graphs</a> as follows:</p>
 
         <ul>
           <li>if |E| is a <a>blank node</a> then <var>Γ</var>*(|E|) = <var>Γ</var>(|E|) if it is defined, |E| otherwise</li>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -656,15 +656,20 @@
         
         <p>Given an <a>RDF* graph</a> |E|, we call the <dfn data-abbr="ebn">embedded blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>embedded triple</a> in |E|; we call the <dfn data-abbr="abn">asserted blank nodes</dfn> of |E| the set of <a>blank nodes</a> appearing in <a>subject</a> or <a>object</a> position of some <a>asserted triple</a>. Note that the intersection of <a>ebn</a> and <a>abn</a> may be non-empty.</p>
 
-        <p>Suppose |I| is an <a>RDF* simple interpretation</a>, |A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|, and <var>Γ</var> is a mapping from a set of <a>blank nodes</a> to the set of <a>RDF* terms</a> (which is also a subset of |IR|). Define the mappings [|I|+|A|/<var>Γ</var>] and [|I|+<var>Γ</var>] of <a>RDF* terms</a> into |IR| as follows.</p>
+        <p>Suppose |I| is an <a>RDF* simple interpretation</a>, |A| is a mapping from a set of <a>blank nodes</a> to the universe |IR| of |I|, and <var>Γ</var> is a mapping from a set of <a>blank nodes</a> to the set of <a>RDF* terms</a> (which is also a subset of |IR|). Define the mappings [|I|+|A|/<var>Γ</var>] and [<var>Γ</var>] of <a>RDF* terms</a> into |IR| as follows.</p>
         
         <ul>
-          <li>if |E| is a <a>blank node</a> then [|I|+|A|/<var>Γ</var>](|E|) = |A|(|E|) if it is defined, |E| otherwise</li>
-          <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+|A|/<var>Γ</var>](|E|) = |E|</li>
-          <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+|A|/<var>Γ</var>](|E|) = ([|I|+<var>Γ</var>](|s|),[|I|+<var>Γ</var>](|p|),[|I|+<var>Γ</var>](|o|))</li>
-          <li>if |E| is a <a>blank node</a> then [|I|+<var>Γ</var>](|E|) = <var>Γ</var>(|E|) if it is defined, |E| otherwise</li>
-          <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+<var>Γ</var>](|E|) = |E|</li>
-          <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+<var>Γ</var>](|E|) = ([|I|+<var>Γ</var>](|s|),[|I|+<var>Γ</var>](|p|),[|I|+<var>Γ</var>](|o|))</li>
+          <li>[|I|+|A|/<var>Γ</var>]:<ul>
+
+            <li>if |E| is a <a>blank node</a> then [|I|+|A|/<var>Γ</var>](|E|) = |A|(|E|) if it is defined, |E| otherwise</li>
+            <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [|I|+|A|/<var>Γ</var>](|E|) = I(|E|)</li>
+            <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [|I|+|A|/<var>Γ</var>](|E|) = ([<var>Γ</var>](|s|),[<var>Γ</var>](|p|),[<var>Γ</var>](|o|))</li>
+          </ul></li>
+          <li>[<var>Γ</var>]:<ul>
+            <li>if |E| is a <a>blank node</a> then [<var>Γ</var>](|E|) = <var>Γ</var>(|E|) if it is defined, |E| otherwise</li>
+            <li>if |E| is an <a>IRI</a> or a <a>literal</a>, then [<var>Γ</var>](|E|) = |E|</li>
+            <li>if |E| is an <a>RDF* triple</a> (|s|,|p|,|o|), then [<var>Γ</var>](|E|) = ([<var>Γ</var>](|s|),[<var>Γ</var>](|p|),[<var>Γ</var>](|o|))</li>
+          </ul></li>
         </ul>
         
         <p>Extend the mapping [|I|+|A|/<var>Γ</var>] to <a>RDF* graphs</a> using <a href="#semantic-condition-ground-graphs">the rules given above for ground graphs</a>. Then the denotation of any <a>RDF* graph</a> in |I| is given by:</p>


### PR DESCRIPTION
exit grounding function,
embedded bnodes are now more like existential variables


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/pull/51.html" title="Last updated on Dec 9, 2020, 2:38 PM UTC (18b6c1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/51/4669e42...18b6c1c.html" title="Last updated on Dec 9, 2020, 2:38 PM UTC (18b6c1c)">Diff</a>