### PR TITLE
change "we we"  to "we"

### DIFF
--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -226,7 +226,7 @@ SELECT ?claimer WHERE {
   <section id="concepts">
     <h2>Concepts and Abstract Syntax</h2>
 
-    <p>In the following, we we introduce a number of definitions specific to SPARQL-star, which rely on the following notions (extending some of them) defined in [[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]]:
+    <p>In the following, we introduce a number of definitions specific to SPARQL-star, which rely on the following notions (extending some of them) defined in [[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]]:
     <dfn data-cite="RDF11-CONCEPTS#dfn-blank-node">blank node</dfn>,
     <dfn data-cite="RDF11-CONCEPTS#dfn-default-graph">default graph</dfn>,
     <dfn data-cite="RDF11-CONCEPTS#dfn-graph-name">graph name</dfn>,


### PR DESCRIPTION
as flagged by @gatemezing


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-star/pull/125.html" title="Last updated on Mar 5, 2021, 2:38 PM UTC (da9f8d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/125/56089b2...TallTed:da9f8d7.html" title="Last updated on Mar 5, 2021, 2:38 PM UTC (da9f8d7)">Diff</a>