### PR TITLE
Add N-Triples* and N-Quads* sections

### DIFF
--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -397,7 +397,7 @@ SELECT ?claimer WHERE {
     <section id="n-triples-star" class="informative">
     <h2>N-Quads*</h2>
 
-    <p>The [[N-QUADS]] format is extended to describe the N-Quads* format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples Grammar</a>.</p>
+    <p>The [[N-QUADS]] format is extended to describe the N-Quads* format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples* Grammar</a>.</p>
 
     <p class="note">As RDF* describes <a>embedded triples</a> and not embedded quads, the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a> component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a> does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
   </section>
@@ -405,7 +405,7 @@ SELECT ?claimer WHERE {
     <section class="informative">
       <h2>Other Concrete Syntaxes</h2>
 
-      <p>While this document specifies a small number concrete syntaxes, nothing prevents other concrete syntaxes of RDF* from being proposed. In particular, other existing concrete syntaxes for RDF, such as RDF/XML [[RDF-SYNTAX-GRAMMAR]], could be extended to support RDF*.</p>
+      <p>While this document specifies a small number of concrete syntaxes, nothing prevents other concrete syntaxes of RDF* from being proposed. In particular, other existing concrete syntaxes for RDF, such as RDF/XML [[RDF-SYNTAX-GRAMMAR]], could be extended to support RDF*.</p>
     </section>
 
   </section>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -350,7 +350,7 @@ SELECT ?claimer WHERE {
     <section id="n-triples-star">
     <h2>N-Triples*</h2>
 
-    <p>This section describes N-Triples*, a minimal extension of the N-Triples format [[N-TRIPLES]] allowing a subject or an object of a triple to be an embedded triple. Note that there is no annotation syntax in N-Triples*.</p>
+    <p>This section describes N-Triples*, a minimal extension of the N-Triples format [[N-TRIPLES]] allowing a <a>subject</a> or an <a>object</a> of an <a>RDF* triple</a> to be an <a>embedded triple</a>. Note that there is no annotation syntax in N-Triples*.</p>
 
     <section id="n-triples-star-grammar">
       <h2>Grammar</h2>
@@ -394,7 +394,7 @@ SELECT ?claimer WHERE {
     </section>
     </section>
 
-    <section id="n-triples-star">
+    <section id="n-triples-star" class="informative">
     <h2>N-Quads*</h2>
 
     <p>The [[N-QUADS]] format is extended to describe the N-Quads* format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples Grammar</a>.</p>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -394,7 +394,7 @@ SELECT ?claimer WHERE {
     </section>
     </section>
 
-    <section id="n-triples-star">
+    <section id="n-quads-star">
     <h2>N-Quads*</h2>
 
     <p>The [[N-QUADS]] format is extended to describe the N-Quads* format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples* Grammar</a>.</p>
@@ -402,8 +402,8 @@ SELECT ?claimer WHERE {
     <p class="note">As RDF* describes <a>embedded triples</a> and not embedded quads, the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a> component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a> does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
 
     <p>An N-Quads* document defines an <a>RDF* dataset</a> composed of
-      a single <a>default graph</a>, which is an <a>RDF* graph</a>,
-      and zero or more <a>named graphs</a>, which are <a>RDF graphs</a>.</p>
+      a single <a>default graph</a>, and zero or more <a>named graphs</a>,
+      all of which are <a>RDF* graphs</a>.</p>
 
     <p>A conforming N-Quads* parser MUST parse any valid
       <strong>N-Quads document</strong> and additionally parse the 

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -46,7 +46,7 @@
       shortName: "rdf-star",
       group: "rdf-dev",
       xref: ["RDF11-CONCEPTS", "SPARQL11-QUERY", "RDF11-MT"],
-      maxTocLevel: 2,
+      maxTocLevel: 3,
     };
   </script>
   <style>
@@ -230,7 +230,9 @@ SELECT ?claimer WHERE {
     <p>Again, this definition is an extension of the notion of <a>RDF dataset</a>, hence it follows that any <a>RDF dataset</a> is also an <a>RDF* dataset</a>.</p>
   </section>
 
-  <section id="turtle-star">
+  <section>
+  <h2>Concrete Syntaxes</h2>
+    <section id="turtle-star">
     <h2>Turtle*</h2>
     <p>In this section, we present Turtle*, an extension of the Turtle format [[TURTLE]] allowing the representation of <a>RDF* graphs</a>. For the sake of conciseness, we only describe here the differences between Turtle* and Turtle.</p>
 
@@ -343,11 +345,67 @@ SELECT ?claimer WHERE {
 
       <p>All other productions MUST be handled as specified by <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]], while still applying the changes above recursively.</p>
     </section>
+  </section>
+
+    <section id="n-triples-star">
+    <h2>N-Triples*</h2>
+
+    <p>This section describes N-Triples*, a minimal extension of the N-Triples format [[N-TRIPLES]] allowing a subject or an object of a triple to be an embedded triple. Note that there is no annotation syntax in N-Triples*.</p>
+
+    <section id="n-triples-star-grammar">
+      <h2>Grammar</h2>
+      <p>N-Triples* is defined to follow the same grammar as the <a data-cite="N-TRIPLES#n-triples-grammar">N-Triples Grammar</a>, except for the EBNF productions specified below, which replace the productions having the same number (if any) in the original grammar.</p>
+
+      <table class="n-triples-star-ebnf">
+        <tbody id="grammar-productions" class="ebnf">
+          <tr id="grammar-production-nt-subject">
+            <td>[3]</td>
+            <td><code>subject</code></td>
+            <td>::=</td>
+            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
+          </tr>
+          <tr id="grammar-production-nt-object">
+            <td>[5]</td>
+            <td><code>object</code></td>
+            <td>::=</td>
+            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
+          </tr>
+          <tr id="grammar-production-nt-embTriple">
+            <td>[7]</td>
+            <td><code>embTriple</code></td>
+            <td>::=</td>
+            <td>&quot;&lt;&lt;&quot; <a href="#grammar-production-nt-subject">subject</a> <a data-cite="N-TRIPLES#grammar-production-predicate">predicate</a> <a href="#grammar-production-nt-object">object</a> &quot;&gt;&gt;&quot;</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="note">As with Turtle*, the changes are that <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions have been extended to accept <a>embedded triples</a>, which are described by the new production <a href="#grammar-production-nt-embTriple">7</a>. N-Triples* does not include an <a href="#grammar-production-annotation">annotation</a> form.</p>
+    </section>
+
+    <section id="n-triples-star-parsing">
+      <h2>Parsing</h2>
+      <p>In contrast to [[N-TRIPLES]], N-Triples* allows recursion on the <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions.</p>
+
+    <p>An N-Triples* document defines an <a>RDF* graph</a> composed of a set of <a>RDF* triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF* triple</a> defined by the terms constructed for <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
+
+      <p>In addition to the <a data-cite="N-TRIPLES#sec-parsing-terms">Term Constructors</a> defined in [[N-TRIPLES]], an additional constructor is defined for <a href="#grammar-production-nt-embTriple">`embTriple`</a> of type <a>RDF* triple</a> defined by the terms constructed for <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
+
+    <p>All other productions MUST be handled as specified by <a data-cite="N-TRIPLES#sec-parsing-terms">Section 8.1 of the N-Triples specification</a> [[N-TRIPLES]], while still applying the changes above recursively.</p>
+    </section>
+    </section>
+
+    <section id="n-triples-star">
+    <h2>N-Quads*</h2>
+
+    <p>The [[N-QUADS]] format is extended to describe the N-Quads* format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples Grammar</a>.</p>
+
+    <p class="note">As RDF* describes <a>embedded triples</a> and not embedded quads, the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a> component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a> does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
+  </section>
 
     <section class="informative">
       <h2>Other Concrete Syntaxes</h2>
 
-      <p>While this document specifies only one concrete syntax, nothing prevents other concrete syntaxes of RDF* from being proposed. In particular, other existing concrete syntaxes for RDF, such as RDF/XML [[RDF-SYNTAX-GRAMMAR]], could be extended to support RDF*. In particular, the N-Triples syntax [[N-TRIPLES]] being a subset of Turtle, an appropriate subset of Turtle* could be defined to extend N-Triples accordingly.</p>
+      <p>While this document specifies a small number concrete syntaxes, nothing prevents other concrete syntaxes of RDF* from being proposed. In particular, other existing concrete syntaxes for RDF, such as RDF/XML [[RDF-SYNTAX-GRAMMAR]], could be extended to support RDF*.</p>
     </section>
 
   </section>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -394,12 +394,21 @@ SELECT ?claimer WHERE {
     </section>
     </section>
 
-    <section id="n-triples-star" class="informative">
+    <section id="n-triples-star">
     <h2>N-Quads*</h2>
 
     <p>The [[N-QUADS]] format is extended to describe the N-Quads* format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples* Grammar</a>.</p>
 
     <p class="note">As RDF* describes <a>embedded triples</a> and not embedded quads, the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a> component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a> does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
+
+    <p>An N-Quads* document defines an <a>RDF* dataset</a> composed of
+      a single <a>default graph</a>, which is an <a>RDF* graph</a>,
+      and zero or more <a>named graphs</a>, which are <a>RDF graphs</a>.</p>
+
+    <p>A conforming N-Quads* parser MUST parse any valid
+      <strong>N-Quads document</strong> and additionally parse the <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions
+      from N-Triples* to generate <a>RDF* triples</a> which are
+      added to the <a>default graph</a>.</p>
   </section>
 
     <section class="informative">

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -350,7 +350,7 @@ SELECT ?claimer WHERE {
     <section id="n-triples-star">
     <h2>N-Triples*</h2>
 
-    <p>This section describes N-Triples*, a minimal extension of the N-Triples format [[N-TRIPLES]] allowing a <a>subject</a> or an <a>object</a> of an <a>RDF* triple</a> to be an <a>embedded triple</a>. Note that there is no annotation syntax in N-Triples*.</p>
+    <p>This section describes N-Triples*, a minimal extension of the N-Triples format [[N-TRIPLES]] allowing a <a>subject</a> or an <a>object</a> of an <a>RDF* triple</a> to be an <a>embedded triple</a>.</p>
 
     <section id="n-triples-star-grammar">
       <h2>Grammar</h2>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -406,7 +406,9 @@ SELECT ?claimer WHERE {
       and zero or more <a>named graphs</a>, which are <a>RDF graphs</a>.</p>
 
     <p>A conforming N-Quads* parser MUST parse any valid
-      <strong>N-Quads document</strong> and additionally parse the <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions
+      <strong>N-Quads document</strong> and additionally parse the 
+      <a href="#grammar-production-nt-subject"><code>subject</code></a> and 
+      <a href="#grammar-production-nt-object"><code>object</code></a> productions
       from N-Triples* to generate <a>RDF* triples</a> which are
       added to the <a>default graph</a>.</p>
   </section>

--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -410,7 +410,8 @@ SELECT ?claimer WHERE {
       <a href="#grammar-production-nt-subject"><code>subject</code></a> and 
       <a href="#grammar-production-nt-object"><code>object</code></a> productions
       from N-Triples* to generate <a>RDF* triples</a> which are
-      added to the <a>default graph</a>.</p>
+      added to either the <a>default graph</a> or associated
+      <a>named graph</a>, as appropriate.</p>
   </section>
 
     <section class="informative">


### PR DESCRIPTION
… as part of a new Concrete Syntaxes Section, which also includes Turtle*.

Fixes #16.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gkellogg/rdf-star/pull/87.html" title="Last updated on Feb 9, 2021, 7:26 PM UTC (e5c223c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/87/9a5fdc0...gkellogg:e5c223c.html" title="Last updated on Feb 9, 2021, 7:26 PM UTC (e5c223c)">Diff</a>