### PR TITLE
Added Overview content

### DIFF
--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -33,10 +33,6 @@
           "name": "Bryan Thompson",
           "company": "Amazon",
         },
-        {
-          "name": "Jeen Broekstra",
-          "company": "metaphacts",
-        },
       ],
       github: "w3c/rdf-star",
       shortName: "rdf-star",
@@ -106,15 +102,68 @@
     <section class="informative">
       <h2>Overview</h2>
 
-      <p>TODO (the purpose of this section will be to provide an informal introduction to the approach for practitioners)</p>
+<p>The RDF data model lets you state facts in three-part subject-predicate-object statements known as triples. For example, with a single RDF triple you can say that employee38 has a hireDate of "2020-04-03". A triple's predicate is a property specified with an IRI (an Internationalized version of a URI) to identify the namespace of the property name. A triple's subject and object can each be any entity that can be referenced using an IRI, and the object can also be a literal value such as "2020-04-03" or another data type such as a numeric or Boolean value. </p>
+
+<p>The subject and object of a triple can themselves be triples. In the statement "employee22 claims that employee38 has a familyName of 'Smith'", the object of the triple that has employee22 as its subject is the statement "employee38 has a familyName of 'Smith'". This use of a triple as the subject or object resource of another triple so that we can say things about that triple is known as <a href='https://www.w3.org/TR/1999/REC-rdf-syntax-19990222/#higherorder'>reification</a>. </p>
+<p>The concept of reification has always been part of RDF, but expressing it in RDF concrete syntaxes such as Turtle, n-triples, and RDF/XML has been verbose and cumbersome. This specification describes a new, more compact conceptual data model and Turtle concrete syntax for reification known as RDF* (pronounced "RDF star"). This model and syntax enable the creation of concise triples that reference other triples as subject and object resources.</p>
+
+<p>Triples that include a triple as a subject or an object are known as RDF* triples. The following dataset shows the example triples from above using the Turtle RDF* syntax, which uses double angle brackets to enclose a triple serving as a subject or object resource:</p>
+
+      <pre data-transform="updateExample"
+        data-content-type="text/x-turtle-star"
+        class="nohighlight example"
+      >
+        <!--
+@prefix : <http://www.example.org/> .
+
+:employee38 :hireDate "2020-04-03" .
+:employee22 :claims << :employee38 :familyName "Smith" >> .
+        -->
+      </pre>
+
+<p>After declaring a prefix so that IRIs can be abbreviated, the first triple in this example asserts that employee38 has a hireDate of "2020-04-03". Note that this dataset does not assert that employee38 has a familyName of "Smith"; it says that employee22 has made that claim. In other words, the triple "employee38 has a familyName of 'Smith'" is not what we call an asserted triple, like "employee38 has a hireDate of '2020-04-03'" above; it is known as an embedded triple. (If we added the triple `:employee38 :familyName "Smith"` below the triple about employee22's claim in the example above, then this triple about employee38's familyName would be both an embedded triple and an asserted one.) </p>
+
+<p>This specification also describes an extension to the SPARQL Protocol and Query Language known as SPARQL* (pronounced "SPARQL star") for the querying of RDF* triples. For example, the following SPARQL* query asks "who has made any claims about employee38?"</p>
+
+<pre data-transform="updateExample"
+     data-content-type="application/x-sparql-star-query"
+     class="nohighlight example"
+>
+                <!--
+PREFIX : <http://www.example.org/> 
+
+SELECT ?claimer WHERE {
+   ?claimer :claims << :employee38 ?property ?value >>
+}
+-->
+</pre>
+    
+
+<p> SPARQL query triple patterns that include a triple pattern as a subject or object are known as SPARQL* triple patterns. </p>
+
+<p>For the remainder of this document, examples will assume that the following prefixes have been declared to represent the IRIs shown with them here: </p>
+
+<table>
+<tr><td>`:`</td><td>`&lt;http://www.example.org/&gt;`</td></tr>
+<tr><td>`rdfs:`</td><td>`&lt;http://www.w3.org/2000/01/rdf-schema#>`</td></tr>
+<tr><td>`owl:`</td><td>`&lt;http://www.w3.org/2002/07/owl#>`</td></tr>
+<tr><td>`prov:`</td><td>`&lt;http://www.w3.org/ns/prov#>`</td></tr>
+<tr><td>`dc:`</td><td>`&lt;http://purl.org/dc/elements/1.1/>`</td></tr>
+<tr><td>`dct:`</td><td>`&lt;http://purl.org/dc/terms/>`</td></tr>
+</table>
+<!-- 
+<p>TODO (the purpose of this section will be to provide an informal introduction to the approach for practitioners)</p>
+
+*** Note from Bob: the following was in this section but I think it's a bit too technical to qualify as part of an informal introduction to the approach for practitioners.  I didn't delete it because I thought you'd want to move it somewhere. ***
+
+</p>
       <p>The syntax of RDF is defined in two layers:</p>
       <ul>
         <li>the <dfn>abstract syntax</dfn>, which is the conceptual data model of RDF, and</li>
         <li>multiple <dfn data-cite="RDF11-CONCEPTS#dfn-concrete-rdf-syntax" data-lt="concrete syntax|concrete RDF syntax|concrete RDF syntaxes">concrete syntaxes</dfn> (such as RDF/XML [[RDF-SYNTAX-GRAMMAR]], Turtle [[TURTLE]] or JSON-LD [[JSON-LD11]]), which are data formats used to serialize the abstract syntax into files or over the wire.</li>
       </ul>
       <p>Similarly, this document defines the <a>abstract syntax</a> of RDF* in <a href="#concepts"></a>, and one <a>concrete syntax</a> based on Turtle [[TURTLE]] in <a href="#turtle-star"></a>.</p>
-
-      <p>TODO list the prefix definitions implicitly used in all examples</p>
+-->
     </section>
 
     <section id="conformance">
@@ -184,20 +233,6 @@
       <p>Turtle* is defined to follow the <a data-cite="TURTLE#h3_sec-grammar-grammar">same grammar</a> as Turtle, <em>except</em> for the <a data-cite="XML#sec-notation"><abbr title="Extended Backus-Naur Form">EBNF</abbr> productions</a> specified below, which replace the productions having the same number (if any) in the original grammar.</p>
 
       <table class="grammar">
-        <tr id="grammar-production-objectList">
-          <td>[8]</td>
-          <td>`objectList`</td>
-          <td>::=</td>
-          <td>
-            <a href="#grammar-production-object">object</a>
-            <a href="#grammar-production-annotation">annotation</a>`?`
-            `(`
-            <code class="grammar-literal">','</code>
-            <a href="#grammar-production-object">object</a>
-            <a href="#grammar-production-annotation">annotation</a>`?`
-            `)*`
-          </td>
-        </tr>
         <tr id="grammar-production-subject">
           <td>[10]</td>
           <td>`subject`</td>
@@ -213,8 +248,7 @@
           <td>[12]</td>
           <td>`object`</td>
           <td>::=</td>
-          <td>
-            <a data-cite="TURTLE#grammar-production-iri">iri</a> `|`
+          <td><a data-cite="TURTLE#grammar-production-iri">iri</a> `|`
             <a  data-cite="TURTLE#grammar-production-BlankNode">BlankNode</a> `|`
             <a  data-cite="TURTLE#grammar-production-collection">collection</a> `|`
             <a data-cite="TURTLE#grammar-production-blankNodePropertyList">blankNodePropertyList</a> `|`
@@ -238,8 +272,7 @@
           <td>[28]</td>
           <td>`embSubject`</td>
           <td>::=</td>
-          <td>
-            <a data-cite="TURTLE#grammar-production-iri">iri</a> `|`
+          <td><a data-cite="TURTLE#grammar-production-iri">iri</a> `|`
             <a  data-cite="TURTLE#grammar-production-BlankNode">BlankNode</a> `|`
             <a href="#grammar-production-embTriple">embTriple</a>
           </td>
@@ -248,26 +281,15 @@
           <td>[29]</td>
           <td>`embObject`</td>
           <td>::=</td>
-          <td>
-            <a data-cite="TURTLE#grammar-production-iri">iri</a> `|`
+          <td><a data-cite="TURTLE#grammar-production-iri">iri</a> `|`
             <a  data-cite="TURTLE#grammar-production-BlankNode">BlankNode</a> `|`
             <a data-cite="TURTLE#grammar-production-literal">literal</a> `|`
             <a href="#grammar-production-embTriple">embTriple</a>
           </td>
         </tr>
-        <tr id="grammar-production-annotation">
-          <td>[31]</td>
-          <td>`annotation`</td>
-          <td>::=</td>
-          <td>
-            <code class="grammar-literal">'{|'</code>
-            <a  data-cite="TURTLE#grammar-production-predicateObjectList">predicateObjectList</a>
-            <code class="grammar-literal">'|}'</code>
-          </td>
-        </tr>
       </table>
 
-      <p class="note">The changes are that <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-object">`object`</a> productions have been extended to accept <a>embedded triples</a>, which are described by the new productions <a href="#grammar-production-embTriple">27</a> to <a href="#grammar-production-embObject">29</a>. Note that <a>embedded triples</a> accept a more restricted range of <a>subject</a> and <a>object</a> expressions than <a>asserted triples</a>. Additionally, the <a href="#grammar-production-objectList">`objectList`</a> production now accepts an optional <a href="#grammar-production-annotation">annotation</a> after each object.</p>
+      <p class="note">The only changes are that <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-object">`object`</a> productions have been extended to accept <a>embedded triples</a>, which are described by the new productions <a href="#grammar-production-embTriple">27</a> to <a href="#grammar-production-embObject">29</a>. Note that <a>embedded triples</a> accept a more restricted range of <a>subject</a> and <a>object</a> expressions than <a>asserted triples</a>.</p>
 
       <div class="issue" data-number="9"></div>
     </section>
@@ -280,11 +302,9 @@
       </ul>
       <p>Additionally, the <a data-cite="TURTLE#curSubject">|curSubject|</a> can be bound to any <a>RDF* term</a> (including an <a>embedded triple</a>).</p>
 
-      <p>A Turtle* document defines an <a>RDF* graph</a> composed of a set of <a>RDF* triples</a>. The <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|. The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>. The <a href="#grammar-production-object">`object`</a> and <a href="#grammar-production-embObject">`embObject`</a> productions set the |curObject|. Finishing the <a href="#grammar-production-object">`object`</a> production, an <a>RDF* triple</a> |curSubject| |curPredicate| |curObject| is generated and added to the <a>RDF* graph</a>.</p>
+      <p>A Turtle* document defines an <a>RDF* graph</a> composed of a set of <a>RDF* triples</a>. The <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|. The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>. The <a href="#grammar-production-embObject">`embObject`</a> productions set the |curObject|. For each <a href="#grammar-production-object">`object`</a> |N|, an <a>RDF* triple</a> |curSubject| |curPredicate| |N| is generated and added to the <a>RDF* graph</a>.</p>
 
       <p>Beginning the <a href="#grammar-production-embTriple">`embTriple`</a> production records the |curSubject| and |curPredicate|. Finishing the <a href="#grammar-production-embTriple">`embTriple`</a> production yields the <a>RDF* triple</a> |curSubject| |curPredicate| |curObject| and restores the recorded values of |curSubject| and |curPredicate|.</p>
-
-      <p>Beginning the <a href="#grammar-production-annotation">`annotation`</a> production records the |curSubject| and |curPredicate|, and sets the |curSubject| to the <a>RDF* triple</a> |curSubject| |curPredicate| |curObject|. Finishing the <a href="#grammar-production-annotation">`annotation`</a> production restores the recorded values of |curSubject| and |curPredicate|.</p>
 
       <p>All other productions MUST be handled as specified by <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]], while still applying the changes above recursively.</p>
     </section>
@@ -426,11 +446,11 @@
           <td>`EmbTP`</td>
           <td>::=</td>
           <td>
-            <code class="token">'&lt;&lt;'</code>
+            <code class="token">'&lt;&lt;</code>
             <a href="#rEmbSubjectOrObject">EmbSubjectOrObject</a>
             <a data-cite="SPARQL11-QUERY#rVerb">Verb</a>
             <a href="#rEmbSubjectOrObject">EmbSubjectOrObject</a>
-            <code class="token">'&gt;&gt;'</code>
+            <code class="token">'&gt;&gt;</code>
           </td>
         </tr>
         <tr id="rEmbSubjectOrObject">
@@ -556,20 +576,16 @@
       <section>
         <h2>Translate Property Path Patterns</h2>
 
-        <p>The <a data-cite="SPARQL11-QUERY#sparqlTranslatePathPatterns">translation of property path patterns</a> has to be adjusted because the extended grammar allows for <a>SPARQL* property path patterns</a> whose subject or object is a <a>SPARQL* triple pattern</a>.</p>
+        <p>The <a data-cite="SPARQL11-QUERY#sparqlTranslatePathPatterns">translation of property path patterns</a> has to be adjusted because the extended grammar allows for property path patterns whose subject or object is an <a>embedded triple pattern</a> (cf. <a href="#sparql-star-grammar"></a>).</p>
 
         <p>The translation as specified in the W3C specification distinguishes four cases. The first three of these cases do not require adjustment because they are taken care of either by recursion or by the adjusted translation of basic graph patterns (as defined in <a href="#translate-bgp"></a> below). However, the fourth case MUST be adjusted as follows.</p>
 
-        <p>Let |X| |P| |Y| be a string that corresponds to the fourth case in [<a data-cite="SPARQL11-QUERY#sparqlTranslatePathPatterns">SPARQL11-QUERY, Section 18.2.2.4</a>]. Given the grammar introduced in <a href="#sparql-star-grammar"></a>, |X| and |Y| may be an <a>RDF term</a>, a <a>variable</a>, or an <a>embedded triple pattern</a>, respectively (and |P| is a <a>property path expression</a>). The string |X| |P| |Y| is translated to the algebra expression `Path`(<var>X’</var>,|P|,<var>Y’</var>) where <var>X’</var> and <var>Y’</var> are the result of calling a function named `Lift` for |X| and |Y|, respectively. For some input string |Z| (such as |X| or |Y|) that can be an <a>RDF term</a>, a <a>variable</a>, or an <a>embedded triple pattern</a>, the function `Lift` is defined recursively as follows:</p>
+        <p>Let |X| |P| |Y| be a string that corresponds to the fourth case in [<a data-cite="SPARQL11-QUERY#sparqlTranslatePathPatterns">SPARQL11-QUERY, Section 18.2.2.4</a>]. Given the grammar introduced in <a href="#sparql-star-grammar"></a>, |X| and |Y| may be an <a>RDF term</a>, a <a>variable</a>, or an <a>embedded triple pattern</a>, respectively (and |P| is a <a>property path expression</a>). The string |X| |P| |Y| is translated to the algebra expression `Path`(<var>X’</var>,|P|,<var>Y’</var>) where <var>X’</var> and <var>Y’</var> are the result of calling a function named `Lift` for |X| and |Y|, respectively. For some input string |Z| (such as |X| or |Y|) that can be an <a>RDF term</a>, a <a>variable</a>, or an <a>embedded triple pattern</a>, the function `Lift` is defined as follows:</p>
 
         <ol id="lift">
-          <li>If |Z| is an <a>embedded triple pattern</a> &lt;&lt;|S|,|P|,|O|&gt;&gt; then return the <a>SPARQL* triple pattern</a> (`Lift`(|S|), |P|, `Lift`(|O|));</li>
+          <li>If |Z| is an <a>embedded triple pattern</a> &lt;&lt;|S|,|P|,|O|&gt;&gt; then return the <a>SPARQL* triple pattern</a> (`Lift`(|S|, |P|, `Lift`(|O|));</li>
           <li>Otherwise, return |Z|.</li>
         </ol>
-
-        <div class="note">
-          The purpose of this translation step is to convert any property path pattern as can be written based on the extended grammar for SPARQL* (cf. <a href="#sparql-star-grammar"></a>) into a <a>SPARQL* property path pattern</a> as considered in the algebra. To this end, the function `Lift` translates every <a>embedded triple pattern</a> as can be written in the SPARQL* syntax into a <a>SPARQL* triple pattern</a>.
-        </div>
       </section>
 
       <section id="translate-bgp">
@@ -611,134 +627,30 @@
         </li>
       </ol>
 
+      <div class="issue" data-number="8"></div>
+
       <p>For any other algebra expression, the SPARQL specification defines algebra operators [[SPARQL11-QUERY]]. These definitions can be extended naturally to operate over multisets of <a>SPARQL* solution mappings</a> (instead of ordinary <a>solution mappings</a>). Given this extension, the recursive steps of the definition of the <a data-cite="SPARQL11-QUERY#sparqlAlgebraEval">eval</a> function for SPARQL* are the same as in the SPARQL specification.</p>
     </section>
 
     <section>
       <h2>Query Result Formats</h2>
 
-      <p>In SPARQL, queries can take four forms: <em>SELECT</em>, <em>CONSTRUCT</em>, <em>DESCRIBE</em>, and <em>ASK</em> - see <a data-cite="SPARQL11-QUERY#QueryForms">SPARQL1.1 Query, Section 16</a> [[SPARQL11-QUERY]]. The first of these returns a <a data-cite="SPARQL11-QUERY#defn_sparqlSolutionSequence">sequence of solution mappings</a> that contain variable bindings. The second and third both return an RDF graph, and the last returns a boolean value.
-      </p>
-      <p>The result of the <em>ASK</em> query form is not changed by the introduction of RDF*, and the result of the <em>CONSTRUCT</em> and <em>DESCRIBE</em> forms can be represented by <a href="#turtle-star">Turtle*</a>. However, since the <em>SELECT</em> form deals with returning individual RDF terms, the specific serialization formats for representing such query results need to be extended so that the new <a>embedded</a> triple RDF term can be represented. In this section, we propose extensions for the two most common formats for this purpose: [[[sparql11-results-json]]], and [[[rdf-sparql-XMLres]]].</p>
-
-      <div class="issue" data-number="43"></div>
+      <p>TODO: brief introduction paragraph (including a note that result of a CONSTRUCT query or a DESCRIBE query can be serialized using <a href="#turtle-star">Turtle*</a>)</p>
 
       <section>
         <h2>SPARQL* Query Results JSON Format</h2>
-        <p>
-        The result of a SPARQL SELECT query is serialized in JSON as defined in [[[sparql11-results-json]]], which specifies a JSON representation of variable bindings to RDF terms (see [<a data-cite="sparql11-results-json#select-results">sparql11-results-json, Section 3.2</a>]). To accomodate the new RDF term for <a>embedded</a> triples that RDF* introduces, the table of RDF term JSON representations in  <a data-cite="sparql11-results-json#select-encode-terms">sparql11-results-json, Section 3.2.2</a> is extended with the following entry:
-        </p>
-        <dl>
-            <dt>An <a>embedded</a> triple with subject RDF term `S`, predicate RDF term `P` and object RDF term `O`</dt>
-            <dd>
-              <pre>
-                {
-                  "type": "triple",
-                  "value": {
-                     "subject": S,
-                     "predicate": P,
-                     "object": O
-                  }
-                }
-              </pre>
-              where `S`, `P` and `O` are encoded using the same format, recursively.
-            </dd>
-          </dl>
-        <div class="example">
-            Consider the following RDF term, an <a>embedded</a> triple in Turtle* syntax:
-          <pre data-transform="updateExample"
-            data-content-type="text/x-turtle-star"
-            class="nohighlight example"
-          >
-            <!--
-            << <http://example.org/alice> <http://example.org/name> "Alice" >>
-            -->
-          </pre>
-          This term is represented in JSON as follows:
-          <pre class="example">
-                {
-                  "type": "triple",
-                  "value": {
-                     "subject": {
-                        "type": "uri",
-                        "value" "http://example.org/alice"
-                     },
-                     "predicate": {
-                        "type": "uri",
-                        "value" "http://example.org/name"
-                     },
-                     "object": {
-                        "type": "literal",
-                        "value" "Alice",
-                        "datatype": "http://www.w3.org/2001/XMLSchema#string"
-                     },
-                  }
-                }
-          </pre>
-        </div>
-      <!-- <div class="issue" data-number="13"></div> -->
+
+        <div class="issue" data-number="13"></div>
+
       </section>
 
       <section>
         <h2>SPARQL* Query Results XML Format</h2>
-       <p>
-        The result of a SPARQL SELECT query is serialized in XML as defined in [[[rdf-sparql-XMLres]]]. This format proposes an XML representation of variable bindings to RDF terms.
-       </p>
-       <p>To accomodate the new RDF term for <a>embedded</a> triples that RDF* introduces, the list of RDF terms and their XML representations in [<a href="rdf-sparql-XMLres#results">rdf-sparql-XMLres, Section 2.3.1</a>] is extended as follows:
-        </p>
-        <p>
-        <dl>
-            <dt>An <a>embedded</a> triple with subject term `S`, predicate term `P`, and object term `O`</dt>
-          <dd>
-            <pre data-transform="updateExample" class="xml">
-              <!--
-              <binding>
-                <triple>
-                  <subject>S</subject>
-                  <predicate>P</predicate>
-                  <object>O</object>
-                </triple>
-              </binding>
-              -->
-            </pre>
-            where `S`, `P` and `O` are encoded recursively, using the same format, without the enclosing `&lt;binding&gt;` tag.
-          </dd>
-        </dl>
-        <div class="example">
-            Consider the following RDF term, an <a>embedded</a> triple in Turtle* syntax:
-          <pre data-transform="updateExample"
-            data-content-type="text/x-turtle-star"
-            class="nohighlight example"
-          >
-            <!--
-            << <http://example.org/alice> <http://example.org/name> "Alice" >>
-            -->
-          </pre>
-          This term is represented in XML as follows:
-          <pre data-transform="updateExample" class="xml example">
-            <!--
-            <triple>
-                <subject>
-                    <uri>http://example.org/alice</uri>
-                </subject>
-                <predicate>
-                    <uri>http://example.org/name</uri>
-                </predicate>
-                <object>
-                    <literal datatype='http://www.w3.org/2001/XMLSchema#string'>Alice</literal>
-                </object>
-            </triple>
-            -->
-          </pre>
-        </div>
 
-        <!-- <div class="issue" data-number="12"></div> -->
+        <div class="issue" data-number="12"></div>
 
       </section>
-
-    </section>
-
-  </section>
+      
     </section>
 
   </section>
@@ -969,24 +881,6 @@
         <p class="issue">We didn't prove it yet...</p>
       </section>
 
-    </section>
-
-  </section>
-
-  <section class="appendix">
-    <h2>Historical remarks</h2>
-
-    <section class="appendix">
-      <h2>SA-mode and PG-mode</h2>
-
-      <p>A lot of discussions on the <a href="https://lists.w3.org/Archives/Public/public-rdf-star/">RDF* mailing list</a> and <a href="https://github.com/w3c/rdf-star">GitHub repository</a> refer to SA-mode and PG-mode. Those abbreviations stand for "Separate Assertion mode" and "Property Graph mode". They originate in the fact that different versions of RDF* have been published over the years, with different designs. In PG-mode, any <a>embedded triple</a> was also considered <a>asserted</a>. SA-mode, on the other hand, allowed the use of <a>embedded triples</a> without those triples being automatically <a>asserted</a>, requiring that they be <a>asserted</a> separately when that was intended. SA-mode was more flexible, but induced redundancy in the use-cases that PG-mode was designed to address.</p>
-
-      <p>The notion of <a href="#grammar-production-annotation">annotations</a> in the <a href="#turtle-star">Turtle*</a> syntax was introduced to remove the need for different modes. Rather than interpret the same syntax differently in each mode, which would have caused interoperability problems and required a switch for those modes, it was decided to provide a different syntax for each use case.</p>
-
-      <ul>
-        <li>The <code>&lt;&lt; ... &gt;&gt;</code> syntax represents an <a>embedded triple</a> without asserting it, satisfying the need formerly filled by SA-mode.</li>
-        <li>The <code>:a :b :c {| :p :o ... |}</code> annotation syntax creates triples where the subject is an <a>embedded</a> version of the triple <a>asserted</a> just before the annotation (here, <code>:a :b :c</code>), without the need to repeat it, satisfying the need formerly filled by PG-mode.</li>
-      </ul>
     </section>
 
   </section>


### PR DESCRIPTION
Note that some content that was in the Overview before won't show up in the browser with this version but is in the HTML file, commented out in case someone wants to move it somewhere else.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bobdc/rdf-star/pull/67.html" title="Last updated on Dec 12, 2020, 2:19 PM UTC (18beb23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/67/9c340cc...bobdc:18beb23.html" title="Last updated on Dec 12, 2020, 2:19 PM UTC (18beb23)">Diff</a>