### PR TITLE
tweak description of N-Triples* triple production

### DIFF
--- a/rdf-star-cg-spec.html
+++ b/rdf-star-cg-spec.html
@@ -411,7 +411,7 @@ SELECT ?claimer WHERE {
       <h2>Parsing</h2>
       <p>In contrast to [[N-TRIPLES]], N-Triples* allows recursion on the <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions.</p>
 
-    <p>An N-Triples* document defines an <a>RDF* graph</a> composed of a set of <a>RDF* triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF* triple</a> defined by the terms constructed for <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
+    <p>An N-Triples* document defines an <a>RDF* graph</a> composed of a set of <a>RDF* triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF* triple</a> composed of a <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
 
       <p>In addition to the <a data-cite="N-TRIPLES#sec-parsing-terms">Term Constructors</a> defined in [[N-TRIPLES]], an additional constructor is defined for <a href="#grammar-production-nt-embTriple">`embTriple`</a> of type <a>RDF* triple</a> defined by the terms constructed for <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
 


### PR DESCRIPTION
```
s/The triple production produces an RDF* triple defined by the terms constructed for subject, predicate and object.
 /The triple production produces an RDF* triple composed of a subject, predicate and object.
 /
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ericprud/rdf-star/pull/91.html" title="Last updated on Feb 12, 2021, 7:53 AM UTC (e790c13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/91/0f804f5...ericprud:e790c13.html" title="Last updated on Feb 12, 2021, 7:53 AM UTC (e790c13)">Diff</a>