### PR TITLE
annotation syntax for SPARQL*

### DIFF
--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -560,7 +560,7 @@
                 class="nohighlight example"
               >
                 <!--
-                ?x :p :o1 .
+                ?x :p :o1, o2 .
                 <<?x :p :o1>> :ap1 ?y ;
                               :ap2 ?z .
                 <<?x :p :o2>> :ap3 ?z .

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -430,20 +430,11 @@
           <td>`ObjectListPath`</td>
           <td>::=</td>
           <td>
-            <a href="#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
             `(`
               <code class="token">','</code>
-              <a href="#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+              <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
             `)*`
-          </td>
-        </tr>
-        <tr id="rObjectPath">
-          <td>[87]</td>
-          <td>`ObjectPath`</td>
-          <td>::=</td>
-          <td>
-            <a data-cite="SPARQL11-QUERY#rGraphNode">GraphNode</a> `|`
-            <a href="#rEmbTP">EmbTP</a>
           </td>
         </tr>
         <tr id="rGraphNodePath">

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -425,6 +425,27 @@
             <a data-cite="SPARQL11-QUERY#rPropertyListPath">PropertyListPath</a>
           </td>
         </tr>
+        <tr id="rObjectListPath">
+          <td>[86]</td>
+          <td>`ObjectListPath`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            `(`
+              <code class="token">','</code>
+              <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            `)*`
+          </td>
+        </tr>
+        <tr id="rObjectPath">
+          <td>[87]</td>
+          <td>`ObjectPath`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="SPARQL11-QUERY#rGraphNode">GraphNode</a> `|`
+            <a href="#rEmbTP">EmbTP</a>
+          </td>
+        </tr>
         <tr id="rGraphNodePath">
           <td>[105]</td>
           <td>`GraphNodePath`</td>
@@ -497,7 +518,7 @@
       </p>
 
       <p>
-        Additionally, the <a href="#rObjectList">ObjectList</a> production now accepts an optional <dfn>annotation pattern</dfn> after each object.
+        Additionally, both the <a href="#rObjectList">ObjectList</a> and the <a href="#rObjectListPath">ObjectListPath</a> productions now accept an optional <dfn>annotation pattern</dfn> after each object.
       </p>
 
       <div class="issue" data-number="6"></div>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -430,10 +430,10 @@
           <td>`ObjectListPath`</td>
           <td>::=</td>
           <td>
-            <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPatternPath">AnnotationPatternPath</a>`?`
             `(`
               <code class="token">','</code>
-              <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+              <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPatternPath">AnnotationPatternPath</a>`?`
             `)*`
           </td>
         </tr>
@@ -489,6 +489,16 @@
           <td>
             <code class="token">'{|'</code>
             <a data-cite="SPARQL11-QUERY#rPropertyListNotEmpty">PropertyListNotEmpty</a>
+            <code class="token">'|}'</code>
+          </td>
+        </tr>
+        <tr id="rAnnotationPatternPath">
+          <td>[178]</td>
+          <td>`AnnotationPatternPath`</td>
+          <td>::=</td>
+          <td>
+            <code class="token">'{|'</code>
+            <a data-cite="SPARQL11-QUERY#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>
             <code class="token">'|}'</code>
           </td>
         </tr>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -524,11 +524,41 @@
       <section>
         <h2>Expand Syntax Forms</h2>
 
-        <p>The translation process starts with expanding <q>abbreviations for IRIs and triple patterns</q> [<a data-cite="SPARQL11-QUERY#sparqlExpandForms">SPARQL11-QUERY, Section 18.2.2.1</a>]. This step MUST be extended in two ways:</p>
+        <p>The translation process starts with expanding <q>abbreviations for IRIs and triple patterns</q> [<a data-cite="SPARQL11-QUERY#sparqlExpandForms">SPARQL11-QUERY, Section 18.2.2.1</a>]. This step MUST be extended in three ways:</p>
 
         <ol>
           <li><div>
-            <p>Abbreviations for <a>triple patterns</a> with <a>embedded triple patterns</a> MUST be expanded as if each <a>embedded triple pattern</a> was a <a>variable</a> (or an <a>RDF term</a>).
+            <p><a>Annotation patterns</a> MUST be replaced by additional <a>SPARQL* triple patterns</a> that have the annotated triple pattern as an <a>embedded triple pattern</a> in their subject position.</p>
+
+            <div class="example">
+              For instance, the following syntax expression:
+              <pre data-transform="updateExample"
+                data-content-type="application/x-sparql-star-query"
+                class="nohighlight example"
+              >
+                <!--
+                ?x :p :o1 {| :ap1 ?y;
+                             :ap2 ?z |} ,
+                      :o2 {| :ap3 ?z |} .
+                -->
+              </pre>
+              must be replaced by
+              <pre data-transform="updateExample"
+                data-content-type="application/x-sparql-star-query"
+                class="nohighlight example"
+              >
+                <!--
+                ?x :p :o1 .
+                <<?x :p :o1>> :ap1 ?y ;
+                              :ap2 ?z .
+                <<?x :p :o2>> :ap3 ?z .
+                -->
+              </pre>
+            </div>
+
+          </div></li>
+          <li><div>
+            <p>Abbreviations for <a>triple patterns</a> with <a>embedded triple patterns</a> MUST be expanded as if each <a>embedded triple pattern</a> was a <a>variable</a> (or an <a>RDF term</a>).</p>
 
             <div class="example">
               For instance, the following syntax expression:

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -371,10 +371,10 @@
           <td>
             <code class="token">'BIND'</code>
             <code class="token">'('</code>
-            (
+            `(`
               <a data-cite="SPARQL11-QUERY#rExpression">Expression</a> `|`
               <a href="#rEmbTP">EmbTP</a>
-            )
+            `)`
             <code class="token">'AS'</code>
             <a data-cite="SPARQL11-QUERY#rVar">Var</a>
             <code class="token">')'</code>
@@ -391,6 +391,18 @@
             <a data-cite="SPARQL11-QUERY#rTriplesNode">TriplesNode</a>
             <a data-cite="SPARQL11-QUERY#rPropertyList">PropertyList</a>
         </td>
+        <tr id="rObjectList">
+          <td>[79]</td>
+          <td>`ObjectList`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="SPARQL11-QUERY#rObject">Object</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            `(`
+              <code class="token">','</code>
+              <a data-cite="SPARQL11-QUERY#rObject">Object</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            `)*`
+          </td>
+        </tr>
         <tr id="rObject">
           <td>[80]</td>
           <td>`Object`</td>
@@ -455,6 +467,16 @@
             <a data-cite="SPARQL11-QUERY#rVar">Var</a> `|`
             <a data-cite="SPARQL11-QUERY#rGraphTerm">GraphTerm</a> `|`
             <a href="#rEmbTP">EmbTP</a>
+          </td>
+        </tr>
+        <tr id="rAnnotationPattern">
+          <td>[177]</td>
+          <td>`AnnotationPattern`</td>
+          <td>::=</td>
+          <td>
+            <code class="token">'{|'</code>
+            <a data-cite="SPARQL11-QUERY#rPropertyListNotEmpty">PropertyListNotEmpty</a>
+            <code class="token">'|}'</code>
           </td>
         </tr>
       </table>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -361,7 +361,8 @@
     <section id="sparql-star-grammar">
       <h2>Grammar</h2>
 
-      <p>SPARQL* is defined to follow the <a data-cite="SPARQL11-QUERY#sparqlGrammar">same grammar</a> as SPARQL, <em>except</em> for the <a data-cite="XML#sec-notation"><abbr title="Extended Backus-Naur Form">EBNF</abbr> productions</a> specified below, which replace the productions having the same number (if any) in the original grammar.</p>
+      <p>SPARQL* is defined to follow the <a data-cite="SPARQL11-QUERY#sparqlGrammar">same grammar</a> as SPARQL, <em>except</em> for the <a data-cite="XML#sec-notation"><abbr title="Extended Backus-Naur Form">EBNF</abbr> productions</a> specified below, which replace the productions having the same number (if any) in the original grammar. Productions <a href="#rEmbTP">[174]</a> and following have been added and have no counterpart in
+      the original grammar.</p>
 
       <table class="grammar">
         <tr id="rBind">
@@ -493,6 +494,10 @@
         positions of <a>SPARQL* triple patterns</a>,
         as well as in BIND statements
         (<a href="#rBind">[60]</a>).
+      </p>
+
+      <p>
+        Additionally, the <a href="#rObjectList">ObjectList</a> production now accepts an optional <dfn>annotation pattern</dfn> after each object.
       </p>
 
       <div class="issue" data-number="6"></div>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -397,10 +397,10 @@
           <td>`ObjectList`</td>
           <td>::=</td>
           <td>
-            <a data-cite="SPARQL11-QUERY#rObject">Object</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            <a href="#rObject">Object</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
             `(`
               <code class="token">','</code>
-              <a data-cite="SPARQL11-QUERY#rObject">Object</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+              <a href="#rObject">Object</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
             `)*`
           </td>
         </tr>
@@ -430,10 +430,10 @@
           <td>`ObjectListPath`</td>
           <td>::=</td>
           <td>
-            <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+            <a href="#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
             `(`
               <code class="token">','</code>
-              <a data-cite="SPARQL11-QUERY#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
+              <a href="#rObjectPath">ObjectPath</a> <a href="#rAnnotationPattern">AnnotationPattern</a>`?`
             `)*`
           </td>
         </tr>


### PR DESCRIPTION
This PR is meant to address the SPARQL* part of #9


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/pull/65.html" title="Last updated on Dec 18, 2020, 11:56 AM UTC (627a6b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/65/9c340cc...627a6b5.html" title="Last updated on Dec 18, 2020, 11:56 AM UTC (627a6b5)">Diff</a>