### PR TITLE
GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     - name: ReSpec Checker
       uses: w3c/spec-prod@v1
       with:
+        TOOLCHAIN: respec
         SOURCE: rdf-star-cg-spec.html
         VALIDATE_LINKS: true
         VALIDATE_MARKUP: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+# This workflow validates the document for markup and examples.
+name: CI
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    name: Build and Validate
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # Validate via ReSpec
+    # See https://github.com/w3c/spec-prod/blob/main/docs/examples.md
+    - name: ReSpec Checker
+      uses: w3c/spec-prod@v1
+      with:
+        SOURCE: rdf-star-cg-spec.html
+        VALIDATE_LINKS: true
+        VALIDATE_MARKUP: true


### PR DESCRIPTION
This uses ReSpec to build and check the spec, including markup errors.

Note that it currently finds three issues with either directly, or indirectly linked resources. Some should be fixed. The link checking can be turned off.

It would run on every push and PR, as configured, and generally show a pass/fail as part of the PR.