### PR TITLE
More combinations on embedded syntax

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all
 all:
+	#./make-jsonld-manifests.rb
 	./make-html-manifests.py
 
 .PHONY: clean

--- a/tests/make-html-manifests.py
+++ b/tests/make-html-manifests.py
@@ -9,7 +9,7 @@ DIR = Path(__file__).parent
 
 def main():
     for i in [
-        ["semantics", "manifest.jsonld"],
+        ["semantics", "manifest.ttl"],
         ["turtle", "syntax", "manifest.ttl"],
         ["turtle", "eval", "manifest.ttl"],
         ["nt", "syntax", "manifest.ttl"],

--- a/tests/make-jsonld-manifests.rb
+++ b/tests/make-jsonld-manifests.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+require 'json/ld'
+require 'rdf/turtle'
+
+man_dir = File.expand_path("")
+%w{
+  nt/syntax
+  semantics
+  sparql/syntax
+  turtle/syntax
+  turtle/eval
+}.map {|p| File.expand_path(p)}.
+  each do |dir|
+  Dir.chdir(dir) do |path|
+    RDF::Turtle::Reader.open('manifest.ttl', base_uri: path) do |ttl_reader|
+      JSON::LD::Writer.open('manifest.jsonld',
+                            frame: "#{man_dir}/manifest-context.jsonld",
+                            context: "#{man_dir}/manifest-context.jsonld",
+                            base_uri: path
+      ) do |jsonld_writer|
+        puts "Create #{path}/manifest.jsonld"
+        jsonld_writer << ttl_reader
+      end
+    end
+  end
+end
+

--- a/tests/nt/syntax/manifest.jsonld
+++ b/tests/nt/syntax/manifest.jsonld
@@ -1,0 +1,196 @@
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "rdft": "http://www.w3.org/ns/rdftest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "include": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "entries": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "recognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "unrecognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "action": {
+      "@type": "@id"
+    },
+    "result": {
+      "@type": "@id"
+    },
+    "label": "rdfs:label",
+    "comment": "rdfs:comment",
+    "seeAlso": {
+      "@id": "rdfs:seeAlso",
+      "@type": "@id"
+    },
+    "approval": {
+      "@id": "rdft:approval",
+      "@type": "@id"
+    },
+    "Approved": "rdft:Approved",
+    "Proposed": "rdft:Proposed",
+    "Rejected": "rdft:Rejected",
+    "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
+  },
+  "@id": "syntax",
+  "@type": "Manifest",
+  "label": "N-Triples* Syntax Tests",
+  "entries": [
+    {
+      "@id": "#ntriples-star-1",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-syntax-1.nt",
+      "name": "N-Triples* - subject triple term"
+    },
+    {
+      "@id": "#ntriples-star-2",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-syntax-2.nt",
+      "name": "N-Triples* - object triple term"
+    },
+    {
+      "@id": "#ntriples-star-3",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-syntax-3.nt",
+      "name": "N-Triples* - subject and object triple terms"
+    },
+    {
+      "@id": "#ntriples-star-4",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-syntax-4.nt",
+      "name": "N-Triples* - whitespace and terms"
+    },
+    {
+      "@id": "#ntriples-star-5",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-syntax-5.nt",
+      "name": "N-Triples* - Nested, no whitespace"
+    },
+    {
+      "@id": "#ntriples-star-bnode-1",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-bnode-1.nt",
+      "name": "N-Triples* - Blank node subject"
+    },
+    {
+      "@id": "#ntriples-star-bnode-2",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-bnode-2.nt",
+      "name": "N-Triples* - Blank node object"
+    },
+    {
+      "@id": "#ntriples-star-nested-1",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-nested-1.nt",
+      "name": "N-Triples* - Nested subject term"
+    },
+    {
+      "@id": "#ntriples-star-nested-2",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-nested-2.nt",
+      "name": "N-Triples* - Nested object term"
+    },
+    {
+      "@id": "#ntriples-star-bad-1",
+      "@type": "rdft:TestNTriplesNegativeSyntax",
+      "action": "ntriples-star-bad-syntax-1.nt",
+      "name": "N-Triples* - Bad - triple term as predicate"
+    },
+    {
+      "@id": "#ntriples-star-bad-2",
+      "@type": "rdft:TestNTriplesNegativeSyntax",
+      "action": "ntriples-star-bad-syntax-2.nt",
+      "name": "N-Triples* - Bad - triple term, literal subject"
+    },
+    {
+      "@id": "#ntriples-star-bad-3",
+      "@type": "rdft:TestNTriplesNegativeSyntax",
+      "action": "ntriples-star-bad-syntax-3.nt",
+      "name": "N-Triples* - Bad - triple term, literal predicate"
+    },
+    {
+      "@id": "#nt-ttl-star-1",
+      "@type": "TestTurtlePositiveSyntax",
+      "action": "nt-ttl-star-syntax-1.ttl",
+      "name": "N-Triples* as Turtle* - subject triple term"
+    },
+    {
+      "@id": "#nt-ttl-star-2",
+      "@type": "TestTurtlePositiveSyntax",
+      "action": "nt-ttl-star-syntax-2.ttl",
+      "name": "N-Triples* as Turtle* - object triple term"
+    },
+    {
+      "@id": "#nt-ttl-star-3",
+      "@type": "TestTurtlePositiveSyntax",
+      "action": "nt-ttl-star-syntax-3.ttl",
+      "name": "N-Triples* as Turtle* - subject and object triple terms"
+    },
+    {
+      "@id": "#nt-ttl-star-4",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-syntax-4.nt",
+      "name": "N-Triples* as Turtle* - whitespace and terms"
+    },
+    {
+      "@id": "#nt-ttl-star-5",
+      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "action": "ntriples-star-syntax-5.nt",
+      "name": "N-Triples* as Turtle* - Nested, no whitespace"
+    },
+    {
+      "@id": "#nt-ttl-star-bnode-1",
+      "@type": "TestTurtlePositiveSyntax",
+      "action": "nt-ttl-star-bnode-1.ttl",
+      "name": "N-Triples* as Turtle* - Blank node subject"
+    },
+    {
+      "@id": "#nt-ttl-star-bnode-2",
+      "@type": "TestTurtlePositiveSyntax",
+      "action": "nt-ttl-star-bnode-2.ttl",
+      "name": "N-Triples* as Turtle* - Blank node object"
+    },
+    {
+      "@id": "#nt-ttl-star-nested-1",
+      "@type": "TestTurtlePositiveSyntax",
+      "action": "nt-ttl-star-nested-1.ttl",
+      "name": "N-Triples* as Turtle* - Nested subject term"
+    },
+    {
+      "@id": "#nt-ttl-star-nested-2",
+      "@type": "TestTurtlePositiveSyntax",
+      "action": "nt-ttl-star-nested-2.ttl",
+      "name": "N-Triples* as Turtle* - Nested object term"
+    },
+    {
+      "@id": "#nt-ttl-star-bad-1",
+      "@type": "TestTurtleNegativeSyntax",
+      "action": "nt-ttl-star-bad-syntax-1.ttl",
+      "name": "N-Triples* as Turtle* - Bad - triple term as predicate"
+    },
+    {
+      "@id": "#nt-ttl-star-bad-2",
+      "@type": "TestTurtleNegativeSyntax",
+      "action": "nt-ttl-star-bad-syntax-2.ttl",
+      "name": "N-Triples* as Turtle* - Bad - triple term, literal subject"
+    },
+    {
+      "@id": "#nt-ttl-star-bad-3",
+      "@type": "TestTurtleNegativeSyntax",
+      "action": "nt-ttl-star-bad-syntax-3.ttl",
+      "name": "N-Triples* as Turtle* - Bad - triple term, literal predicate"
+    }
+  ]
+}

--- a/tests/semantics/manifest.ttl
+++ b/tests/semantics/manifest.ttl
@@ -1,0 +1,353 @@
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX :       <#>
+
+<> a mf:Manifest;
+  rdfs:comment "RDF* Semantics tests";
+  rdfs:seeAlso <README>;
+  mf:entries (
+    :triple-in-subject
+    :triple-in-object
+    :all-identical-embedded-triples-are-the-same
+    :embedded-triples-no-spurious
+    :bnodes-in-embedded-subject
+    :bnodes-in-embedded-object
+    :bnodes-in-embedded-subject-and-object
+    :bnodes-in-embedded-subject-and-object-fail
+    :same-bnode-same-embedded-term
+    :different-bnodes-same-embedded-term
+    :constrained-bnodes-in-embedded-subject
+    :constrained-bnodes-in-embedded-object
+    :constrained-bnodes-in-embedded-fail
+    :constrained-bnodes-on-literal
+    :malformed-literal-control
+    :malformed-literal
+    :malformed-literal-accepted
+    :malformed-literal-no-spurious
+    :malformed-literal-bnode
+    :malformed-literal-bnode-2
+    :malformed-literal-bnode-3
+    :opaque-literal-control
+    :opaque-literal
+    :opaque-language-string-control
+    :opaque-language-string
+    :opaque-iri-control
+    :opaque-iri
+    :embedded-not-asserted
+    :annotated-asserted
+    :annotation
+    :annotation-unfolded
+  ) .
+
+:all-identical-embedded-triples-are-the-same a mf:PositiveEntailmentTest;
+  rdfs:comment "Multiple occurences of the same embedded triples are undistinguishable in the abstract model (EVENTUALLY, this should be a Turtle* test rather than a semantics test).";
+  mf:action <test001a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "all-identical-embedded-triples-are-the-same";
+  mf:recognizedDatatypes ();
+  mf:result <test001r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:annotated-asserted a mf:PositiveEntailmentTest;
+  rdfs:comment "Annotated triples are asserted.";
+  mf:action <test007a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "annotated-asserted";
+  mf:recognizedDatatypes ();
+  mf:result <test007r1.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:annotation a mf:PositiveEntailmentTest;
+  rdfs:comment "Annotation are about the annotated triple.";
+  mf:action <test007a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "annotation";
+  mf:recognizedDatatypes ();
+  mf:result <test007r2.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:annotation-unfolded a mf:PositiveEntailmentTest;
+  rdfs:comment "Annotation is the same as separate assertions.";
+  mf:action <test007a2.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "annotation-unfolded";
+  mf:recognizedDatatypes ();
+  mf:result <test007a.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:bnodes-in-embedded-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-embedded-object";
+  mf:recognizedDatatypes ();
+  mf:result <test002or.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:bnodes-in-embedded-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-embedded-subject";
+  mf:recognizedDatatypes ();
+  mf:result <test002sr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:bnodes-in-embedded-subject-and-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-embedded-subject-and-object";
+  mf:recognizedDatatypes ();
+  mf:result <test002sor.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:bnodes-in-embedded-subject-and-object-fail a mf:NegativeEntailmentTest;
+  rdfs:comment "The same bnode can not match different embedded terms.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-embedded-subject-and-object-fail";
+  mf:recognizedDatatypes ();
+  mf:result <test002sbr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:constrained-bnodes-in-embedded-fail a mf:NegativeEntailmentTest;
+  rdfs:comment "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.";
+  mf:action <test004a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-in-embedded-fail";
+  mf:recognizedDatatypes ();
+  mf:result <test004fr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:constrained-bnodes-in-embedded-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes.";
+  mf:action <test004a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-in-embedded-object";
+  mf:recognizedDatatypes ();
+  mf:result <test004or.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:constrained-bnodes-in-embedded-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes";
+  mf:action <test004a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-in-embedded-subject";
+  mf:recognizedDatatypes ();
+  mf:result <test004sr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:constrained-bnodes-on-literal a mf:PositiveEntailmentTest;
+  rdfs:comment "Literals in embedded triples and outside can be replaced by fresh bnodes.";
+  mf:action <test006a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-on-literal";
+  mf:recognizedDatatypes ();
+  mf:result <test006r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:different-bnodes-same-embedded-term a mf:PositiveEntailmentTest;
+  rdfs:comment "Different bnodes can match identical embedded terms.";
+  mf:action <test003a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "different-bnodes-same-embedded-term";
+  mf:recognizedDatatypes ();
+  mf:result <test002sor.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:embedded-not-asserted a mf:NegativeEntailmentTest;
+  rdfs:comment "Embedded triples are not asserted.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "embedded-not-asserted";
+  mf:recognizedDatatypes ();
+  mf:result <test002pgr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:embedded-triples-no-spurious a mf:NegativeEntailmentTest;
+  rdfs:comment "This test ensures that other entailments are not spurious.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "embedded-triples-no-spurious";
+  mf:recognizedDatatypes ();
+  mf:result <test005.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:malformed-literal a mf:NegativeEntailmentTest;
+  rdfs:comment "Malformed literals are allowed when embedded.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result false;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:malformed-literal-accepted a mf:PositiveEntailmentTest;
+  rdfs:comment "Malformed literals are allowed when embedded.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-accepted";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:malformed-literal-bnode a mf:PositiveEntailmentTest;
+  rdfs:comment "Malformed literals can be replaced by blank nodes.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-bnode";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <test002or.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:malformed-literal-bnode-2 a mf:PositiveEntailmentTest;
+  rdfs:comment "Identical malformed literals can be replaced with the same blank node.";
+  mf:action <malformed-literal-2a.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-bnode-2";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal-2r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:malformed-literal-bnode-3 a mf:NegativeEntailmentTest;
+  rdfs:comment "Identical malformed literals can not be replaced with the same blank node.";
+  mf:action <malformed-literal-3a.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-bnode-3";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal-3r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:malformed-literal-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal* tests do not pass spuriously.";
+  mf:action <malformed-literal-control.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-control";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result false;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:malformed-literal-no-spurious a mf:NegativeEntailmentTest;
+  rdfs:comment "Embedded malformed literals do not lead to spurious entailment.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-no-spurious";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal-other.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:opaque-iri a mf:NegativeEntailmentTest;
+  rdfs:comment "Embedded IRIs are opaque.";
+  mf:action <superman.ttl>;
+  mf:entailmentRegime "RDFS-Plus";
+  mf:name "opaque-iri";
+  mf:recognizedDatatypes ();
+  mf:result <superman_undesired_entailment.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:opaque-iri-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.";
+  mf:action <control-sameas-a.ttl>;
+  mf:entailmentRegime "RDFS-Plus";
+  mf:name "opaque-iri-control";
+  mf:recognizedDatatypes ();
+  mf:result <control-sameas-r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:opaque-language-string a mf:NegativeEntailmentTest;
+  rdfs:comment "Embedded literals (including language strings) are opaque, even when their datatype is recognized.";
+  mf:action <lowercase-language-string.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-language-string";
+  mf:recognizedDatatypes ();
+  mf:result <upercase-language-string.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:opaque-language-string-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.";
+  mf:action <lowercase-language-string-control.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-language-string-control";
+  mf:recognizedDatatypes ();
+  mf:result <upercase-language-string-control.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:opaque-literal a mf:NegativeEntailmentTest;
+  rdfs:comment "Embedded literals are opaque, even when their datatype is recognized.";
+  mf:action <non-canonical-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-literal";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <canonical-literal.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:opaque-literal-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.";
+  mf:action <non-canonical-literal-control.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-literal-control";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <canonical-literal-control.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:same-bnode-same-embedded-term a mf:PositiveEntailmentTest;
+  rdfs:comment "Identical embedde term can be replaced by the same fresh bnode multiple times.";
+  mf:action <test003a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "same-bnode-same-embedded-term";
+  mf:recognizedDatatypes ();
+  mf:result <test002sbr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Proposed .
+
+:triple-in-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Embedded triples can appear in object position (EVENTUALLY, this should be a Turtle* test rather than a semantics test).";
+  mf:action <test000o.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "triple-in-object";
+  mf:recognizedDatatypes ();
+  mf:result <test000o.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Approved .
+
+:triple-in-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Embedded triples can appear in subject position (EVENTUALLY, this should be a Turtle* test rather than a semantics test).";
+  mf:action <test000s.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "triple-in-subject";
+  mf:recognizedDatatypes ();
+  mf:result <test000s.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Approved .

--- a/tests/sparql/syntax/manifest.html
+++ b/tests/sparql/syntax/manifest.html
@@ -69,6 +69,8 @@
 <li class="proposed"><a href="#sparql-star-ann-1">SPARQL* - Annotation form</a>
 <li class="proposed"><a href="#sparql-star-ann-2">SPARQL* - Annotation example</a>
 <li class="proposed"><a href="#sparql-star-ann-3">SPARQL* - Annotation example</a>
+<li class="proposed"><a href="#sparql-star-ann-4">SPARQL* - Annotation with embedding</a>
+<li class="proposed"><a href="#sparql-star-ann-5">SPARQL* - Annotation on triple with embedded object</a>
 <li class="proposed"><a href="#sparql-star-bad-1">SPARQL* - bad - triple term as predicate</a>
 <li class="proposed"><a href="#sparql-star-bad-2">SPARQL* - bad - triple term outside triple</a>
 <li class="proposed"><a href="#sparql-star-bad-3">SPARQL* - bad - collection list in triple term</a>
@@ -87,6 +89,8 @@
 <li class="proposed"><a href="#sparql-star-update-1">SPARQL* - update</a>
 <li class="proposed"><a href="#sparql-star-update-2">SPARQL* - update</a>
 <li class="proposed"><a href="#sparql-star-update-3">SPARQL* - update</a>
+<li class="proposed"><a href="#sparql-star-update-4">SPARQL* - update with embedding</a>
+<li class="proposed"><a href="#sparql-star-update-5">SPARQL* - update with embedded object</a>
 <li class="proposed"><a href="#sparql-star-bad-update-1">SPARQL* - update - bad syntax</a>
 <li class="proposed"><a href="#sparql-star-bad-update-2">SPARQL* - update - bad syntax</a>
 </ul>
@@ -325,6 +329,36 @@ PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
 
 SELECT * {
    :s :p &lt;&lt;:a :b :c&gt;&gt; {| ?q ?z |}
+}</pre>
+<div>MUST be accepted</div>
+</section><section id="sparql-star-ann-4" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL* - Annotation with embedding <a href="#sparql-star-ann-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
+</table>
+<div><code><a href="sparql-star-annotation-4.rq">sparql-star-annotation-4.rq</a></code></div>
+<pre>
+PREFIX :        &lt;http://example.com/ns#&gt;
+PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
+
+SELECT * {
+   :s :p &lt;&lt;:a :b :c&gt;&gt; {| ?q &lt;&lt;:s1 :p1 ?z&gt;&gt; |}
+}</pre>
+<div>MUST be accepted</div>
+</section><section id="sparql-star-ann-5" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL* - Annotation on triple with embedded object <a href="#sparql-star-ann-5">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
+</table>
+<div><code><a href="sparql-star-annotation-5.rq">sparql-star-annotation-5.rq</a></code></div>
+<pre>
+PREFIX :        &lt;http://example.com/ns#&gt;
+PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
+
+SELECT * {
+   &lt;&lt;?s :p1 :o1&gt;&gt; ?p ?o {| :r ?Z |} .
 }</pre>
 <div>MUST be accepted</div>
 </section><section id="sparql-star-bad-1" class="entry proposed NegativeSyntaxTest11">
@@ -596,6 +630,42 @@ INSERT {
     &lt;&lt; :a :b :c &gt;&gt; ?P :o2  {| ?Y ?Z |}
 } WHERE {
    &lt;&lt; :a :b :c &gt;&gt; ?P :o1 {| ?Y ?Z |}
+}
+
+</pre>
+<div>MUST result into</div>
+</section><section id="sparql-star-update-4" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL* - update with embedding <a href="#sparql-star-update-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
+</table>
+<div><code><a href="sparql-star-syntax-update-4.ru">sparql-star-syntax-update-4.ru</a></code></div>
+<pre>
+PREFIX : &lt;http://example.com/ns#&gt;
+
+INSERT {
+    &lt;&lt; :a :b :c &gt;&gt; ?P :o2  {| ?Y &lt;&lt;:s1 :p1 ?Z&gt;&gt; |}
+} WHERE {
+   &lt;&lt; :a :b :c &gt;&gt; ?P :o1 {| ?Y &lt;&lt;:s1 :p1 ?Z&gt;&gt; |}
+}
+
+</pre>
+<div>MUST result into</div>
+</section><section id="sparql-star-update-5" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL* - update with embedded object <a href="#sparql-star-update-5">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
+</table>
+<div><code><a href="sparql-star-syntax-update-5.ru">sparql-star-syntax-update-5.ru</a></code></div>
+<pre>
+PREFIX : &lt;http://example.com/ns#&gt;
+
+INSERT {
+    ?S ?P :&lt;&lt; :a :b ?O &gt;&gt;  {| ?Y ?Z |}
+} WHERE {
+   ?S ?P &lt;&lt; :a :b ?O &gt;&gt; {| ?Y ?Z |}
 }
 
 </pre>

--- a/tests/sparql/syntax/manifest.jsonld
+++ b/tests/sparql/syntax/manifest.jsonld
@@ -40,6 +40,16 @@
 	    "action" :  "sparql-star-annotation-3.rq",
 	    "name" :    "SPARQL* - Annotation example"
 	}, {
+	    "@id" :     "#sparql-star-ann-4",
+	    "@type" :   "mf:PositiveSyntaxTest11",
+	    "action" :  "sparql-star-annotation-4.rq",
+	    "name" :    "SPARQL* - Annotation with embedding"
+	}, {
+	    "@id" :     "#sparql-star-ann-5",
+	    "@type" :   "mf:PositiveSyntaxTest11",
+	    "action" :  "sparql-star-annotation-5.rq",
+	    "name" :    "SPARQL* - Annotation on triple with embedded object"
+	}, {
 	    "@id" :     "#sparql-star-bad-1",
 	    "@type" :   "mf:NegativeSyntaxTest11",
 	    "action" :  "sparql-star-syntax-bad-01.rq",
@@ -178,6 +188,16 @@
 	    "@id" :     "#sparql-star-update-3",
 	    "@type" :   "mf:PositiveUpdateSyntaxTest11",
 	    "action" :  "sparql-star-syntax-update-3.ru",
+	    "name" :    "SPARQL* - update"
+	}, {
+	    "@id" :     "#sparql-star-update-4",
+	    "@type" :   "mf:PositiveUpdateSyntaxTest11",
+	    "action" :  "sparql-star-syntax-update-4.ru",
+	    "name" :    "SPARQL* - update"
+	}, {
+	    "@id" :     "#sparql-star-update-5",
+	    "@type" :   "mf:PositiveUpdateSyntaxTest11",
+	    "action" :  "sparql-star-syntax-update-5.ru",
 	    "name" :    "SPARQL* - update"
 	}
     ]

--- a/tests/sparql/syntax/manifest.ttl
+++ b/tests/sparql/syntax/manifest.ttl
@@ -33,6 +33,8 @@ PREFIX :       <#>
         :sparql-star-ann-1
         :sparql-star-ann-2
         :sparql-star-ann-3
+        :sparql-star-ann-4
+        :sparql-star-ann-5
 
         :sparql-star-bad-1
         :sparql-star-bad-2
@@ -55,6 +57,8 @@ PREFIX :       <#>
         :sparql-star-update-1
         :sparql-star-update-2
         :sparql-star-update-3
+        :sparql-star-update-4
+        :sparql-star-update-5
         
         :sparql-star-bad-update-1
         :sparql-star-bad-update-2
@@ -181,6 +185,16 @@ PREFIX :       <#>
     mf:action    <sparql-star-annotation-3.rq> ;
     .
 
+:sparql-star-ann-4 rdf:type mf:PositiveSyntaxTest11 ;
+    mf:name      "SPARQL* - Annotation with embedding" ;
+    mf:action    <sparql-star-annotation-4.rq> ;
+    .
+
+:sparql-star-ann-5 rdf:type mf:PositiveSyntaxTest11 ;
+    mf:name      "SPARQL* - Annotation on triple with embedded object" ;
+    mf:action    <sparql-star-annotation-5.rq> ;
+    .
+
 ## Bad annotation syntax
 
 :sparql-star-bad-ann-1 rdf:type mf:NegativeSyntaxTest11 ;
@@ -233,6 +247,16 @@ PREFIX :       <#>
 :sparql-star-update-3  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL* - update";
     mf:action    <sparql-star-syntax-update-3.ru> ;
+    .
+
+:sparql-star-update-4  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+    mf:name      "SPARQL* - update with embedding";
+    mf:action    <sparql-star-syntax-update-4.ru> ;
+    .
+
+:sparql-star-update-5  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+    mf:name      "SPARQL* - update with embedded object";
+    mf:action    <sparql-star-syntax-update-5.ru> ;
     .
 
 ## SPARQL* Update - bad syntax

--- a/tests/sparql/syntax/sparql-star-annotation-4.rq
+++ b/tests/sparql/syntax/sparql-star-annotation-4.rq
@@ -1,0 +1,6 @@
+PREFIX :        <http://example.com/ns#>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+SELECT * {
+   :s :p <<:a :b :c>> {| ?q <<:s1 :p1 ?z>> |}
+}

--- a/tests/sparql/syntax/sparql-star-annotation-5.rq
+++ b/tests/sparql/syntax/sparql-star-annotation-5.rq
@@ -1,0 +1,6 @@
+PREFIX :        <http://example.com/ns#>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+SELECT * {
+   <<?s :p1 :o1>> ?p ?o {| :r ?Z |} .
+}

--- a/tests/sparql/syntax/sparql-star-syntax-update-4.ru
+++ b/tests/sparql/syntax/sparql-star-syntax-update-4.ru
@@ -1,0 +1,8 @@
+PREFIX : <http://example.com/ns#>
+
+INSERT {
+    << :a :b :c >> ?P :o2  {| ?Y <<:s1 :p1 ?Z>> |}
+} WHERE {
+   << :a :b :c >> ?P :o1 {| ?Y <<:s1 :p1 ?Z>> |}
+}
+

--- a/tests/sparql/syntax/sparql-star-syntax-update-5.ru
+++ b/tests/sparql/syntax/sparql-star-syntax-update-5.ru
@@ -1,0 +1,8 @@
+PREFIX : <http://example.com/ns#>
+
+INSERT {
+    ?S ?P << :a :b ?O >> {| ?Y ?Z |}
+} WHERE {
+   ?S ?P << :a :b ?O >> {| ?Y ?Z |}
+}
+

--- a/tests/turtle/eval/manifest.html
+++ b/tests/turtle/eval/manifest.html
@@ -63,6 +63,9 @@
 <li class="proposed"><a href="#turtle-star-annotation-3">Turtle* - Annotation - predicate and object lists</a>
 <li class="proposed"><a href="#turtle-star-annotation-4">Turtle* - Annotation - nested</a>
 <li class="proposed"><a href="#turtle-star-annotation-5">Turtle* - Annotation object list</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-1">Turtle* - Annotation with embedding</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-2">Turtle* - Annotation on triple with embedded subject</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-3">Turtle* - Annotation on triple with embedded object</a>
 </ul>
 <section id="turtle-star-1" class="entry proposed rdft:TestTurtleEval">
 <h2>Turtle* - subject triple term <a href="#turtle-star-1">🔗</a></h2>
@@ -246,5 +249,59 @@ PREFIX : &lt;http://example/&gt;
 &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o1&gt; .
 &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle* - Annotation with embedding <a href="#turtle-star-embed-annotation-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-1.ttl">turtle-star-eval-embed-annotation-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :r &lt;&lt;:s1 :p1 :o1&gt;&gt; |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-1.nt">turtle-star-eval-embed-annotation-1.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt;&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle* - Annotation on triple with embedded subject <a href="#turtle-star-embed-annotation-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-2.ttl">turtle-star-eval-embed-annotation-2.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;:s1 :p1 :o1&gt;&gt; :p :o {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-2.nt">turtle-star-eval-embed-annotation-2.nt</a></code></div>
+<pre class="result">
+&lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt;&lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-3" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle* - Annotation on triple with embedded object <a href="#turtle-star-embed-annotation-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-3.ttl">turtle-star-eval-embed-annotation-3.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p &lt;&lt;:s2 :p2 :o2&gt;&gt; {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-3.nt">turtle-star-eval-embed-annotation-3.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;&lt;&lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt;&gt;&gt; .
+&lt;&lt;&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;&lt;&lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt;&gt;&gt;&gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
 </pre>
 </section>

--- a/tests/turtle/eval/manifest.jsonld
+++ b/tests/turtle/eval/manifest.jsonld
@@ -1,63 +1,136 @@
 {
-    "@context" : "../../manifest-context.jsonld",
-    "@id" :      "",
-    "@type" :    "mf:Manifest",
-    "label" :    "Turtle* Evaluation Tests",
-    "entries" :  [
-	{
-	    "@id" :    "#turtle-star-1",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-01.ttl",
-	    "name" :   "Turtle* - subject triple term",
-	    "result" : "turtle-star-eval-01.nt"
-	}, {
-	    "@id" :    "#turtle-star-2",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-02.ttl",
-	    "name" :   "Turtle* - object triple term",
-	    "result" : "turtle-star-eval-02.nt"
-	}, {
-	    "@id" :    "#turtle-star-annotation-1",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-annotation-1.ttl",
-	    "name" :   "Turtle* - Annotation form",
-	    "result" : "turtle-star-eval-annotation-1.nt"
-	}, {
-	    "@id" :    "#turtle-star-annotation-2",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-annotation-2.ttl",
-	    "name" :   "Turtle* - Annotation example",
-	    "result" : "turtle-star-eval-annotation-2.nt"
-	}, {
-	    "@id" :    "#turtle-star-annotation-3",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-annotation-3.ttl",
-	    "name" :   "Turtle* - Annotation - predicate and object lists",
-	    "result" : "turtle-star-eval-annotation-3.nt"
-	}, {
-	    "@id" :    "#turtle-star-annotation-4",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-annotation-4.ttl",
-	    "name" :   "Turtle* - Annotation - nested",
-	    "result" : "turtle-star-eval-annotation-4.nt"
-	}, {
-	    "@id" :    "#turtle-star-annotation-5",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-annotation-5.ttl",
-	    "name" :   "Turtle* - Annotation object list",
-	    "result" : "turtle-star-eval-annotation-5.nt"
-	}, {
-	    "@id" :    "#turtle-star-bnode-1",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-bnode-1.ttl",
-	    "name" :   "Turtle* - blank node label",
-	    "result" : "turtle-star-eval-bnode-1.nt"
-	}, {
-	    "@id" :    "#turtle-star-bnode-2",
-	    "@type" :  "rdft:TestTurtleEval",
-	    "action" : "turtle-star-eval-bnode-2.ttl",
-	    "name" :   "Turtle* - blank node labels",
-	    "result" : "turtle-star-eval-bnode-2.nt"
-	}
-    ]
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "rdft": "http://www.w3.org/ns/rdftest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "include": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "entries": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "recognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "unrecognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "action": {
+      "@type": "@id"
+    },
+    "result": {
+      "@type": "@id"
+    },
+    "label": "rdfs:label",
+    "comment": "rdfs:comment",
+    "seeAlso": {
+      "@id": "rdfs:seeAlso",
+      "@type": "@id"
+    },
+    "approval": {
+      "@id": "rdft:approval",
+      "@type": "@id"
+    },
+    "Approved": "rdft:Approved",
+    "Proposed": "rdft:Proposed",
+    "Rejected": "rdft:Rejected",
+    "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
+  },
+  "@id": "eval",
+  "@type": "Manifest",
+  "label": "Turtle* Evaluation Tests",
+  "entries": [
+    {
+      "@id": "#turtle-star-1",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-01.ttl",
+      "result": "turtle-star-eval-01.nt",
+      "name": "Turtle* - subject triple term"
+    },
+    {
+      "@id": "#turtle-star-2",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-02.ttl",
+      "result": "turtle-star-eval-02.nt",
+      "name": "Turtle* - object triple term"
+    },
+    {
+      "@id": "#turtle-star-bnode-1",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-bnode-1.ttl",
+      "result": "turtle-star-eval-bnode-1.nt",
+      "name": "Turtle* - blank node label"
+    },
+    {
+      "@id": "#turtle-star-bnode-2",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-bnode-2.ttl",
+      "result": "turtle-star-eval-bnode-2.nt",
+      "name": "Turtle* - blank node labels"
+    },
+    {
+      "@id": "#turtle-star-annotation-1",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-annotation-1.ttl",
+      "result": "turtle-star-eval-annotation-1.nt",
+      "name": "Turtle* - Annotation form"
+    },
+    {
+      "@id": "#turtle-star-annotation-2",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-annotation-2.ttl",
+      "result": "turtle-star-eval-annotation-2.nt",
+      "name": "Turtle* - Annotation example"
+    },
+    {
+      "@id": "#turtle-star-annotation-3",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-annotation-3.ttl",
+      "result": "turtle-star-eval-annotation-3.nt",
+      "name": "Turtle* - Annotation - predicate and object lists"
+    },
+    {
+      "@id": "#turtle-star-annotation-4",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-annotation-4.ttl",
+      "result": "turtle-star-eval-annotation-4.nt",
+      "name": "Turtle* - Annotation - nested"
+    },
+    {
+      "@id": "#turtle-star-annotation-5",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-annotation-5.ttl",
+      "result": "turtle-star-eval-annotation-5.nt",
+      "name": "Turtle* - Annotation object list"
+    },
+    {
+      "@id": "#turtle-star-embed-annotation-1",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-embed-annotation-1.ttl",
+      "result": "turtle-star-eval-embed-annotation-1.nt",
+      "name": "Turtle* - Annotation with embedding"
+    },
+    {
+      "@id": "#turtle-star-embed-annotation-2",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-embed-annotation-2.ttl",
+      "result": "turtle-star-eval-embed-annotation-2.nt",
+      "name": "Turtle* - Annotation on triple with embedded subject"
+    },
+    {
+      "@id": "#turtle-star-embed-annotation-3",
+      "@type": "rdft:TestTurtleEval",
+      "action": "turtle-star-eval-embed-annotation-3.ttl",
+      "result": "turtle-star-eval-embed-annotation-3.nt",
+      "name": "Turtle* - Annotation on triple with embedded object"
+    }
+  ]
 }

--- a/tests/turtle/eval/manifest.ttl
+++ b/tests/turtle/eval/manifest.ttl
@@ -22,6 +22,9 @@ PREFIX :       <#>
         :turtle-star-annotation-3
         :turtle-star-annotation-4
         :turtle-star-annotation-5
+        :turtle-star-embed-annotation-1
+        :turtle-star-embed-annotation-2
+        :turtle-star-embed-annotation-3
     ) .
 
 :turtle-star-1 rdf:type rdft:TestTurtleEval ;
@@ -76,4 +79,22 @@ PREFIX :       <#>
    mf:name      "Turtle* - Annotation object list" ;
    mf:action    <turtle-star-eval-annotation-5.ttl> ;
    mf:result    <turtle-star-eval-annotation-5.nt> ;
+   .
+
+:turtle-star-embed-annotation-1 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle* - Annotation with embedding" ;
+   mf:action    <turtle-star-eval-embed-annotation-1.ttl> ;
+   mf:result    <turtle-star-eval-embed-annotation-1.nt> ;
+   .
+   
+:turtle-star-embed-annotation-2 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle* - Annotation on triple with embedded subject" ;
+   mf:action    <turtle-star-eval-embed-annotation-2.ttl> ;
+   mf:result    <turtle-star-eval-embed-annotation-2.nt> ;
+   .
+   
+:turtle-star-embed-annotation-3 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle* - Annotation on triple with embedded object" ;
+   mf:action    <turtle-star-eval-embed-annotation-3.ttl> ;
+   mf:result    <turtle-star-eval-embed-annotation-3.nt> ;
    .

--- a/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt
+++ b/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<<<http://example/s> <http://example/p> <http://example/o>>> <http://example/r> <<<http://example/s1> <http://example/p1> <http://example/o1>>> .

--- a/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl
+++ b/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p :o {| :r <<:s1 :p1 :o1>> |} .

--- a/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt
+++ b/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt
@@ -1,0 +1,2 @@
+<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o> .
+<<<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o>>> <http://example/r> <http://example/z> .

--- a/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl
+++ b/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+<<:s1 :p1 :o1>> :p :o {| :r :z |} .

--- a/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt
+++ b/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>> .
+<<<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>>>> <http://example/r> <http://example/z> .

--- a/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl
+++ b/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p <<:s2 :p2 :o2>> {| :r :z |} .


### PR DESCRIPTION
@afs I didn't see a script for generating manifest.jsonld from manifest.ttl; I updated sparql/syntax/manifest.jsonld by hand, but didn't update turtle/eval/manifest.jsonld. I did build the HTML versions, however.