### PR TITLE
manifest.ttl - no BASE; PREFIX trs

### DIFF
--- a/tests/make-jsonld-manifests.rb
+++ b/tests/make-jsonld-manifests.rb
@@ -2,6 +2,9 @@
 require "bundler/setup"
 require 'json/ld'
 require 'rdf/turtle'
+require 'rdf/isomorphic'
+require 'rdf/ordered_repo'
+require 'rdf/normalize'
 
 man_dir = File.expand_path("")
 local_ctx = JSON.parse(File.read("#{man_dir}/manifest-context.jsonld"))
@@ -14,17 +17,23 @@ local_ctx = JSON.parse(File.read("#{man_dir}/manifest-context.jsonld"))
   turtle/eval
 }.each do |path|
   dir = File.expand_path(path)
-  base = "https://w3c.github.io/rdf-star/tests/#{path}/manifest"
-  RDF::Turtle::Reader.open("#{dir}/manifest.ttl") do |ttl_reader|
-    local_ctx['@context']['@base'] = base
-    JSON::LD::Writer.open("#{dir}/manifest.jsonld",
-                          frame: local_ctx,
-                          context: local_ctx,
-                          base_uri: base
-    ) do |jsonld_writer|
-      puts "#{dir}/manifest.jsonld"
-      jsonld_writer << ttl_reader
-    end
+  base = "https://w3c.github.io/rdf-star/tests/#{path}/"
+  ttl_graph = RDF::OrderedRepo.load("#{dir}/manifest.ttl", base_uri: base)
+  local_ctx['@context']['@base'] = base
+  local_ctx['@context']['trs'] = "https://w3c.github.io/rdf-star/tests/#{path}#"
+  JSON::LD::Writer.open("#{dir}/manifest.jsonld",
+    format: :jsonld, 
+    frame: local_ctx,
+    context: local_ctx,
+    base_uri: base) {|writer| writer << ttl_graph}
+
+  # Validate that the two graphs say the same thing.
+  jsonld_graph = RDF::OrderedRepo.load("#{dir}/manifest.jsonld", base_uri: base)
+  if !jsonld_graph.isomorphic?(ttl_graph)
+    STDERR.puts "expected #{dir}/manifest.jsonld to be isomorphic with expected #{dir}/manifest.ttl"
+    STDERR.puts "\nFrom Turtle:\n#{ttl_graph.dump(:normalize)}"
+    STDERR.puts "\nFrom JSON-LD:\n#{jsonld_graph.dump(:normalize)}"
+    exit(1)
   end
 end
 

--- a/tests/manifest-context.jsonld
+++ b/tests/manifest-context.jsonld
@@ -8,8 +8,9 @@
         "qt":   "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
         "ut":   "http://www.w3.org/2009/sparql/tests/test-update#",
         "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
-
+        "trs":  "https://w3c.github.io/rdf-star/tests/turtle/syntax#",
         "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+        "@base": "",
         "include": {
             "@type": "@id",
             "@container": "@list"

--- a/tests/manifest.ttl
+++ b/tests/manifest.ttl
@@ -3,14 +3,13 @@
 ## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 ## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
 
-BASE           <manifest>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX :       <#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests#>
 
-<>  rdf:type mf:Manifest ;
+trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "RDF-star test suite" ;
     rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
     mf:include (

--- a/tests/nt/syntax/manifest.html
+++ b/tests/nt/syntax/manifest.html
@@ -56,33 +56,35 @@
 <h1>manifest</h1>
 <p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
 <ul class="entries">
-<li class="proposed"><a href="#ntriples-star-1">N-Triples-star - subject embedded triple</a>
-<li class="proposed"><a href="#ntriples-star-2">N-Triples-star - object embedded triple</a>
-<li class="proposed"><a href="#ntriples-star-3">N-Triples-star - subject and object embedded triples</a>
-<li class="proposed"><a href="#ntriples-star-4">N-Triples-star - whitespace and terms</a>
-<li class="proposed"><a href="#ntriples-star-5">N-Triples-star - Nested, no whitespace</a>
-<li class="proposed"><a href="#ntriples-star-bnode-1">N-Triples-star - Blank node subject</a>
-<li class="proposed"><a href="#ntriples-star-bnode-2">N-Triples-star - Blank node object</a>
-<li class="proposed"><a href="#ntriples-star-nested-1">N-Triples-star - Nested subject term</a>
-<li class="proposed"><a href="#ntriples-star-nested-2">N-Triples-star - Nested object term</a>
-<li class="proposed"><a href="#ntriples-star-bad-1">N-Triples-star - Bad - embedded triple as predicate</a>
-<li class="proposed"><a href="#ntriples-star-bad-2">N-Triples-star - Bad - embedded triple, literal subject</a>
-<li class="proposed"><a href="#ntriples-star-bad-3">N-Triples-star - Bad - embedded triple, literal predicate</a>
-<li class="proposed"><a href="#nt-ttl-star-1">N-Triples-star as Turtle-star - subject embedded triple</a>
-<li class="proposed"><a href="#nt-ttl-star-2">N-Triples-star as Turtle-star - object embedded triple</a>
-<li class="proposed"><a href="#nt-ttl-star-3">N-Triples-star as Turtle-star - subject and object embedded triples</a>
-<li class="proposed"><a href="#nt-ttl-star-4">N-Triples-star as Turtle-star - whitespace and terms</a>
-<li class="proposed"><a href="#nt-ttl-star-5">N-Triples-star as Turtle-star - Nested, no whitespace</a>
-<li class="proposed"><a href="#nt-ttl-star-bnode-1">N-Triples-star as Turtle-star - Blank node subject</a>
-<li class="proposed"><a href="#nt-ttl-star-bnode-2">N-Triples-star as Turtle-star - Blank node object</a>
-<li class="proposed"><a href="#nt-ttl-star-nested-1">N-Triples-star as Turtle-star - Nested subject term</a>
-<li class="proposed"><a href="#nt-ttl-star-nested-2">N-Triples-star as Turtle-star - Nested object term</a>
-<li class="proposed"><a href="#nt-ttl-star-bad-1">N-Triples-star as Turtle-star - Bad - embedded triple as predicate</a>
-<li class="proposed"><a href="#nt-ttl-star-bad-2">N-Triples-star as Turtle-star - Bad - embedded triple, literal subject</a>
-<li class="proposed"><a href="#nt-ttl-star-bad-3">N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate</a>
+<li class="proposed"><a href="trs:ntriples-star-1">N-Triples-star - subject embedded triple</a>
+<li class="proposed"><a href="trs:ntriples-star-2">N-Triples-star - object embedded triple</a>
+<li class="proposed"><a href="trs:ntriples-star-3">N-Triples-star - subject and object embedded triples</a>
+<li class="proposed"><a href="trs:ntriples-star-4">N-Triples-star - whitespace and terms</a>
+<li class="proposed"><a href="trs:ntriples-star-5">N-Triples-star - Nested, no whitespace</a>
+<li class="proposed"><a href="trs:ntriples-star-bnode-1">N-Triples-star - Blank node subject</a>
+<li class="proposed"><a href="trs:ntriples-star-bnode-2">N-Triples-star - Blank node object</a>
+<li class="proposed"><a href="trs:ntriples-star-nested-1">N-Triples-star - Nested subject term</a>
+<li class="proposed"><a href="trs:ntriples-star-nested-2">N-Triples-star - Nested object term</a>
+<li class="proposed"><a href="trs:ntriples-star-bad-1">N-Triples-star - Bad - embedded triple as predicate</a>
+<li class="proposed"><a href="trs:ntriples-star-bad-2">N-Triples-star - Bad - embedded triple, literal subject</a>
+<li class="proposed"><a href="trs:ntriples-star-bad-3">N-Triples-star - Bad - embedded triple, literal predicate</a>
+<li class="proposed"><a href="trs:ntriples-star-bad-4">N-Triples-star - Bad - embedded triple, blank node predicate</a>
+<li class="proposed"><a href="trs:nt-ttl-star-1">N-Triples-star as Turtle-star - subject embedded triple</a>
+<li class="proposed"><a href="trs:nt-ttl-star-2">N-Triples-star as Turtle-star - object embedded triple</a>
+<li class="proposed"><a href="trs:nt-ttl-star-3">N-Triples-star as Turtle-star - subject and object embedded triples</a>
+<li class="proposed"><a href="trs:nt-ttl-star-4">N-Triples-star as Turtle-star - whitespace and terms</a>
+<li class="proposed"><a href="trs:nt-ttl-star-5">N-Triples-star as Turtle-star - Nested, no whitespace</a>
+<li class="proposed"><a href="trs:nt-ttl-star-bnode-1">N-Triples-star as Turtle-star - Blank node subject</a>
+<li class="proposed"><a href="trs:nt-ttl-star-bnode-2">N-Triples-star as Turtle-star - Blank node object</a>
+<li class="proposed"><a href="trs:nt-ttl-star-nested-1">N-Triples-star as Turtle-star - Nested subject term</a>
+<li class="proposed"><a href="trs:nt-ttl-star-nested-2">N-Triples-star as Turtle-star - Nested object term</a>
+<li class="proposed"><a href="trs:nt-ttl-star-bad-1">N-Triples-star as Turtle-star - Bad - embedded triple as predicate</a>
+<li class="proposed"><a href="trs:nt-ttl-star-bad-2">N-Triples-star as Turtle-star - Bad - embedded triple, literal subject</a>
+<li class="proposed"><a href="trs:nt-ttl-star-bad-3">N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate</a>
+<li class="proposed"><a href="trs:nt-ttl-star-bad-4">N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate</a>
 </ul>
-<section id="ntriples-star-1" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - subject embedded triple <a href="#ntriples-star-1">🔗</a></h2>
+<section id="rs:ntriples-star-1" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - subject embedded triple <a href="trs:ntriples-star-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -92,8 +94,8 @@
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-2" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - object embedded triple <a href="#ntriples-star-2">🔗</a></h2>
+</section><section id="rs:ntriples-star-2" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - object embedded triple <a href="trs:ntriples-star-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -103,8 +105,8 @@
 &lt;http://example/x&gt; &lt;http://example/p&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-3" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - subject and object embedded triples <a href="#ntriples-star-3">🔗</a></h2>
+</section><section id="rs:ntriples-star-3" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - subject and object embedded triples <a href="trs:ntriples-star-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -114,8 +116,8 @@
 &lt;&lt; &lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt; &gt;&gt; &lt;http://example/q&gt; &lt;&lt; &lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt; &gt;&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-4" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - whitespace and terms <a href="#ntriples-star-4">🔗</a></h2>
+</section><section id="rs:ntriples-star-4" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - whitespace and terms <a href="trs:ntriples-star-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -125,8 +127,8 @@
 &lt;&lt;&lt;http://example/s1&gt;&lt;http://example/p1&gt;&lt;http://example/o1&gt;&gt;&gt;&lt;http://example/q&gt;&lt;&lt;&lt;http://example/s2&gt;&lt;http://example/p2&gt;&lt;http://example/o2&gt;&gt;&gt;.
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-5" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - Nested, no whitespace <a href="#ntriples-star-5">🔗</a></h2>
+</section><section id="rs:ntriples-star-5" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - Nested, no whitespace <a href="trs:ntriples-star-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -135,8 +137,8 @@
 <pre>
 &lt;&lt;&lt;&lt;&lt;http://example/s1&gt;&lt;http://example/p1&gt;&lt;http://example/o1&gt;&gt;&gt;&lt;http://example/q1&gt;&lt;&lt;&lt;http://example/s2&gt;&lt;http://example/p2&gt;&lt;http://example/o2&gt;&gt;&gt;&gt;&gt;&lt;http://example/q2&gt;&lt;&lt;&lt;&lt;&lt;http://example/s3&gt;&lt;http://example/p3&gt;&lt;http://example/o3&gt;&gt;&gt;&lt;http://example/q3&gt;&lt;&lt;&lt;http://example/s4&gt;&lt;http://example/p4&gt;&lt;http://example/o4&gt;&gt;&gt;&gt;&gt;.</pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-bnode-1" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - Blank node subject <a href="#ntriples-star-bnode-1">🔗</a></h2>
+</section><section id="rs:ntriples-star-bnode-1" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - Blank node subject <a href="trs:ntriples-star-bnode-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -147,8 +149,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; "ABC" .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-bnode-2" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - Blank node object <a href="#ntriples-star-bnode-2">🔗</a></h2>
+</section><section id="rs:ntriples-star-bnode-2" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - Blank node object <a href="trs:ntriples-star-bnode-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -159,8 +161,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; _:b1 &gt;&gt; &lt;http://example/q&gt; "456"^^&lt;http://www.w3.org/2001/XMLSchema#integer&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-nested-1" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - Nested subject term <a href="#ntriples-star-nested-1">🔗</a></h2>
+</section><section id="rs:ntriples-star-nested-1" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - Nested subject term <a href="trs:ntriples-star-nested-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -172,8 +174,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; &gt;&gt; &lt;http://example/q&gt; "1"^^&lt;http://www.w3.org/2001/XMLSchema#integer&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-nested-2" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star - Nested object term <a href="#ntriples-star-nested-2">🔗</a></h2>
+</section><section id="rs:ntriples-star-nested-2" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star - Nested object term <a href="trs:ntriples-star-nested-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -185,8 +187,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/a&gt; &lt;http://example/q&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-bad-1" class="entry proposed rdft:TestNTriplesNegativeSyntax">
-<h2>N-Triples-star - Bad - embedded triple as predicate <a href="#ntriples-star-bad-1">🔗</a></h2>
+</section><section id="rs:ntriples-star-bad-1" class="entry proposed rdft:TestNTriplesNegativeSyntax">
+<h2>N-Triples-star - Bad - embedded triple as predicate <a href="trs:ntriples-star-bad-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesNegativeSyntax</td>
@@ -196,8 +198,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;http://example/a&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt;  &lt;http://example/o&gt; &gt;&gt;  &lt;http://example/z&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-bad-2" class="entry proposed rdft:TestNTriplesNegativeSyntax">
-<h2>N-Triples-star - Bad - embedded triple, literal subject <a href="#ntriples-star-bad-2">🔗</a></h2>
+</section><section id="rs:ntriples-star-bad-2" class="entry proposed rdft:TestNTriplesNegativeSyntax">
+<h2>N-Triples-star - Bad - embedded triple, literal subject <a href="trs:ntriples-star-bad-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesNegativeSyntax</td>
@@ -207,8 +209,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; "XYZ" &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="ntriples-star-bad-3" class="entry proposed rdft:TestNTriplesNegativeSyntax">
-<h2>N-Triples-star - Bad - embedded triple, literal predicate <a href="#ntriples-star-bad-3">🔗</a></h2>
+</section><section id="rs:ntriples-star-bad-3" class="entry proposed rdft:TestNTriplesNegativeSyntax">
+<h2>N-Triples-star - Bad - embedded triple, literal predicate <a href="trs:ntriples-star-bad-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesNegativeSyntax</td>
@@ -218,8 +220,19 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/s&gt; "XYZ" &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST result into</div>
-</section><section id="nt-ttl-star-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>N-Triples-star as Turtle-star - subject embedded triple <a href="#nt-ttl-star-1">🔗</a></h2>
+</section><section id="rs:ntriples-star-bad-4" class="entry proposed rdft:TestNTriplesNegativeSyntax">
+<h2>N-Triples-star - Bad - embedded triple, blank node predicate <a href="trs:ntriples-star-bad-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestNTriplesNegativeSyntax</td>
+</table>
+<div><code><a href="ntriples-star-bad-syntax-4.nt">ntriples-star-bad-syntax-4.nt</a></code></div>
+<pre>
+&lt;&lt; &lt;http://example/s&gt; _:label &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
+</pre>
+<div>MUST result into</div>
+</section><section id="rs:nt-ttl-star-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>N-Triples-star as Turtle-star - subject embedded triple <a href="trs:nt-ttl-star-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -229,8 +242,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="nt-ttl-star-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>N-Triples-star as Turtle-star - object embedded triple <a href="#nt-ttl-star-2">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>N-Triples-star as Turtle-star - object embedded triple <a href="trs:nt-ttl-star-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -240,8 +253,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;http://example/x&gt; &lt;http://example/p&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="nt-ttl-star-3" class="entry proposed TestTurtlePositiveSyntax">
-<h2>N-Triples-star as Turtle-star - subject and object embedded triples <a href="#nt-ttl-star-3">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-3" class="entry proposed TestTurtlePositiveSyntax">
+<h2>N-Triples-star as Turtle-star - subject and object embedded triples <a href="trs:nt-ttl-star-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -251,8 +264,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt; &gt;&gt; &lt;http://example/q&gt; &lt;&lt; &lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt; &gt;&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="nt-ttl-star-4" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star as Turtle-star - whitespace and terms <a href="#nt-ttl-star-4">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-4" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star as Turtle-star - whitespace and terms <a href="trs:nt-ttl-star-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -262,8 +275,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt;&lt;http://example/s1&gt;&lt;http://example/p1&gt;&lt;http://example/o1&gt;&gt;&gt;&lt;http://example/q&gt;&lt;&lt;&lt;http://example/s2&gt;&lt;http://example/p2&gt;&lt;http://example/o2&gt;&gt;&gt;.
 </pre>
 <div>MUST result into</div>
-</section><section id="nt-ttl-star-5" class="entry proposed rdft:TestNTriplesPositiveSyntax">
-<h2>N-Triples-star as Turtle-star - Nested, no whitespace <a href="#nt-ttl-star-5">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-5" class="entry proposed rdft:TestNTriplesPositiveSyntax">
+<h2>N-Triples-star as Turtle-star - Nested, no whitespace <a href="trs:nt-ttl-star-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestNTriplesPositiveSyntax</td>
@@ -272,8 +285,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 <pre>
 &lt;&lt;&lt;&lt;&lt;http://example/s1&gt;&lt;http://example/p1&gt;&lt;http://example/o1&gt;&gt;&gt;&lt;http://example/q1&gt;&lt;&lt;&lt;http://example/s2&gt;&lt;http://example/p2&gt;&lt;http://example/o2&gt;&gt;&gt;&gt;&gt;&lt;http://example/q2&gt;&lt;&lt;&lt;&lt;&lt;http://example/s3&gt;&lt;http://example/p3&gt;&lt;http://example/o3&gt;&gt;&gt;&lt;http://example/q3&gt;&lt;&lt;&lt;http://example/s4&gt;&lt;http://example/p4&gt;&lt;http://example/o4&gt;&gt;&gt;&gt;&gt;.</pre>
 <div>MUST result into</div>
-</section><section id="nt-ttl-star-bnode-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>N-Triples-star as Turtle-star - Blank node subject <a href="#nt-ttl-star-bnode-1">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-bnode-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>N-Triples-star as Turtle-star - Blank node subject <a href="trs:nt-ttl-star-bnode-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -284,8 +297,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; "ABC" .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="nt-ttl-star-bnode-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>N-Triples-star as Turtle-star - Blank node object <a href="#nt-ttl-star-bnode-2">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-bnode-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>N-Triples-star as Turtle-star - Blank node object <a href="trs:nt-ttl-star-bnode-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -296,8 +309,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; _:b1 &gt;&gt; &lt;http://example/q&gt; "456"^^&lt;http://www.w3.org/2001/XMLSchema#integer&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="nt-ttl-star-nested-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>N-Triples-star as Turtle-star - Nested subject term <a href="#nt-ttl-star-nested-1">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-nested-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>N-Triples-star as Turtle-star - Nested subject term <a href="trs:nt-ttl-star-nested-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -309,8 +322,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; &gt;&gt; &lt;http://example/q&gt; "1"^^&lt;http://www.w3.org/2001/XMLSchema#integer&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="nt-ttl-star-nested-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>N-Triples-star as Turtle-star - Nested object term <a href="#nt-ttl-star-nested-2">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-nested-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>N-Triples-star as Turtle-star - Nested object term <a href="trs:nt-ttl-star-nested-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -322,8 +335,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/a&gt; &lt;http://example/q&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="nt-ttl-star-bad-1" class="entry proposed TestTurtleNegativeSyntax">
-<h2>N-Triples-star as Turtle-star - Bad - embedded triple as predicate <a href="#nt-ttl-star-bad-1">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-bad-1" class="entry proposed TestTurtleNegativeSyntax">
+<h2>N-Triples-star as Turtle-star - Bad - embedded triple as predicate <a href="trs:nt-ttl-star-bad-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -333,8 +346,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;http://example/a&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt;  &lt;http://example/o&gt; &gt;&gt;  &lt;http://example/z&gt; .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="nt-ttl-star-bad-2" class="entry proposed TestTurtleNegativeSyntax">
-<h2>N-Triples-star as Turtle-star - Bad - embedded triple, literal subject <a href="#nt-ttl-star-bad-2">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-bad-2" class="entry proposed TestTurtleNegativeSyntax">
+<h2>N-Triples-star as Turtle-star - Bad - embedded triple, literal subject <a href="trs:nt-ttl-star-bad-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -344,8 +357,8 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; "XYZ" &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="nt-ttl-star-bad-3" class="entry proposed TestTurtleNegativeSyntax">
-<h2>N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate <a href="#nt-ttl-star-bad-3">🔗</a></h2>
+</section><section id="rs:nt-ttl-star-bad-3" class="entry proposed TestTurtleNegativeSyntax">
+<h2>N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate <a href="trs:nt-ttl-star-bad-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -353,6 +366,17 @@ _:b0 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 <div><code><a href="nt-ttl-star-bad-syntax-3.ttl">nt-ttl-star-bad-syntax-3.ttl</a></code></div>
 <pre>
 &lt;&lt; &lt;http://example/s&gt; "XYZ" &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="rs:nt-ttl-star-bad-4" class="entry proposed TestTurtleNegativeSyntax">
+<h2>N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate <a href="trs:nt-ttl-star-bad-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="nt-ttl-star-bad-syntax-4.ttl">nt-ttl-star-bad-syntax-4.ttl</a></code></div>
+<pre>
+&lt;&lt; &lt;http://example/s&gt; _:label &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
 <div>MUST be rejected</div>
 </section>

--- a/tests/nt/syntax/manifest.jsonld
+++ b/tests/nt/syntax/manifest.jsonld
@@ -8,7 +8,9 @@
     "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
     "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
     "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/nt/syntax#",
     "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/nt/syntax/",
     "include": {
       "@type": "@id",
       "@container": "@list"
@@ -62,156 +64,167 @@
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
-    "@base": "https://w3c.github.io/rdf-star/tests/nt/syntax/manifest"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
   },
-  "@id": "manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
+  "label": "N-Triples-star Syntax Tests",
   "entries": [
     {
-      "@id": "#ntriples-star-1",
+      "@id": "trs:ntriples-star-1",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - subject embedded triple",
       "action": "ntriples-star-syntax-1.nt"
     },
     {
-      "@id": "#ntriples-star-2",
+      "@id": "trs:ntriples-star-2",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - object embedded triple",
       "action": "ntriples-star-syntax-2.nt"
     },
     {
-      "@id": "#ntriples-star-3",
+      "@id": "trs:ntriples-star-3",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - subject and object embedded triples",
       "action": "ntriples-star-syntax-3.nt"
     },
     {
-      "@id": "#ntriples-star-4",
+      "@id": "trs:ntriples-star-4",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - whitespace and terms",
       "action": "ntriples-star-syntax-4.nt"
     },
     {
-      "@id": "#ntriples-star-5",
+      "@id": "trs:ntriples-star-5",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - Nested, no whitespace",
       "action": "ntriples-star-syntax-5.nt"
     },
     {
-      "@id": "#ntriples-star-bnode-1",
+      "@id": "trs:ntriples-star-bnode-1",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - Blank node subject",
       "action": "ntriples-star-bnode-1.nt"
     },
     {
-      "@id": "#ntriples-star-bnode-2",
+      "@id": "trs:ntriples-star-bnode-2",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - Blank node object",
       "action": "ntriples-star-bnode-2.nt"
     },
     {
-      "@id": "#ntriples-star-nested-1",
+      "@id": "trs:ntriples-star-nested-1",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - Nested subject term",
       "action": "ntriples-star-nested-1.nt"
     },
     {
-      "@id": "#ntriples-star-nested-2",
+      "@id": "trs:ntriples-star-nested-2",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star - Nested object term",
       "action": "ntriples-star-nested-2.nt"
     },
     {
-      "@id": "#ntriples-star-bad-1",
+      "@id": "trs:ntriples-star-bad-1",
       "@type": "rdft:TestNTriplesNegativeSyntax",
       "name": "N-Triples-star - Bad - embedded triple as predicate",
       "action": "ntriples-star-bad-syntax-1.nt"
     },
     {
-      "@id": "#ntriples-star-bad-2",
+      "@id": "trs:ntriples-star-bad-2",
       "@type": "rdft:TestNTriplesNegativeSyntax",
       "name": "N-Triples-star - Bad - embedded triple, literal subject",
       "action": "ntriples-star-bad-syntax-2.nt"
     },
     {
-      "@id": "#ntriples-star-bad-3",
+      "@id": "trs:ntriples-star-bad-3",
       "@type": "rdft:TestNTriplesNegativeSyntax",
       "name": "N-Triples-star - Bad - embedded triple, literal predicate",
       "action": "ntriples-star-bad-syntax-3.nt"
     },
     {
-      "@id": "#nt-ttl-star-1",
+      "@id": "trs:ntriples-star-bad-4",
+      "@type": "rdft:TestNTriplesNegativeSyntax",
+      "name": "N-Triples-star - Bad - embedded triple, blank node predicate",
+      "action": "ntriples-star-bad-syntax-4.nt"
+    },
+    {
+      "@id": "trs:nt-ttl-star-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "N-Triples-star as Turtle-star - subject embedded triple",
       "action": "nt-ttl-star-syntax-1.ttl"
     },
     {
-      "@id": "#nt-ttl-star-2",
+      "@id": "trs:nt-ttl-star-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "N-Triples-star as Turtle-star - object embedded triple",
       "action": "nt-ttl-star-syntax-2.ttl"
     },
     {
-      "@id": "#nt-ttl-star-3",
+      "@id": "trs:nt-ttl-star-3",
       "@type": "TestTurtlePositiveSyntax",
       "name": "N-Triples-star as Turtle-star - subject and object embedded triples",
       "action": "nt-ttl-star-syntax-3.ttl"
     },
     {
-      "@id": "#nt-ttl-star-4",
+      "@id": "trs:nt-ttl-star-4",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star as Turtle-star - whitespace and terms",
       "action": "ntriples-star-syntax-4.nt"
     },
     {
-      "@id": "#nt-ttl-star-5",
+      "@id": "trs:nt-ttl-star-5",
       "@type": "rdft:TestNTriplesPositiveSyntax",
       "name": "N-Triples-star as Turtle-star - Nested, no whitespace",
       "action": "ntriples-star-syntax-5.nt"
     },
     {
-      "@id": "#nt-ttl-star-bnode-1",
+      "@id": "trs:nt-ttl-star-bnode-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "N-Triples-star as Turtle-star - Blank node subject",
       "action": "nt-ttl-star-bnode-1.ttl"
     },
     {
-      "@id": "#nt-ttl-star-bnode-2",
+      "@id": "trs:nt-ttl-star-bnode-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "N-Triples-star as Turtle-star - Blank node object",
       "action": "nt-ttl-star-bnode-2.ttl"
     },
     {
-      "@id": "#nt-ttl-star-nested-1",
+      "@id": "trs:nt-ttl-star-nested-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "N-Triples-star as Turtle-star - Nested subject term",
       "action": "nt-ttl-star-nested-1.ttl"
     },
     {
-      "@id": "#nt-ttl-star-nested-2",
+      "@id": "trs:nt-ttl-star-nested-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "N-Triples-star as Turtle-star - Nested object term",
       "action": "nt-ttl-star-nested-2.ttl"
     },
     {
-      "@id": "#nt-ttl-star-bad-1",
+      "@id": "trs:nt-ttl-star-bad-1",
       "@type": "TestTurtleNegativeSyntax",
       "name": "N-Triples-star as Turtle-star - Bad - embedded triple as predicate",
       "action": "nt-ttl-star-bad-syntax-1.ttl"
     },
     {
-      "@id": "#nt-ttl-star-bad-2",
+      "@id": "trs:nt-ttl-star-bad-2",
       "@type": "TestTurtleNegativeSyntax",
       "name": "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject",
       "action": "nt-ttl-star-bad-syntax-2.ttl"
     },
     {
-      "@id": "#nt-ttl-star-bad-3",
+      "@id": "trs:nt-ttl-star-bad-3",
       "@type": "TestTurtleNegativeSyntax",
       "name": "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate",
       "action": "nt-ttl-star-bad-syntax-3.ttl"
+    },
+    {
+      "@id": "trs:nt-ttl-star-bad-4",
+      "@type": "TestTurtleNegativeSyntax",
+      "name": "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate",
+      "action": "nt-ttl-star-bad-syntax-4.ttl"
     }
-  ],
-  "label": "N-Triples-star Syntax Tests"
+  ]
 }

--- a/tests/nt/syntax/manifest.ttl
+++ b/tests/nt/syntax/manifest.ttl
@@ -3,117 +3,116 @@
 ## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 ## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
 
-BASE           <https://w3c.github.io/rdf-star/tests/nt/syntax/manifest>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX :       <#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/nt/syntax#>
 
-<>  rdf:type mf:Manifest ;
+trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "N-Triples-star Syntax Tests" ;
     mf:entries
     (
-        :ntriples-star-1
-        :ntriples-star-2
-        :ntriples-star-3
-        :ntriples-star-4
-        :ntriples-star-5
+        trs:ntriples-star-1
+        trs:ntriples-star-2
+        trs:ntriples-star-3
+        trs:ntriples-star-4
+        trs:ntriples-star-5
 
-        :ntriples-star-bnode-1
-        :ntriples-star-bnode-2
+        trs:ntriples-star-bnode-1
+        trs:ntriples-star-bnode-2
 
-        :ntriples-star-nested-1
-        :ntriples-star-nested-2
+        trs:ntriples-star-nested-1
+        trs:ntriples-star-nested-2
 
-        :ntriples-star-bad-1
-        :ntriples-star-bad-2
-        :ntriples-star-bad-3
+        trs:ntriples-star-bad-1
+        trs:ntriples-star-bad-2
+        trs:ntriples-star-bad-3
 
 # The same data, except in file *.ttl and "TestTurtle"
 
-        :nt-ttl-star-1
-        :nt-ttl-star-2
-        :nt-ttl-star-3
-        :nt-ttl-star-4
-        :nt-ttl-star-5
+        trs:nt-ttl-star-1
+        trs:nt-ttl-star-2
+        trs:nt-ttl-star-3
+        trs:nt-ttl-star-4
+        trs:nt-ttl-star-5
 
-        :nt-ttl-star-bnode-1
-        :nt-ttl-star-bnode-2
+        trs:nt-ttl-star-bnode-1
+        trs:nt-ttl-star-bnode-2
 
-        :nt-ttl-star-nested-1
-        :nt-ttl-star-nested-2
+        trs:nt-ttl-star-nested-1
+        trs:nt-ttl-star-nested-2
 
-        :nt-ttl-star-bad-1
-        :nt-ttl-star-bad-2
-        :nt-ttl-star-bad-3
+        trs:nt-ttl-star-bad-1
+        trs:nt-ttl-star-bad-2
+        trs:nt-ttl-star-bad-3
     ) .
 
-:ntriples-star-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - subject embedded triple" ;
    mf:action    <ntriples-star-syntax-1.nt> ;
    .
 
-:ntriples-star-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - object embedded triple" ;
    mf:action    <ntriples-star-syntax-2.nt> ;
    .
 
-:ntriples-star-3 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-3 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - subject and object embedded triples" ;
    mf:action    <ntriples-star-syntax-3.nt> ;
    .
 
-:ntriples-star-4 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-4 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - whitespace and terms" ;
    mf:action    <ntriples-star-syntax-4.nt> ;
    .
 
-:ntriples-star-5 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-5 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - Nested, no whitespace" ;
    mf:action    <ntriples-star-syntax-5.nt> ;
    .
 
 # Blank nodes
 
-:ntriples-star-bnode-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-bnode-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - Blank node subject" ;
    mf:action    <ntriples-star-bnode-1.nt> ;
    .
 
-:ntriples-star-bnode-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-bnode-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - Blank node object" ;
    mf:action    <ntriples-star-bnode-2.nt> ;
    .
    
-:ntriples-star-nested-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-nested-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - Nested subject term" ;
    mf:action    <ntriples-star-nested-1.nt> ;
    .
 
-:ntriples-star-nested-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:ntriples-star-nested-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star - Nested object term" ;
    mf:action    <ntriples-star-nested-2.nt> ;
    .
 
 ## Bad syntax
  
-:ntriples-star-bad-1 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:ntriples-star-bad-1 rdf:type rdft:TestNTriplesNegativeSyntax ;
     mf:name      "N-Triples-star - Bad - embedded triple as predicate" ;
     mf:action    <ntriples-star-bad-syntax-1.nt> ;
     .
     
-:ntriples-star-bad-2 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:ntriples-star-bad-2 rdf:type rdft:TestNTriplesNegativeSyntax ;
     mf:name      "N-Triples-star - Bad - embedded triple, literal subject" ;
     mf:action    <ntriples-star-bad-syntax-2.nt> ;
     .
 
-:ntriples-star-bad-3 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:ntriples-star-bad-3 rdf:type rdft:TestNTriplesNegativeSyntax ;
     mf:name      "N-Triples-star - Bad - embedded triple, literal predicate" ;
     mf:action    <ntriples-star-bad-syntax-3.nt> ;
     .
 
-:ntriples-star-bad-4 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:ntriples-star-bad-4 rdf:type rdft:TestNTriplesNegativeSyntax ;
     mf:name      "N-Triples-star - Bad - embedded triple, blank node predicate" ;
     mf:action    <ntriples-star-bad-syntax-4.nt> ;
     .
@@ -124,71 +123,71 @@ PREFIX :       <#>
 
 ## Good Syntax
 
-:nt-ttl-star-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:nt-ttl-star-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - subject embedded triple" ;
    mf:action    <nt-ttl-star-syntax-1.ttl> ;
    .
 
-:nt-ttl-star-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:nt-ttl-star-2 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - object embedded triple" ;
    mf:action    <nt-ttl-star-syntax-2.ttl> ;
    .
 
-:nt-ttl-star-3 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:nt-ttl-star-3 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - subject and object embedded triples" ;
    mf:action    <nt-ttl-star-syntax-3.ttl> ;
    .
 
-:nt-ttl-star-4 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:nt-ttl-star-4 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - whitespace and terms" ;
    mf:action    <ntriples-star-syntax-4.nt> ;
    .
 
-:nt-ttl-star-5 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:nt-ttl-star-5 rdf:type rdft:TestNTriplesPositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - Nested, no whitespace" ;
    mf:action    <ntriples-star-syntax-5.nt> ;
    .
 
 # Blank nodes
 
-:nt-ttl-star-bnode-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:nt-ttl-star-bnode-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - Blank node subject" ;
    mf:action    <nt-ttl-star-bnode-1.ttl> ;
    .
 
-:nt-ttl-star-bnode-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:nt-ttl-star-bnode-2 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - Blank node object" ;
    mf:action    <nt-ttl-star-bnode-2.ttl> ;
    .
    
-:nt-ttl-star-nested-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:nt-ttl-star-nested-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - Nested subject term" ;
    mf:action    <nt-ttl-star-nested-1.ttl> ;
    .
 
-:nt-ttl-star-nested-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:nt-ttl-star-nested-2 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - Nested object term" ;
    mf:action    <nt-ttl-star-nested-2.ttl> ;
    .
 
 ## Bad syntax
  
-:nt-ttl-star-bad-1 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:nt-ttl-star-bad-1 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples-star as Turtle-star - Bad - embedded triple as predicate" ;
     mf:action    <nt-ttl-star-bad-syntax-1.ttl> ;
     .
     
-:nt-ttl-star-bad-2 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:nt-ttl-star-bad-2 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject" ;
     mf:action    <nt-ttl-star-bad-syntax-2.ttl> ;
     .
 
-:nt-ttl-star-bad-3 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:nt-ttl-star-bad-3 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate" ;
     mf:action    <nt-ttl-star-bad-syntax-3.ttl> ;
     .
 
-:nt-ttl-star-bad-4 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:nt-ttl-star-bad-4 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate" ;
     mf:action    <nt-ttl-star-bad-syntax-4.ttl> ;
     .

--- a/tests/nt/syntax/manifest.ttl
+++ b/tests/nt/syntax/manifest.ttl
@@ -28,6 +28,7 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:ntriples-star-bad-1
         trs:ntriples-star-bad-2
         trs:ntriples-star-bad-3
+        trs:ntriples-star-bad-4
 
 # The same data, except in file *.ttl and "TestTurtle"
 
@@ -46,6 +47,7 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:nt-ttl-star-bad-1
         trs:nt-ttl-star-bad-2
         trs:nt-ttl-star-bad-3
+        trs:nt-ttl-star-bad-4
     ) .
 
 trs:ntriples-star-1 rdf:type rdft:TestNTriplesPositiveSyntax ;

--- a/tests/semantics/manifest.html
+++ b/tests/semantics/manifest.html
@@ -56,37 +56,37 @@
 <h1>manifest</h1>
 <p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
 <ul class="entries">
-<li class="approved"><a href="#triple-in-subject">triple-in-subject</a>
-<li class="approved"><a href="#triple-in-object">triple-in-object</a>
-<li class="proposed"><a href="#all-identical-embedded-triples-are-the-same">all-identical-embedded-triples-are-the-same</a>
-<li class="proposed"><a href="#embedded-triples-no-spurious">embedded-triples-no-spurious</a>
-<li class="proposed"><a href="#bnodes-in-embedded-subject">bnodes-in-embedded-subject</a>
-<li class="proposed"><a href="#bnodes-in-embedded-object">bnodes-in-embedded-object</a>
-<li class="proposed"><a href="#bnodes-in-embedded-subject-and-object">bnodes-in-embedded-subject-and-object</a>
-<li class="proposed"><a href="#bnodes-in-embedded-subject-and-object-fail">bnodes-in-embedded-subject-and-object-fail</a>
-<li class="proposed"><a href="#same-bnode-same-embedded-term">same-bnode-same-embedded-term</a>
-<li class="proposed"><a href="#different-bnodes-same-embedded-term">different-bnodes-same-embedded-term</a>
-<li class="proposed"><a href="#constrained-bnodes-in-embedded-subject">constrained-bnodes-in-embedded-subject</a>
-<li class="proposed"><a href="#constrained-bnodes-in-embedded-object">constrained-bnodes-in-embedded-object</a>
-<li class="proposed"><a href="#constrained-bnodes-in-embedded-fail">constrained-bnodes-in-embedded-fail</a>
-<li class="proposed"><a href="#constrained-bnodes-on-literal">constrained-bnodes-on-literal</a>
-<li class="proposed"><a href="#malformed-literal-control">malformed-literal-control</a>
-<li class="proposed"><a href="#malformed-literal">malformed-literal</a>
-<li class="proposed"><a href="#malformed-literal-accepted">malformed-literal-accepted</a>
-<li class="proposed"><a href="#malformed-literal-no-spurious">malformed-literal-no-spurious</a>
-<li class="proposed"><a href="#malformed-literal-bnode">malformed-literal-bnode</a>
-<li class="proposed"><a href="#malformed-literal-bnode-2">malformed-literal-bnode-2</a>
-<li class="proposed"><a href="#malformed-literal-bnode-3">malformed-literal-bnode-3</a>
-<li class="proposed"><a href="#opaque-literal-control">opaque-literal-control</a>
-<li class="proposed"><a href="#opaque-literal">opaque-literal</a>
-<li class="proposed"><a href="#opaque-language-string-control">opaque-language-string-control</a>
-<li class="proposed"><a href="#opaque-language-string">opaque-language-string</a>
-<li class="proposed"><a href="#opaque-iri-control">opaque-iri-control</a>
-<li class="proposed"><a href="#opaque-iri">opaque-iri</a>
-<li class="proposed"><a href="#embedded-not-asserted">embedded-not-asserted</a>
-<li class="proposed"><a href="#annotated-asserted">annotated-asserted</a>
-<li class="proposed"><a href="#annotation">annotation</a>
-<li class="proposed"><a href="#annotation-unfolded">annotation-unfolded</a>
+<li class="approved"><a href="trs:triple-in-subject">triple-in-subject</a>
+<li class="approved"><a href="trs:triple-in-object">triple-in-object</a>
+<li class="proposed"><a href="trs:all-identical-embedded-triples-are-the-same">all-identical-embedded-triples-are-the-same</a>
+<li class="proposed"><a href="trs:embedded-triples-no-spurious">embedded-triples-no-spurious</a>
+<li class="proposed"><a href="trs:bnodes-in-embedded-subject">bnodes-in-embedded-subject</a>
+<li class="proposed"><a href="trs:bnodes-in-embedded-object">bnodes-in-embedded-object</a>
+<li class="proposed"><a href="trs:bnodes-in-embedded-subject-and-object">bnodes-in-embedded-subject-and-object</a>
+<li class="proposed"><a href="trs:bnodes-in-embedded-subject-and-object-fail">bnodes-in-embedded-subject-and-object-fail</a>
+<li class="proposed"><a href="trs:same-bnode-same-embedded-term">same-bnode-same-embedded-term</a>
+<li class="proposed"><a href="trs:different-bnodes-same-embedded-term">different-bnodes-same-embedded-term</a>
+<li class="proposed"><a href="trs:constrained-bnodes-in-embedded-subject">constrained-bnodes-in-embedded-subject</a>
+<li class="proposed"><a href="trs:constrained-bnodes-in-embedded-object">constrained-bnodes-in-embedded-object</a>
+<li class="proposed"><a href="trs:constrained-bnodes-in-embedded-fail">constrained-bnodes-in-embedded-fail</a>
+<li class="proposed"><a href="trs:constrained-bnodes-on-literal">constrained-bnodes-on-literal</a>
+<li class="proposed"><a href="trs:malformed-literal-control">malformed-literal-control</a>
+<li class="proposed"><a href="trs:malformed-literal">malformed-literal</a>
+<li class="proposed"><a href="trs:malformed-literal-accepted">malformed-literal-accepted</a>
+<li class="proposed"><a href="trs:malformed-literal-no-spurious">malformed-literal-no-spurious</a>
+<li class="proposed"><a href="trs:malformed-literal-bnode">malformed-literal-bnode</a>
+<li class="proposed"><a href="trs:malformed-literal-bnode-2">malformed-literal-bnode-2</a>
+<li class="proposed"><a href="trs:malformed-literal-bnode-3">malformed-literal-bnode-3</a>
+<li class="proposed"><a href="trs:opaque-literal-control">opaque-literal-control</a>
+<li class="proposed"><a href="trs:opaque-literal">opaque-literal</a>
+<li class="proposed"><a href="trs:opaque-language-string-control">opaque-language-string-control</a>
+<li class="proposed"><a href="trs:opaque-language-string">opaque-language-string</a>
+<li class="proposed"><a href="trs:opaque-iri-control">opaque-iri-control</a>
+<li class="proposed"><a href="trs:opaque-iri">opaque-iri</a>
+<li class="proposed"><a href="trs:embedded-not-asserted">embedded-not-asserted</a>
+<li class="proposed"><a href="trs:annotated-asserted">annotated-asserted</a>
+<li class="proposed"><a href="trs:annotation">annotation</a>
+<li class="proposed"><a href="trs:annotation-unfolded">annotation-unfolded</a>
 </ul>
 <h2>About this test suite</h2>
 <pre>
@@ -139,8 +139,8 @@ A document on the results of the testing will eventually be at
 http://w3c.github.io/rdf-star/tests/reports.html .
 This document will have more information on submitting reports, including examples
 of what the reports should contain.</pre>
-<section id="triple-in-subject" class="entry approved PositiveEntailmentTest">
-<h2>triple-in-subject <a href="#triple-in-subject">🔗</a></h2>
+<section id="rs:triple-in-subject" class="entry approved PositiveEntailmentTest">
+<h2>triple-in-subject <a href="trs:triple-in-subject">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>approved</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -160,8 +160,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; :a :b :c &gt;&gt; :p1 :o1.
 </pre>
 <p>Embedded triples can appear in subject position (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).</p>
-</section><section id="triple-in-object" class="entry approved PositiveEntailmentTest">
-<h2>triple-in-object <a href="#triple-in-object">🔗</a></h2>
+</section><section id="rs:triple-in-object" class="entry approved PositiveEntailmentTest">
+<h2>triple-in-object <a href="trs:triple-in-object">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>approved</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -181,8 +181,8 @@ prefix : &lt;http://example.com/ns#&gt;
 :s1 :p1 &lt;&lt; :x :y :z &gt;&gt;.
 </pre>
 <p>Embedded triples can appear in object position (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).</p>
-</section><section id="all-identical-embedded-triples-are-the-same" class="entry proposed PositiveEntailmentTest">
-<h2>all-identical-embedded-triples-are-the-same <a href="#all-identical-embedded-triples-are-the-same">🔗</a></h2>
+</section><section id="rs:all-identical-embedded-triples-are-the-same" class="entry proposed PositiveEntailmentTest">
+<h2>all-identical-embedded-triples-are-the-same <a href="trs:all-identical-embedded-triples-are-the-same">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -203,8 +203,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; :a :b :c &gt;&gt; :p1 :o1; :p2 :o2.
 </pre>
 <p>Multiple occurences of the same embedded triples are undistinguishable in the abstract model (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).</p>
-</section><section id="embedded-triples-no-spurious" class="entry proposed NegativeEntailmentTest">
-<h2>embedded-triples-no-spurious <a href="#embedded-triples-no-spurious">🔗</a></h2>
+</section><section id="rs:embedded-triples-no-spurious" class="entry proposed NegativeEntailmentTest">
+<h2>embedded-triples-no-spurious <a href="trs:embedded-triples-no-spurious">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -224,8 +224,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; :a :b :d &gt;&gt; :p1 :o1.
 </pre>
 <p>This test ensures that other entailments are not spurious.</p>
-</section><section id="bnodes-in-embedded-subject" class="entry proposed PositiveEntailmentTest">
-<h2>bnodes-in-embedded-subject <a href="#bnodes-in-embedded-subject">🔗</a></h2>
+</section><section id="rs:bnodes-in-embedded-subject" class="entry proposed PositiveEntailmentTest">
+<h2>bnodes-in-embedded-subject <a href="trs:bnodes-in-embedded-subject">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -245,8 +245,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; _:x :b :c &gt;&gt; :p1 :o1.
 </pre>
 <p>Terms in embedded triples can be replaced by fresh bnodes.</p>
-</section><section id="bnodes-in-embedded-object" class="entry proposed PositiveEntailmentTest">
-<h2>bnodes-in-embedded-object <a href="#bnodes-in-embedded-object">🔗</a></h2>
+</section><section id="rs:bnodes-in-embedded-object" class="entry proposed PositiveEntailmentTest">
+<h2>bnodes-in-embedded-object <a href="trs:bnodes-in-embedded-object">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -266,8 +266,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; :a :b _:x &gt;&gt; :p1 :o1.
 </pre>
 <p>Terms in embedded triples can be replaced by fresh bnodes.</p>
-</section><section id="bnodes-in-embedded-subject-and-object" class="entry proposed PositiveEntailmentTest">
-<h2>bnodes-in-embedded-subject-and-object <a href="#bnodes-in-embedded-subject-and-object">🔗</a></h2>
+</section><section id="rs:bnodes-in-embedded-subject-and-object" class="entry proposed PositiveEntailmentTest">
+<h2>bnodes-in-embedded-subject-and-object <a href="trs:bnodes-in-embedded-subject-and-object">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -287,8 +287,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; _:x :b _:y &gt;&gt; :p1 :o1.
 </pre>
 <p>Terms in embedded triples can be replaced by fresh bnodes.</p>
-</section><section id="bnodes-in-embedded-subject-and-object-fail" class="entry proposed NegativeEntailmentTest">
-<h2>bnodes-in-embedded-subject-and-object-fail <a href="#bnodes-in-embedded-subject-and-object-fail">🔗</a></h2>
+</section><section id="rs:bnodes-in-embedded-subject-and-object-fail" class="entry proposed NegativeEntailmentTest">
+<h2>bnodes-in-embedded-subject-and-object-fail <a href="trs:bnodes-in-embedded-subject-and-object-fail">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -308,8 +308,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; _:x :b _:x &gt;&gt; :p1 :o1.
 </pre>
 <p>The same bnode can not match different embedded terms.</p>
-</section><section id="same-bnode-same-embedded-term" class="entry proposed PositiveEntailmentTest">
-<h2>same-bnode-same-embedded-term <a href="#same-bnode-same-embedded-term">🔗</a></h2>
+</section><section id="rs:same-bnode-same-embedded-term" class="entry proposed PositiveEntailmentTest">
+<h2>same-bnode-same-embedded-term <a href="trs:same-bnode-same-embedded-term">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -329,8 +329,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; _:x :b _:x &gt;&gt; :p1 :o1.
 </pre>
 <p>Identical embedde term can be replaced by the same fresh bnode multiple times.</p>
-</section><section id="different-bnodes-same-embedded-term" class="entry proposed PositiveEntailmentTest">
-<h2>different-bnodes-same-embedded-term <a href="#different-bnodes-same-embedded-term">🔗</a></h2>
+</section><section id="rs:different-bnodes-same-embedded-term" class="entry proposed PositiveEntailmentTest">
+<h2>different-bnodes-same-embedded-term <a href="trs:different-bnodes-same-embedded-term">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -350,8 +350,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; _:x :b _:y &gt;&gt; :p1 :o1.
 </pre>
 <p>Different bnodes can match identical embedded terms.</p>
-</section><section id="constrained-bnodes-in-embedded-subject" class="entry proposed PositiveEntailmentTest">
-<h2>constrained-bnodes-in-embedded-subject <a href="#constrained-bnodes-in-embedded-subject">🔗</a></h2>
+</section><section id="rs:constrained-bnodes-in-embedded-subject" class="entry proposed PositiveEntailmentTest">
+<h2>constrained-bnodes-in-embedded-subject <a href="trs:constrained-bnodes-in-embedded-subject">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -373,8 +373,8 @@ prefix : &lt;http://example.com/ns#&gt;
 _:x :label "A".
 </pre>
 <p>Terms in embedded triples and outside can be replaced by fresh bnodes</p>
-</section><section id="constrained-bnodes-in-embedded-object" class="entry proposed PositiveEntailmentTest">
-<h2>constrained-bnodes-in-embedded-object <a href="#constrained-bnodes-in-embedded-object">🔗</a></h2>
+</section><section id="rs:constrained-bnodes-in-embedded-object" class="entry proposed PositiveEntailmentTest">
+<h2>constrained-bnodes-in-embedded-object <a href="trs:constrained-bnodes-in-embedded-object">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -396,8 +396,8 @@ prefix : &lt;http://example.com/ns#&gt;
 _:x :label "C".
 </pre>
 <p>Terms in embedded triples and outside can be replaced by fresh bnodes.</p>
-</section><section id="constrained-bnodes-in-embedded-fail" class="entry proposed NegativeEntailmentTest">
-<h2>constrained-bnodes-in-embedded-fail <a href="#constrained-bnodes-in-embedded-fail">🔗</a></h2>
+</section><section id="rs:constrained-bnodes-in-embedded-fail" class="entry proposed NegativeEntailmentTest">
+<h2>constrained-bnodes-in-embedded-fail <a href="trs:constrained-bnodes-in-embedded-fail">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -419,8 +419,8 @@ prefix : &lt;http://example.com/ns#&gt;
 _:x :label "C".
 </pre>
 <p>Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.</p>
-</section><section id="constrained-bnodes-on-literal" class="entry proposed PositiveEntailmentTest">
-<h2>constrained-bnodes-on-literal <a href="#constrained-bnodes-on-literal">🔗</a></h2>
+</section><section id="rs:constrained-bnodes-on-literal" class="entry proposed PositiveEntailmentTest">
+<h2>constrained-bnodes-on-literal <a href="trs:constrained-bnodes-on-literal">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -442,8 +442,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 &lt;&lt; :a :b _:x &gt;&gt; :p1 :o1.
 :s2 :p2 _:x.</pre>
 <p>Literals in embedded triples and outside can be replaced by fresh bnodes.</p>
-</section><section id="malformed-literal-control" class="entry proposed PositiveEntailmentTest">
-<h2>malformed-literal-control <a href="#malformed-literal-control">🔗</a></h2>
+</section><section id="rs:malformed-literal-control" class="entry proposed PositiveEntailmentTest">
+<h2>malformed-literal-control <a href="trs:malformed-literal-control">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -458,8 +458,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 :a :b "c"^^xsd:integer.</pre>
 <div>MUST entail</div>
 <p>Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-star tests do not pass spuriously.</p>
-</section><section id="malformed-literal" class="entry proposed NegativeEntailmentTest">
-<h2>malformed-literal <a href="#malformed-literal">🔗</a></h2>
+</section><section id="rs:malformed-literal" class="entry proposed NegativeEntailmentTest">
+<h2>malformed-literal <a href="trs:malformed-literal">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -474,8 +474,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 &lt;&lt; :a :b "c"^^xsd:integer &gt;&gt; :p1 :o1.</pre>
 <div>MUST NOT entail</div>
 <p>Malformed literals are allowed when embedded.</p>
-</section><section id="malformed-literal-accepted" class="entry proposed PositiveEntailmentTest">
-<h2>malformed-literal-accepted <a href="#malformed-literal-accepted">🔗</a></h2>
+</section><section id="rs:malformed-literal-accepted" class="entry proposed PositiveEntailmentTest">
+<h2>malformed-literal-accepted <a href="trs:malformed-literal-accepted">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -496,8 +496,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 
 &lt;&lt; :a :b "c"^^xsd:integer &gt;&gt; :p1 :o1.</pre>
 <p>Malformed literals are allowed when embedded.</p>
-</section><section id="malformed-literal-no-spurious" class="entry proposed NegativeEntailmentTest">
-<h2>malformed-literal-no-spurious <a href="#malformed-literal-no-spurious">🔗</a></h2>
+</section><section id="rs:malformed-literal-no-spurious" class="entry proposed NegativeEntailmentTest">
+<h2>malformed-literal-no-spurious <a href="trs:malformed-literal-no-spurious">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -518,8 +518,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 
 &lt;&lt; :a :b "d"^^xsd:integer &gt;&gt; :p1 :o1.</pre>
 <p>Embedded malformed literals do not lead to spurious entailment.</p>
-</section><section id="malformed-literal-bnode" class="entry proposed PositiveEntailmentTest">
-<h2>malformed-literal-bnode <a href="#malformed-literal-bnode">🔗</a></h2>
+</section><section id="rs:malformed-literal-bnode" class="entry proposed PositiveEntailmentTest">
+<h2>malformed-literal-bnode <a href="trs:malformed-literal-bnode">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -540,8 +540,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; :a :b _:x &gt;&gt; :p1 :o1.
 </pre>
 <p>Malformed literals can be replaced by blank nodes.</p>
-</section><section id="malformed-literal-bnode-2" class="entry proposed PositiveEntailmentTest">
-<h2>malformed-literal-bnode-2 <a href="#malformed-literal-bnode-2">🔗</a></h2>
+</section><section id="rs:malformed-literal-bnode-2" class="entry proposed PositiveEntailmentTest">
+<h2>malformed-literal-bnode-2 <a href="trs:malformed-literal-bnode-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -564,8 +564,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 &lt;&lt; :a :b _:x &gt;&gt; :p1 :o1.
 &lt;&lt; :d :b _:x &gt;&gt; :p2 :o2.</pre>
 <p>Identical malformed literals can be replaced with the same blank node.</p>
-</section><section id="malformed-literal-bnode-3" class="entry proposed NegativeEntailmentTest">
-<h2>malformed-literal-bnode-3 <a href="#malformed-literal-bnode-3">🔗</a></h2>
+</section><section id="rs:malformed-literal-bnode-3" class="entry proposed NegativeEntailmentTest">
+<h2>malformed-literal-bnode-3 <a href="trs:malformed-literal-bnode-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -588,8 +588,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 &lt;&lt; :a :b _:x &gt;&gt; :p1 :o1.
 &lt;&lt; :d :b _:x &gt;&gt; :p2 :o2.</pre>
 <p>Identical malformed literals can not be replaced with the same blank node.</p>
-</section><section id="opaque-literal-control" class="entry proposed PositiveEntailmentTest">
-<h2>opaque-literal-control <a href="#opaque-literal-control">🔗</a></h2>
+</section><section id="rs:opaque-literal-control" class="entry proposed PositiveEntailmentTest">
+<h2>opaque-literal-control <a href="trs:opaque-literal-control">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -610,8 +610,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 
 :a :b "42"^^xsd:integer.</pre>
 <p>Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.</p>
-</section><section id="opaque-literal" class="entry proposed NegativeEntailmentTest">
-<h2>opaque-literal <a href="#opaque-literal">🔗</a></h2>
+</section><section id="rs:opaque-literal" class="entry proposed NegativeEntailmentTest">
+<h2>opaque-literal <a href="trs:opaque-literal">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -632,8 +632,8 @@ prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
 
 &lt;&lt; :a :b "42"^^xsd:integer &gt;&gt; :p1 :o1.</pre>
 <p>Embedded literals are opaque, even when their datatype is recognized.</p>
-</section><section id="opaque-language-string-control" class="entry proposed PositiveEntailmentTest">
-<h2>opaque-language-string-control <a href="#opaque-language-string-control">🔗</a></h2>
+</section><section id="rs:opaque-language-string-control" class="entry proposed PositiveEntailmentTest">
+<h2>opaque-language-string-control <a href="trs:opaque-language-string-control">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -652,8 +652,8 @@ prefix : &lt;http://example.com/ns#&gt;
 
 :a :b "hello"@en-US.</pre>
 <p>Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.</p>
-</section><section id="opaque-language-string" class="entry proposed NegativeEntailmentTest">
-<h2>opaque-language-string <a href="#opaque-language-string">🔗</a></h2>
+</section><section id="rs:opaque-language-string" class="entry proposed NegativeEntailmentTest">
+<h2>opaque-language-string <a href="trs:opaque-language-string">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -672,8 +672,8 @@ prefix : &lt;http://example.com/ns#&gt;
 
 &lt;&lt; :a :b "hello"@en-US &gt;&gt; :p1 :o1.</pre>
 <p>Embedded literals (including language strings) are opaque, even when their datatype is recognized.</p>
-</section><section id="opaque-iri-control" class="entry proposed PositiveEntailmentTest">
-<h2>opaque-iri-control <a href="#opaque-iri-control">🔗</a></h2>
+</section><section id="rs:opaque-iri-control" class="entry proposed PositiveEntailmentTest">
+<h2>opaque-iri-control <a href="trs:opaque-iri-control">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -695,8 +695,8 @@ prefix : &lt;http://example.com/ns#&gt;
 :clark :can :fly .
 </pre>
 <p>Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.</p>
-</section><section id="opaque-iri" class="entry proposed NegativeEntailmentTest">
-<h2>opaque-iri <a href="#opaque-iri">🔗</a></h2>
+</section><section id="rs:opaque-iri" class="entry proposed NegativeEntailmentTest">
+<h2>opaque-iri <a href="trs:opaque-iri">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -717,8 +717,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; :clark :can :fly &gt;&gt; :reportedBy :clark.
 </pre>
 <p>Embedded IRIs are opaque.</p>
-</section><section id="embedded-not-asserted" class="entry proposed NegativeEntailmentTest">
-<h2>embedded-not-asserted <a href="#embedded-not-asserted">🔗</a></h2>
+</section><section id="rs:embedded-not-asserted" class="entry proposed NegativeEntailmentTest">
+<h2>embedded-not-asserted <a href="trs:embedded-not-asserted">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>negative entailment test</td>
@@ -738,8 +738,8 @@ prefix : &lt;http://example.com/ns#&gt;
 :a :b :c.
 </pre>
 <p>Embedded triples are not asserted.</p>
-</section><section id="annotated-asserted" class="entry proposed PositiveEntailmentTest">
-<h2>annotated-asserted <a href="#annotated-asserted">🔗</a></h2>
+</section><section id="rs:annotated-asserted" class="entry proposed PositiveEntailmentTest">
+<h2>annotated-asserted <a href="trs:annotated-asserted">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -759,8 +759,8 @@ prefix : &lt;http://example.com/ns#&gt;
 :a :b :c.
 </pre>
 <p>Annotated triples are asserted.</p>
-</section><section id="annotation" class="entry proposed PositiveEntailmentTest">
-<h2>annotation <a href="#annotation">🔗</a></h2>
+</section><section id="rs:annotation" class="entry proposed PositiveEntailmentTest">
+<h2>annotation <a href="trs:annotation">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>
@@ -780,8 +780,8 @@ prefix : &lt;http://example.com/ns#&gt;
 &lt;&lt; :a :b :c &gt;&gt; :p1 :o1.
 </pre>
 <p>Annotation are about the annotated triple.</p>
-</section><section id="annotation-unfolded" class="entry proposed PositiveEntailmentTest">
-<h2>annotation-unfolded <a href="#annotation-unfolded">🔗</a></h2>
+</section><section id="rs:annotation-unfolded" class="entry proposed PositiveEntailmentTest">
+<h2>annotation-unfolded <a href="trs:annotation-unfolded">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>positive entailment test</td>

--- a/tests/semantics/manifest.jsonld
+++ b/tests/semantics/manifest.jsonld
@@ -8,7 +8,9 @@
     "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
     "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
     "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/semantics#",
     "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/semantics/",
     "include": {
       "@type": "@id",
       "@container": "@list"
@@ -62,515 +64,514 @@
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
-    "@base": "https://w3c.github.io/rdf-star/tests/semantics/manifest"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
   },
-  "@id": "manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
+  "label": "RDF-star Semantics tests",
+  "seeAlso": "README",
   "entries": [
     {
-      "@id": "#triple-in-subject",
+      "@id": "trs:triple-in-subject",
       "@type": "PositiveEntailmentTest",
-      "approval": "Approved",
       "entailmentRegime": "simple",
+      "approval": "Approved",
       "name": "triple-in-subject",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test000s.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "test000s.ttl",
       "comment": "Embedded triples can appear in subject position (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test000s.ttl"
+      ]
     },
     {
-      "@id": "#triple-in-object",
+      "@id": "trs:triple-in-object",
       "@type": "PositiveEntailmentTest",
+      "entailmentRegime": "simple",
       "approval": "Approved",
-      "entailmentRegime": "simple",
       "name": "triple-in-object",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test000o.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "test000o.ttl",
       "comment": "Embedded triples can appear in object position (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test000o.ttl"
+      ]
     },
     {
-      "@id": "#all-identical-embedded-triples-are-the-same",
+      "@id": "trs:all-identical-embedded-triples-are-the-same",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "all-identical-embedded-triples-are-the-same",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test001a.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "test001r.ttl",
       "comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test001r.ttl"
+      ]
     },
     {
-      "@id": "#embedded-triples-no-spurious",
+      "@id": "trs:embedded-triples-no-spurious",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "embedded-triples-no-spurious",
-      "action": "test002a.ttl",
-      "recognizedDatatypes": [
+      "unrecognizedDatatypes": [
 
       ],
+      "action": "test002a.ttl",
+      "result": "test005.ttl",
       "comment": "This test ensures that other entailments are not spurious.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test005.ttl"
+      ]
     },
     {
-      "@id": "#bnodes-in-embedded-subject",
+      "@id": "trs:bnodes-in-embedded-subject",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-subject",
-      "action": "test002a.ttl",
-      "recognizedDatatypes": [
-
-      ],
-      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002sr.ttl"
+      "action": "test002a.ttl",
+      "result": "test002sr.ttl",
+      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "recognizedDatatypes": [
+
+      ]
     },
     {
-      "@id": "#bnodes-in-embedded-object",
+      "@id": "trs:bnodes-in-embedded-object",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-object",
-      "action": "test002a.ttl",
-      "recognizedDatatypes": [
-
-      ],
-      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002or.ttl"
+      "action": "test002a.ttl",
+      "result": "test002or.ttl",
+      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "recognizedDatatypes": [
+
+      ]
     },
     {
-      "@id": "#bnodes-in-embedded-subject-and-object",
+      "@id": "trs:bnodes-in-embedded-subject-and-object",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-subject-and-object",
-      "action": "test002a.ttl",
-      "recognizedDatatypes": [
+      "unrecognizedDatatypes": [
 
       ],
+      "action": "test002a.ttl",
+      "result": "test002sor.ttl",
       "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test002sor.ttl"
+      ]
     },
     {
-      "@id": "#bnodes-in-embedded-subject-and-object-fail",
+      "@id": "trs:bnodes-in-embedded-subject-and-object-fail",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-subject-and-object-fail",
-      "action": "test002a.ttl",
-      "recognizedDatatypes": [
+      "unrecognizedDatatypes": [
 
       ],
+      "action": "test002a.ttl",
+      "result": "test002sbr.ttl",
       "comment": "The same bnode can not match different embedded terms.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test002sbr.ttl"
+      ]
     },
     {
-      "@id": "#same-bnode-same-embedded-term",
+      "@id": "trs:same-bnode-same-embedded-term",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "same-bnode-same-embedded-term",
-      "action": "test003a.ttl",
-      "recognizedDatatypes": [
+      "unrecognizedDatatypes": [
 
       ],
+      "action": "test003a.ttl",
+      "result": "test002sbr.ttl",
       "comment": "Identical embedde term can be replaced by the same fresh bnode multiple times.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test002sbr.ttl"
+      ]
     },
     {
-      "@id": "#different-bnodes-same-embedded-term",
+      "@id": "trs:different-bnodes-same-embedded-term",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "different-bnodes-same-embedded-term",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test003a.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "test002sor.ttl",
       "comment": "Different bnodes can match identical embedded terms.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test002sor.ttl"
+      ]
     },
     {
-      "@id": "#constrained-bnodes-in-embedded-subject",
+      "@id": "trs:constrained-bnodes-in-embedded-subject",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "constrained-bnodes-in-embedded-subject",
-      "action": "test004a.ttl",
-      "recognizedDatatypes": [
+      "unrecognizedDatatypes": [
 
       ],
+      "action": "test004a.ttl",
+      "result": "test004sr.ttl",
       "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test004sr.ttl"
+      ]
     },
     {
-      "@id": "#constrained-bnodes-in-embedded-object",
+      "@id": "trs:constrained-bnodes-in-embedded-object",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "constrained-bnodes-in-embedded-object",
-      "action": "test004a.ttl",
-      "recognizedDatatypes": [
+      "unrecognizedDatatypes": [
 
       ],
+      "action": "test004a.ttl",
+      "result": "test004or.ttl",
       "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test004or.ttl"
+      ]
     },
     {
-      "@id": "#constrained-bnodes-in-embedded-fail",
+      "@id": "trs:constrained-bnodes-in-embedded-fail",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "constrained-bnodes-in-embedded-fail",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test004a.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "test004fr.ttl",
       "comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test004fr.ttl"
+      ]
     },
     {
-      "@id": "#constrained-bnodes-on-literal",
+      "@id": "trs:constrained-bnodes-on-literal",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "constrained-bnodes-on-literal",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test006a.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "test006r.ttl",
       "comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test006r.ttl"
+      ]
     },
     {
-      "@id": "#malformed-literal-control",
+      "@id": "trs:malformed-literal-control",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "malformed-literal-control",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "malformed-literal-control.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ],
+      "mf:result": {
+        "@type": "xsd:boolean",
+        "@value": "false"
+      },
       "comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-star tests do not pass spuriously.",
-      "unrecognizedDatatypes": [
-
-      ],
-      "mf:result": {
-        "@type": "xsd:boolean",
-        "@value": "false"
-      }
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
     },
     {
-      "@id": "#malformed-literal",
+      "@id": "trs:malformed-literal",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "malformed-literal",
-      "action": "malformed-literal.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ],
-      "comment": "Malformed literals are allowed when embedded.",
       "unrecognizedDatatypes": [
 
       ],
+      "action": "malformed-literal.ttl",
       "mf:result": {
         "@type": "xsd:boolean",
         "@value": "false"
-      }
-    },
-    {
-      "@id": "#malformed-literal-accepted",
-      "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
-      "entailmentRegime": "RDF",
-      "name": "malformed-literal-accepted",
-      "action": "malformed-literal.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ],
+      },
       "comment": "Malformed literals are allowed when embedded.",
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
+    },
+    {
+      "@id": "trs:malformed-literal-accepted",
+      "@type": "PositiveEntailmentTest",
+      "entailmentRegime": "RDF",
+      "approval": "Proposed",
+      "name": "malformed-literal-accepted",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "malformed-literal.ttl"
+      "action": "malformed-literal.ttl",
+      "result": "malformed-literal.ttl",
+      "comment": "Malformed literals are allowed when embedded.",
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
     },
     {
-      "@id": "#malformed-literal-no-spurious",
+      "@id": "trs:malformed-literal-no-spurious",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "malformed-literal-no-spurious",
-      "action": "malformed-literal.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
+      "unrecognizedDatatypes": [
+
       ],
+      "action": "malformed-literal.ttl",
+      "result": "malformed-literal-other.ttl",
       "comment": "Embedded malformed literals do not lead to spurious entailment.",
-      "unrecognizedDatatypes": [
-
-      ],
-      "result": "malformed-literal-other.ttl"
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
     },
     {
-      "@id": "#malformed-literal-bnode",
+      "@id": "trs:malformed-literal-bnode",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "malformed-literal-bnode",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "malformed-literal.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ],
+      "result": "test002or.ttl",
       "comment": "Malformed literals can be replaced by blank nodes.",
-      "unrecognizedDatatypes": [
-
-      ],
-      "result": "test002or.ttl"
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
     },
     {
-      "@id": "#malformed-literal-bnode-2",
+      "@id": "trs:malformed-literal-bnode-2",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "malformed-literal-bnode-2",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "malformed-literal-2a.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ],
+      "result": "malformed-literal-2r.ttl",
       "comment": "Identical malformed literals can be replaced with the same blank node.",
-      "unrecognizedDatatypes": [
-
-      ],
-      "result": "malformed-literal-2r.ttl"
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
     },
     {
-      "@id": "#malformed-literal-bnode-3",
+      "@id": "trs:malformed-literal-bnode-3",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "malformed-literal-bnode-3",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "malformed-literal-3a.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ],
+      "result": "malformed-literal-3r.ttl",
       "comment": "Identical malformed literals can not be replaced with the same blank node.",
-      "unrecognizedDatatypes": [
-
-      ],
-      "result": "malformed-literal-3r.ttl"
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
     },
     {
-      "@id": "#opaque-literal-control",
+      "@id": "trs:opaque-literal-control",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "opaque-literal-control",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "non-canonical-literal-control.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ],
+      "result": "canonical-literal-control.ttl",
       "comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
-      "unrecognizedDatatypes": [
-
-      ],
-      "result": "canonical-literal-control.ttl"
-    },
-    {
-      "@id": "#opaque-literal",
-      "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
-      "entailmentRegime": "RDF",
-      "name": "opaque-literal",
-      "action": "non-canonical-literal.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
+      ]
+    },
+    {
+      "@id": "trs:opaque-literal",
+      "@type": "NegativeEntailmentTest",
+      "entailmentRegime": "RDF",
+      "approval": "Proposed",
+      "name": "opaque-literal",
+      "unrecognizedDatatypes": [
+
       ],
+      "action": "non-canonical-literal.ttl",
+      "result": "canonical-literal.ttl",
       "comment": "Embedded literals are opaque, even when their datatype is recognized.",
-      "unrecognizedDatatypes": [
-
-      ],
-      "result": "canonical-literal.ttl"
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ]
     },
     {
-      "@id": "#opaque-language-string-control",
+      "@id": "trs:opaque-language-string-control",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "opaque-language-string-control",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "lowercase-language-string-control.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "upercase-language-string-control.ttl",
       "comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "upercase-language-string-control.ttl"
+      ]
     },
     {
-      "@id": "#opaque-language-string",
+      "@id": "trs:opaque-language-string",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "name": "opaque-language-string",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "lowercase-language-string.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "upercase-language-string.ttl",
       "comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "upercase-language-string.ttl"
+      ]
     },
     {
-      "@id": "#opaque-iri-control",
+      "@id": "trs:opaque-iri-control",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDFS-Plus",
+      "approval": "Proposed",
       "name": "opaque-iri-control",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "control-sameas-a.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "control-sameas-r.ttl",
       "comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "control-sameas-r.ttl"
+      ]
     },
     {
-      "@id": "#opaque-iri",
+      "@id": "trs:opaque-iri",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "RDFS-Plus",
+      "approval": "Proposed",
       "name": "opaque-iri",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "superman.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "superman_undesired_entailment.ttl",
       "comment": "Embedded IRIs are opaque.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "superman_undesired_entailment.ttl"
+      ]
     },
     {
-      "@id": "#embedded-not-asserted",
+      "@id": "trs:embedded-not-asserted",
       "@type": "NegativeEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "embedded-not-asserted",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test002a.ttl",
-      "recognizedDatatypes": [
-
-      ],
+      "result": "test002pgr.ttl",
       "comment": "Embedded triples are not asserted.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test002pgr.ttl"
+      ]
     },
     {
-      "@id": "#annotated-asserted",
+      "@id": "trs:annotated-asserted",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "annotated-asserted",
-      "action": "test007a.ttl",
-      "recognizedDatatypes": [
+      "unrecognizedDatatypes": [
 
       ],
+      "action": "test007a.ttl",
+      "result": "test007r1.ttl",
       "comment": "Annotated triples are asserted.",
-      "unrecognizedDatatypes": [
+      "recognizedDatatypes": [
 
-      ],
-      "result": "test007r1.ttl"
+      ]
     },
     {
-      "@id": "#annotation",
+      "@id": "trs:annotation",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "annotation",
-      "action": "test007a.ttl",
-      "recognizedDatatypes": [
-
-      ],
-      "comment": "Annotation are about the annotated triple.",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test007r2.ttl"
+      "action": "test007a.ttl",
+      "result": "test007r2.ttl",
+      "comment": "Annotation are about the annotated triple.",
+      "recognizedDatatypes": [
+
+      ]
     },
     {
-      "@id": "#annotation-unfolded",
+      "@id": "trs:annotation-unfolded",
       "@type": "PositiveEntailmentTest",
-      "approval": "Proposed",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "name": "annotation-unfolded",
-      "action": "test007a2.ttl",
-      "recognizedDatatypes": [
-
-      ],
-      "comment": "Annotation is the same as separate assertions.",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test007a.ttl"
+      "action": "test007a2.ttl",
+      "result": "test007a.ttl",
+      "comment": "Annotation is the same as separate assertions.",
+      "recognizedDatatypes": [
+
+      ]
     }
-  ],
-  "seeAlso": "README",
-  "label": "RDF-star Semantics tests"
+  ]
 }

--- a/tests/semantics/manifest.ttl
+++ b/tests/semantics/manifest.ttl
@@ -1,49 +1,48 @@
-BASE           <https://w3c.github.io/rdf-star/tests/semantics/manifest>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
-PREFIX :       <#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/semantics#>
 
-<> a mf:Manifest;
+trs:manifest a mf:Manifest;
   rdfs:label "RDF-star Semantics tests";
   rdfs:seeAlso <README>;
   mf:entries (
-    :triple-in-subject
-    :triple-in-object
-    :all-identical-embedded-triples-are-the-same
-    :embedded-triples-no-spurious
-    :bnodes-in-embedded-subject
-    :bnodes-in-embedded-object
-    :bnodes-in-embedded-subject-and-object
-    :bnodes-in-embedded-subject-and-object-fail
-    :same-bnode-same-embedded-term
-    :different-bnodes-same-embedded-term
-    :constrained-bnodes-in-embedded-subject
-    :constrained-bnodes-in-embedded-object
-    :constrained-bnodes-in-embedded-fail
-    :constrained-bnodes-on-literal
-    :malformed-literal-control
-    :malformed-literal
-    :malformed-literal-accepted
-    :malformed-literal-no-spurious
-    :malformed-literal-bnode
-    :malformed-literal-bnode-2
-    :malformed-literal-bnode-3
-    :opaque-literal-control
-    :opaque-literal
-    :opaque-language-string-control
-    :opaque-language-string
-    :opaque-iri-control
-    :opaque-iri
-    :embedded-not-asserted
-    :annotated-asserted
-    :annotation
-    :annotation-unfolded
+    trs:triple-in-subject
+    trs:triple-in-object
+    trs:all-identical-embedded-triples-are-the-same
+    trs:embedded-triples-no-spurious
+    trs:bnodes-in-embedded-subject
+    trs:bnodes-in-embedded-object
+    trs:bnodes-in-embedded-subject-and-object
+    trs:bnodes-in-embedded-subject-and-object-fail
+    trs:same-bnode-same-embedded-term
+    trs:different-bnodes-same-embedded-term
+    trs:constrained-bnodes-in-embedded-subject
+    trs:constrained-bnodes-in-embedded-object
+    trs:constrained-bnodes-in-embedded-fail
+    trs:constrained-bnodes-on-literal
+    trs:malformed-literal-control
+    trs:malformed-literal
+    trs:malformed-literal-accepted
+    trs:malformed-literal-no-spurious
+    trs:malformed-literal-bnode
+    trs:malformed-literal-bnode-2
+    trs:malformed-literal-bnode-3
+    trs:opaque-literal-control
+    trs:opaque-literal
+    trs:opaque-language-string-control
+    trs:opaque-language-string
+    trs:opaque-iri-control
+    trs:opaque-iri
+    trs:embedded-not-asserted
+    trs:annotated-asserted
+    trs:annotation
+    trs:annotation-unfolded
   ) .
 
-:all-identical-embedded-triples-are-the-same a mf:PositiveEntailmentTest;
+trs:all-identical-embedded-triples-are-the-same a mf:PositiveEntailmentTest;
   rdfs:comment "Multiple occurences of the same embedded triples are undistinguishable in the abstract model (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).";
   mf:action <test001a.ttl>;
   mf:entailmentRegime "simple";
@@ -53,7 +52,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:annotated-asserted a mf:PositiveEntailmentTest;
+trs:annotated-asserted a mf:PositiveEntailmentTest;
   rdfs:comment "Annotated triples are asserted.";
   mf:action <test007a.ttl>;
   mf:entailmentRegime "simple";
@@ -63,7 +62,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:annotation a mf:PositiveEntailmentTest;
+trs:annotation a mf:PositiveEntailmentTest;
   rdfs:comment "Annotation are about the annotated triple.";
   mf:action <test007a.ttl>;
   mf:entailmentRegime "simple";
@@ -73,7 +72,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:annotation-unfolded a mf:PositiveEntailmentTest;
+trs::annotation-unfolded a mf:PositiveEntailmentTest;
   rdfs:comment "Annotation is the same as separate assertions.";
   mf:action <test007a2.ttl>;
   mf:entailmentRegime "simple";
@@ -83,7 +82,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:bnodes-in-embedded-object a mf:PositiveEntailmentTest;
+trs:bnodes-in-embedded-object a mf:PositiveEntailmentTest;
   rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
@@ -93,7 +92,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:bnodes-in-embedded-subject a mf:PositiveEntailmentTest;
+trs:bnodes-in-embedded-subject a mf:PositiveEntailmentTest;
   rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
@@ -103,7 +102,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:bnodes-in-embedded-subject-and-object a mf:PositiveEntailmentTest;
+trs:bnodes-in-embedded-subject-and-object a mf:PositiveEntailmentTest;
   rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
@@ -113,7 +112,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:bnodes-in-embedded-subject-and-object-fail a mf:NegativeEntailmentTest;
+trs:bnodes-in-embedded-subject-and-object-fail a mf:NegativeEntailmentTest;
   rdfs:comment "The same bnode can not match different embedded terms.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
@@ -123,7 +122,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:constrained-bnodes-in-embedded-fail a mf:NegativeEntailmentTest;
+trs:constrained-bnodes-in-embedded-fail a mf:NegativeEntailmentTest;
   rdfs:comment "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.";
   mf:action <test004a.ttl>;
   mf:entailmentRegime "simple";
@@ -133,7 +132,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:constrained-bnodes-in-embedded-object a mf:PositiveEntailmentTest;
+trs:constrained-bnodes-in-embedded-object a mf:PositiveEntailmentTest;
   rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes.";
   mf:action <test004a.ttl>;
   mf:entailmentRegime "simple";
@@ -143,7 +142,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:constrained-bnodes-in-embedded-subject a mf:PositiveEntailmentTest;
+trs:constrained-bnodes-in-embedded-subject a mf:PositiveEntailmentTest;
   rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes";
   mf:action <test004a.ttl>;
   mf:entailmentRegime "simple";
@@ -153,7 +152,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:constrained-bnodes-on-literal a mf:PositiveEntailmentTest;
+trs:constrained-bnodes-on-literal a mf:PositiveEntailmentTest;
   rdfs:comment "Literals in embedded triples and outside can be replaced by fresh bnodes.";
   mf:action <test006a.ttl>;
   mf:entailmentRegime "simple";
@@ -163,7 +162,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:different-bnodes-same-embedded-term a mf:PositiveEntailmentTest;
+trs:different-bnodes-same-embedded-term a mf:PositiveEntailmentTest;
   rdfs:comment "Different bnodes can match identical embedded terms.";
   mf:action <test003a.ttl>;
   mf:entailmentRegime "simple";
@@ -173,7 +172,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:embedded-not-asserted a mf:NegativeEntailmentTest;
+trs:embedded-not-asserted a mf:NegativeEntailmentTest;
   rdfs:comment "Embedded triples are not asserted.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
@@ -183,7 +182,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:embedded-triples-no-spurious a mf:NegativeEntailmentTest;
+trs:embedded-triples-no-spurious a mf:NegativeEntailmentTest;
   rdfs:comment "This test ensures that other entailments are not spurious.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
@@ -193,7 +192,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:malformed-literal a mf:NegativeEntailmentTest;
+trs:malformed-literal a mf:NegativeEntailmentTest;
   rdfs:comment "Malformed literals are allowed when embedded.";
   mf:action <malformed-literal.ttl>;
   mf:entailmentRegime "RDF";
@@ -203,7 +202,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:malformed-literal-accepted a mf:PositiveEntailmentTest;
+trs:malformed-literal-accepted a mf:PositiveEntailmentTest;
   rdfs:comment "Malformed literals are allowed when embedded.";
   mf:action <malformed-literal.ttl>;
   mf:entailmentRegime "RDF";
@@ -213,7 +212,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:malformed-literal-bnode a mf:PositiveEntailmentTest;
+trs:malformed-literal-bnode a mf:PositiveEntailmentTest;
   rdfs:comment "Malformed literals can be replaced by blank nodes.";
   mf:action <malformed-literal.ttl>;
   mf:entailmentRegime "RDF";
@@ -223,7 +222,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:malformed-literal-bnode-2 a mf:PositiveEntailmentTest;
+trs:malformed-literal-bnode-2 a mf:PositiveEntailmentTest;
   rdfs:comment "Identical malformed literals can be replaced with the same blank node.";
   mf:action <malformed-literal-2a.ttl>;
   mf:entailmentRegime "RDF";
@@ -233,7 +232,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:malformed-literal-bnode-3 a mf:NegativeEntailmentTest;
+trs:malformed-literal-bnode-3 a mf:NegativeEntailmentTest;
   rdfs:comment "Identical malformed literals can not be replaced with the same blank node.";
   mf:action <malformed-literal-3a.ttl>;
   mf:entailmentRegime "RDF";
@@ -243,7 +242,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:malformed-literal-control a mf:PositiveEntailmentTest;
+trs:malformed-literal-control a mf:PositiveEntailmentTest;
   rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-star tests do not pass spuriously.";
   mf:action <malformed-literal-control.ttl>;
   mf:entailmentRegime "RDF";
@@ -253,7 +252,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:malformed-literal-no-spurious a mf:NegativeEntailmentTest;
+trs:malformed-literal-no-spurious a mf:NegativeEntailmentTest;
   rdfs:comment "Embedded malformed literals do not lead to spurious entailment.";
   mf:action <malformed-literal.ttl>;
   mf:entailmentRegime "RDF";
@@ -263,7 +262,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:opaque-iri a mf:NegativeEntailmentTest;
+trs:opaque-iri a mf:NegativeEntailmentTest;
   rdfs:comment "Embedded IRIs are opaque.";
   mf:action <superman.ttl>;
   mf:entailmentRegime "RDFS-Plus";
@@ -273,7 +272,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:opaque-iri-control a mf:PositiveEntailmentTest;
+trs:opaque-iri-control a mf:PositiveEntailmentTest;
   rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.";
   mf:action <control-sameas-a.ttl>;
   mf:entailmentRegime "RDFS-Plus";
@@ -283,7 +282,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:opaque-language-string a mf:NegativeEntailmentTest;
+trs:opaque-language-string a mf:NegativeEntailmentTest;
   rdfs:comment "Embedded literals (including language strings) are opaque, even when their datatype is recognized.";
   mf:action <lowercase-language-string.ttl>;
   mf:entailmentRegime "RDF";
@@ -293,7 +292,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:opaque-language-string-control a mf:PositiveEntailmentTest;
+trs:opaque-language-string-control a mf:PositiveEntailmentTest;
   rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.";
   mf:action <lowercase-language-string-control.ttl>;
   mf:entailmentRegime "RDF";
@@ -303,7 +302,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:opaque-literal a mf:NegativeEntailmentTest;
+trs:opaque-literal a mf:NegativeEntailmentTest;
   rdfs:comment "Embedded literals are opaque, even when their datatype is recognized.";
   mf:action <non-canonical-literal.ttl>;
   mf:entailmentRegime "RDF";
@@ -313,7 +312,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:opaque-literal-control a mf:PositiveEntailmentTest;
+trs:opaque-literal-control a mf:PositiveEntailmentTest;
   rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.";
   mf:action <non-canonical-literal-control.ttl>;
   mf:entailmentRegime "RDF";
@@ -323,7 +322,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:same-bnode-same-embedded-term a mf:PositiveEntailmentTest;
+trs:same-bnode-same-embedded-term a mf:PositiveEntailmentTest;
   rdfs:comment "Identical embedde term can be replaced by the same fresh bnode multiple times.";
   mf:action <test003a.ttl>;
   mf:entailmentRegime "simple";
@@ -333,7 +332,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-:triple-in-object a mf:PositiveEntailmentTest;
+trs:triple-in-object a mf:PositiveEntailmentTest;
   rdfs:comment "Embedded triples can appear in object position (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).";
   mf:action <test000o.ttl>;
   mf:entailmentRegime "simple";
@@ -343,7 +342,7 @@ PREFIX :       <#>
   mf:unrecognizedDatatypes ();
   test:approval test:Approved .
 
-:triple-in-subject a mf:PositiveEntailmentTest;
+trs:triple-in-subject a mf:PositiveEntailmentTest;
   rdfs:comment "Embedded triples can appear in subject position (EVENTUALLY, this should be a Turtle-star test rather than a semantics test).";
   mf:action <test000s.ttl>;
   mf:entailmentRegime "simple";

--- a/tests/semantics/manifest.ttl
+++ b/tests/semantics/manifest.ttl
@@ -72,7 +72,7 @@ trs:annotation a mf:PositiveEntailmentTest;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs::annotation-unfolded a mf:PositiveEntailmentTest;
+trs:annotation-unfolded a mf:PositiveEntailmentTest;
   rdfs:comment "Annotation is the same as separate assertions.";
   mf:action <test007a2.ttl>;
   mf:entailmentRegime "simple";

--- a/tests/sparql/eval/manifest.html
+++ b/tests/sparql/eval/manifest.html
@@ -56,38 +56,38 @@
 <h1>manifest</h1>
 <p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
 <ul class="entries">
-<li class="proposed"><a href="#sparql-star-results-1j">SPARQL-star - all graph triples (JSON results)</a>
-<li class="proposed"><a href="#sparql-star-results-1x">SPARQL-star - all graph triples (XML results)</a>
-<li class="proposed"><a href="#sparql-star-basic-2">SPARQL-star - match constant embedded triple</a>
-<li class="proposed"><a href="#sparql-star-basic-3">SPARQL-star - match embedded triple, var subject</a>
-<li class="proposed"><a href="#sparql-star-basic-4">SPARQL-star - match embedded triple, var predicate</a>
-<li class="proposed"><a href="#sparql-star-basic-5">SPARQL-star - match embedded triple, var object</a>
-<li class="proposed"><a href="#sparql-star-basic-6">SPARQL-star - no match of embedded triple</a>
-<li class="proposed"><a href="#sparql-star-pattern-1">SPARQL-star - Asserted and embedded triple</a>
-<li class="proposed"><a href="#sparql-star-pattern-2">SPARQL-star -  Asserted and embedded triple</a>
-<li class="proposed"><a href="#sparql-star-pattern-3">SPARQL-star - Pattern - Variable for embedded triple</a>
-<li class="proposed"><a href="#sparql-star-pattern-4">SPARQL-star - Pattern - No match</a>
-<li class="proposed"><a href="#sparql-star-pattern-5">SPARQL-star - Pattern - match variables in triple terms</a>
-<li class="proposed"><a href="#sparql-star-pattern-6">SPARQL-star - Pattern - Nesting 1</a>
-<li class="proposed"><a href="#sparql-star-pattern-7">SPARQL-star - Pattern - Nesting - 2</a>
-<li class="proposed"><a href="#sparql-star-pattern-8">SPARQL-star - Pattern - Match and nesting</a>
-<li class="proposed"><a href="#sparql-star-pattern-9">SPARQL-star - Pattern - Same variable</a>
-<li class="proposed"><a href="#sparql-star-construct-1">SPARQL-star - CONSTRUCT with constant template</a>
-<li class="proposed"><a href="#sparql-star-construct-2">SPARQL-star - CONSTRUCT WHERE with constant template</a>
-<li class="proposed"><a href="#sparql-star-construct-3">SPARQL-star - CONSTRUCT - about every triple</a>
-<li class="proposed"><a href="#sparql-star-construct-4">SPARQL-star - CONSTRUCT with annotation syntax</a>
-<li class="proposed"><a href="#sparql-star-construct-5">SPARQL-star - CONSTRUCT WHERE with annotation syntax</a>
-<li class="proposed"><a href="#sparql-star-graphs-1">SPARQL-star - GRAPH</a>
-<li class="proposed"><a href="#sparql-star-graphs-2">SPARQL-star - GRAPHs with blank node</a>
-<li class="proposed"><a href="#sparql-star-expr-1">SPARQL-star - Embedded triple - BIND - CONSTRUCT</a>
-<li class="proposed"><a href="#sparql-star-expr-2">SPARQL-star - Embedded triple - Functions</a>
-<li class="proposed"><a href="#sparql-star-order-1">SPARQL-star - Embedded triple ORDER BY</a>
-<li class="proposed"><a href="#sparql-star-update-1">SPARQL-star - Update</a>
-<li class="proposed"><a href="#sparql-star-update-2">SPARQL-star - Update - annotation</a>
-<li class="proposed"><a href="#sparql-star-update-3">SPARQL-star - Update - data</a>
+<li class="proposed"><a href="trs:sparql-star-results-1j">SPARQL-star - all graph triples (JSON results)</a>
+<li class="proposed"><a href="trs:sparql-star-results-1x">SPARQL-star - all graph triples (XML results)</a>
+<li class="proposed"><a href="trs:sparql-star-basic-2">SPARQL-star - match constant embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-basic-3">SPARQL-star - match embedded triple, var subject</a>
+<li class="proposed"><a href="trs:sparql-star-basic-4">SPARQL-star - match embedded triple, var predicate</a>
+<li class="proposed"><a href="trs:sparql-star-basic-5">SPARQL-star - match embedded triple, var object</a>
+<li class="proposed"><a href="trs:sparql-star-basic-6">SPARQL-star - no match of embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-1">SPARQL-star - Asserted and embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-2">SPARQL-star -  Asserted and embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-3">SPARQL-star - Pattern - Variable for embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-4">SPARQL-star - Pattern - No match</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-5">SPARQL-star - Pattern - match variables in triple terms</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-6">SPARQL-star - Pattern - Nesting 1</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-7">SPARQL-star - Pattern - Nesting - 2</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-8">SPARQL-star - Pattern - Match and nesting</a>
+<li class="proposed"><a href="trs:sparql-star-pattern-9">SPARQL-star - Pattern - Same variable</a>
+<li class="proposed"><a href="trs:sparql-star-construct-1">SPARQL-star - CONSTRUCT with constant template</a>
+<li class="proposed"><a href="trs:sparql-star-construct-2">SPARQL-star - CONSTRUCT WHERE with constant template</a>
+<li class="proposed"><a href="trs:sparql-star-construct-3">SPARQL-star - CONSTRUCT - about every triple</a>
+<li class="proposed"><a href="trs:sparql-star-construct-4">SPARQL-star - CONSTRUCT with annotation syntax</a>
+<li class="proposed"><a href="trs:sparql-star-construct-5">SPARQL-star - CONSTRUCT WHERE with annotation syntax</a>
+<li class="proposed"><a href="trs:sparql-star-graphs-1">SPARQL-star - GRAPH</a>
+<li class="proposed"><a href="trs:sparql-star-graphs-2">SPARQL-star - GRAPHs with blank node</a>
+<li class="proposed"><a href="trs:sparql-star-expr-1">SPARQL-star - Embedded triple - BIND - CONSTRUCT</a>
+<li class="proposed"><a href="trs:sparql-star-expr-2">SPARQL-star - Embedded triple - Functions</a>
+<li class="proposed"><a href="trs:sparql-star-order-1">SPARQL-star - Embedded triple ORDER BY</a>
+<li class="proposed"><a href="trs:sparql-star-update-1">SPARQL-star - Update</a>
+<li class="proposed"><a href="trs:sparql-star-update-2">SPARQL-star - Update - annotation</a>
+<li class="proposed"><a href="trs:sparql-star-update-3">SPARQL-star - Update - data</a>
 </ul>
-<section id="sparql-star-results-1j" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - all graph triples (JSON results) <a href="#sparql-star-results-1j">🔗</a></h2>
+<section id="rs:sparql-star-results-1j" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - all graph triples (JSON results) <a href="trs:sparql-star-results-1j">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -227,8 +227,8 @@ PREFIX : &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-results-1x" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - all graph triples (XML results) <a href="#sparql-star-results-1x">🔗</a></h2>
+</section><section id="rs:sparql-star-results-1x" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - all graph triples (XML results) <a href="trs:sparql-star-results-1x">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -439,8 +439,8 @@ PREFIX : &lt;http://example/&gt;
   &lt;/results&gt;
 &lt;/sparql&gt;
 </pre>
-</section><section id="sparql-star-basic-2" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - match constant embedded triple <a href="#sparql-star-basic-2">🔗</a></h2>
+</section><section id="rs:sparql-star-basic-2" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - match constant embedded triple <a href="trs:sparql-star-basic-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -475,8 +475,8 @@ PREFIX : &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-basic-3" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - match embedded triple, var subject <a href="#sparql-star-basic-3">🔗</a></h2>
+</section><section id="rs:sparql-star-basic-3" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - match embedded triple, var subject <a href="trs:sparql-star-basic-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -512,8 +512,8 @@ PREFIX : &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-basic-4" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - match embedded triple, var predicate <a href="#sparql-star-basic-4">🔗</a></h2>
+</section><section id="rs:sparql-star-basic-4" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - match embedded triple, var predicate <a href="trs:sparql-star-basic-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -548,8 +548,8 @@ PREFIX : &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-basic-5" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - match embedded triple, var object <a href="#sparql-star-basic-5">🔗</a></h2>
+</section><section id="rs:sparql-star-basic-5" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - match embedded triple, var object <a href="trs:sparql-star-basic-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -584,8 +584,8 @@ PREFIX : &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-basic-6" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - no match of embedded triple <a href="#sparql-star-basic-6">🔗</a></h2>
+</section><section id="rs:sparql-star-basic-6" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - no match of embedded triple <a href="trs:sparql-star-basic-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -617,8 +617,8 @@ PREFIX : &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-1" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Asserted and embedded triple <a href="#sparql-star-pattern-1">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-1" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Asserted and embedded triple <a href="trs:sparql-star-pattern-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -673,8 +673,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-2" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star -  Asserted and embedded triple <a href="#sparql-star-pattern-2">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-2" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star -  Asserted and embedded triple <a href="trs:sparql-star-pattern-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -729,8 +729,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-3" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Pattern - Variable for embedded triple <a href="#sparql-star-pattern-3">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-3" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Pattern - Variable for embedded triple <a href="trs:sparql-star-pattern-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -788,8 +788,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-4" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Pattern - No match <a href="#sparql-star-pattern-4">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-4" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Pattern - No match <a href="trs:sparql-star-pattern-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -835,8 +835,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-5" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Pattern - match variables in triple terms <a href="#sparql-star-pattern-5">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-5" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Pattern - match variables in triple terms <a href="trs:sparql-star-pattern-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -887,8 +887,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-6" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Pattern - Nesting 1 <a href="#sparql-star-pattern-6">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-6" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Pattern - Nesting 1 <a href="trs:sparql-star-pattern-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -936,8 +936,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-7" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Pattern - Nesting - 2 <a href="#sparql-star-pattern-7">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-7" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Pattern - Nesting - 2 <a href="trs:sparql-star-pattern-7">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -987,8 +987,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-8" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Pattern - Match and nesting <a href="#sparql-star-pattern-8">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-8" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Pattern - Match and nesting <a href="trs:sparql-star-pattern-8">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1044,8 +1044,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-pattern-9" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Pattern - Same variable <a href="#sparql-star-pattern-9">🔗</a></h2>
+</section><section id="rs:sparql-star-pattern-9" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Pattern - Same variable <a href="trs:sparql-star-pattern-9">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1095,8 +1095,8 @@ PREFIX :       &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-construct-1" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - CONSTRUCT with constant template <a href="#sparql-star-construct-1">🔗</a></h2>
+</section><section id="rs:sparql-star-construct-1" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - CONSTRUCT with constant template <a href="trs:sparql-star-construct-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1123,8 +1123,8 @@ PREFIX :      &lt;http://example/&gt;
 
 &lt;&lt; :a :b :c &gt;&gt;  :q  :z .
 </pre>
-</section><section id="sparql-star-construct-2" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - CONSTRUCT WHERE with constant template <a href="#sparql-star-construct-2">🔗</a></h2>
+</section><section id="rs:sparql-star-construct-2" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - CONSTRUCT WHERE with constant template <a href="trs:sparql-star-construct-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1151,8 +1151,8 @@ PREFIX :      &lt;http://example/&gt;
 
 &lt;&lt; :a :b :c &gt;&gt;  :q  :z .
 </pre>
-</section><section id="sparql-star-construct-3" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - CONSTRUCT - about every triple <a href="#sparql-star-construct-3">🔗</a></h2>
+</section><section id="rs:sparql-star-construct-3" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - CONSTRUCT - about every triple <a href="trs:sparql-star-construct-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1186,8 +1186,8 @@ PREFIX :      &lt;http://example/&gt;
 
 &lt;&lt; :s :p :o &gt;&gt;  :source  :ABC .
 </pre>
-</section><section id="sparql-star-construct-4" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - CONSTRUCT with annotation syntax <a href="#sparql-star-construct-4">🔗</a></h2>
+</section><section id="rs:sparql-star-construct-4" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - CONSTRUCT with annotation syntax <a href="trs:sparql-star-construct-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1218,8 +1218,8 @@ PREFIX :      &lt;http://example/&gt;
 
 &lt;&lt; :a :b :c &gt;&gt;  :source  :ABC .
 </pre>
-</section><section id="sparql-star-construct-5" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - CONSTRUCT WHERE with annotation syntax <a href="#sparql-star-construct-5">🔗</a></h2>
+</section><section id="rs:sparql-star-construct-5" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - CONSTRUCT WHERE with annotation syntax <a href="trs:sparql-star-construct-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1248,8 +1248,8 @@ PREFIX :      &lt;http://example/&gt;
 
 &lt;&lt; :a :b :c &gt;&gt;  :q  :z .
 </pre>
-</section><section id="sparql-star-graphs-1" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - GRAPH <a href="#sparql-star-graphs-1">🔗</a></h2>
+</section><section id="rs:sparql-star-graphs-1" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - GRAPH <a href="trs:sparql-star-graphs-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1297,8 +1297,8 @@ GRAPH :g2 { &lt;&lt; _:b :r :o3 &gt;&gt; :pb "abc" . }
   }
 }
 </pre>
-</section><section id="sparql-star-graphs-2" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - GRAPHs with blank node <a href="#sparql-star-graphs-2">🔗</a></h2>
+</section><section id="rs:sparql-star-graphs-2" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - GRAPHs with blank node <a href="trs:sparql-star-graphs-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1349,8 +1349,8 @@ GRAPH :g2 { &lt;&lt; _:b :r :o3 &gt;&gt; :pb "abc" . }
   }
 }
 </pre>
-</section><section id="sparql-star-expr-1" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Embedded triple - BIND - CONSTRUCT <a href="#sparql-star-expr-1">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-1" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Embedded triple - BIND - CONSTRUCT <a href="trs:sparql-star-expr-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1402,8 +1402,8 @@ PREFIX :      &lt;http://example/&gt;
 &lt;&lt; &lt;&lt; _:b0 :r :o3 &gt;&gt; :pb "abc" &gt;&gt;
         :graph  :g2 .
 </pre>
-</section><section id="sparql-star-expr-2" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Embedded triple - Functions <a href="#sparql-star-expr-2">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-2" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Embedded triple - Functions <a href="trs:sparql-star-expr-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1449,8 +1449,8 @@ SELECT * {
   }
 }
 </pre>
-</section><section id="sparql-star-order-1" class="entry proposed QueryEvaluationTest">
-<h2>SPARQL-star - Embedded triple ORDER BY <a href="#sparql-star-order-1">🔗</a></h2>
+</section><section id="rs:sparql-star-order-1" class="entry proposed QueryEvaluationTest">
+<h2>SPARQL-star - Embedded triple ORDER BY <a href="trs:sparql-star-order-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>QueryEvaluationTest</td>
@@ -1515,8 +1515,8 @@ PREFIX : &lt;http://example/&gt;
   }
 }
 </pre>
-</section><section id="sparql-star-update-1" class="entry proposed UpdateEvaluationTest">
-<h2>SPARQL-star - Update <a href="#sparql-star-update-1">🔗</a></h2>
+</section><section id="rs:sparql-star-update-1" class="entry proposed UpdateEvaluationTest">
+<h2>SPARQL-star - Update <a href="trs:sparql-star-update-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>UpdateEvaluationTest</td>
@@ -1549,8 +1549,8 @@ GRAPH :g2 { :s2 :p2 :o2 }
 &lt;&lt; :s2 :p2 :o2 &gt;&gt; :source :g2 .
 &lt;&lt; :s1 :p1 :o1 &gt;&gt; :source :g1 .
 </pre>
-</section><section id="sparql-star-update-2" class="entry proposed UpdateEvaluationTest">
-<h2>SPARQL-star - Update - annotation <a href="#sparql-star-update-2">🔗</a></h2>
+</section><section id="rs:sparql-star-update-2" class="entry proposed UpdateEvaluationTest">
+<h2>SPARQL-star - Update - annotation <a href="trs:sparql-star-update-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>UpdateEvaluationTest</td>
@@ -1582,8 +1582,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt; :s1 :p1 :o1 &gt;&gt; :source :g1 .
 &lt;&lt; :s2 :p2 :o2 &gt;&gt; :source :g2.
 </pre>
-</section><section id="sparql-star-update-3" class="entry proposed UpdateEvaluationTest">
-<h2>SPARQL-star - Update - data <a href="#sparql-star-update-3">🔗</a></h2>
+</section><section id="rs:sparql-star-update-3" class="entry proposed UpdateEvaluationTest">
+<h2>SPARQL-star - Update - data <a href="trs:sparql-star-update-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>UpdateEvaluationTest</td>

--- a/tests/sparql/eval/manifest.jsonld
+++ b/tests/sparql/eval/manifest.jsonld
@@ -8,7 +8,9 @@
     "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
     "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
     "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/sparql/eval#",
     "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/sparql/eval/",
     "include": {
       "@type": "@id",
       "@container": "@list"
@@ -62,14 +64,14 @@
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
-    "@base": "https://w3c.github.io/rdf-star/tests/sparql/eval/manifest"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
   },
-  "@id": "manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
+  "label": "SPARQL-star Evaluation Tests",
   "entries": [
     {
-      "@id": "#sparql-star-results-1j",
+      "@id": "trs:sparql-star-results-1j",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - all graph triples (JSON results)",
       "action": {
@@ -79,7 +81,7 @@
       "result": "sparql-star-results-1.srj"
     },
     {
-      "@id": "#sparql-star-results-1x",
+      "@id": "trs:sparql-star-results-1x",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - all graph triples (XML results)",
       "action": {
@@ -89,7 +91,7 @@
       "result": "sparql-star-results-1.srx"
     },
     {
-      "@id": "#sparql-star-basic-2",
+      "@id": "trs:sparql-star-basic-2",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - match constant embedded triple",
       "action": {
@@ -99,7 +101,7 @@
       "result": "sparql-star-basic-2.srj"
     },
     {
-      "@id": "#sparql-star-basic-3",
+      "@id": "trs:sparql-star-basic-3",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - match embedded triple, var subject",
       "action": {
@@ -109,7 +111,7 @@
       "result": "sparql-star-basic-3.srj"
     },
     {
-      "@id": "#sparql-star-basic-4",
+      "@id": "trs:sparql-star-basic-4",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - match embedded triple, var predicate",
       "action": {
@@ -119,7 +121,7 @@
       "result": "sparql-star-basic-4.srj"
     },
     {
-      "@id": "#sparql-star-basic-5",
+      "@id": "trs:sparql-star-basic-5",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - match embedded triple, var object",
       "action": {
@@ -129,7 +131,7 @@
       "result": "sparql-star-basic-5.srj"
     },
     {
-      "@id": "#sparql-star-basic-6",
+      "@id": "trs:sparql-star-basic-6",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - no match of embedded triple",
       "action": {
@@ -139,7 +141,7 @@
       "result": "sparql-star-basic-6.srj"
     },
     {
-      "@id": "#sparql-star-pattern-1",
+      "@id": "trs:sparql-star-pattern-1",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Asserted and embedded triple",
       "action": {
@@ -149,7 +151,7 @@
       "result": "sparql-star-pattern-01.srj"
     },
     {
-      "@id": "#sparql-star-pattern-2",
+      "@id": "trs:sparql-star-pattern-2",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star -  Asserted and embedded triple",
       "action": {
@@ -159,7 +161,7 @@
       "result": "sparql-star-pattern-02.srj"
     },
     {
-      "@id": "#sparql-star-pattern-3",
+      "@id": "trs:sparql-star-pattern-3",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Pattern - Variable for embedded triple",
       "action": {
@@ -169,7 +171,7 @@
       "result": "sparql-star-pattern-03.srj"
     },
     {
-      "@id": "#sparql-star-pattern-4",
+      "@id": "trs:sparql-star-pattern-4",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Pattern - No match",
       "action": {
@@ -179,7 +181,7 @@
       "result": "sparql-star-pattern-04.srj"
     },
     {
-      "@id": "#sparql-star-pattern-5",
+      "@id": "trs:sparql-star-pattern-5",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Pattern - match variables in triple terms",
       "action": {
@@ -189,7 +191,7 @@
       "result": "sparql-star-pattern-05.srj"
     },
     {
-      "@id": "#sparql-star-pattern-6",
+      "@id": "trs:sparql-star-pattern-6",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Pattern - Nesting 1",
       "action": {
@@ -199,7 +201,7 @@
       "result": "sparql-star-pattern-06.srj"
     },
     {
-      "@id": "#sparql-star-pattern-7",
+      "@id": "trs:sparql-star-pattern-7",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Pattern - Nesting - 2",
       "action": {
@@ -209,7 +211,7 @@
       "result": "sparql-star-pattern-07.srj"
     },
     {
-      "@id": "#sparql-star-pattern-8",
+      "@id": "trs:sparql-star-pattern-8",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Pattern - Match and nesting",
       "action": {
@@ -219,7 +221,7 @@
       "result": "sparql-star-pattern-08.srj"
     },
     {
-      "@id": "#sparql-star-pattern-9",
+      "@id": "trs:sparql-star-pattern-9",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Pattern - Same variable",
       "action": {
@@ -229,7 +231,7 @@
       "result": "sparql-star-pattern-09.srj"
     },
     {
-      "@id": "#sparql-star-construct-1",
+      "@id": "trs:sparql-star-construct-1",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - CONSTRUCT with constant template",
       "action": {
@@ -239,7 +241,7 @@
       "result": "sparql-star-construct-1.ttl"
     },
     {
-      "@id": "#sparql-star-construct-2",
+      "@id": "trs:sparql-star-construct-2",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - CONSTRUCT WHERE with constant template",
       "action": {
@@ -249,7 +251,7 @@
       "result": "sparql-star-construct-2.ttl"
     },
     {
-      "@id": "#sparql-star-construct-3",
+      "@id": "trs:sparql-star-construct-3",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - CONSTRUCT - about every triple",
       "action": {
@@ -259,7 +261,7 @@
       "result": "sparql-star-construct-3.ttl"
     },
     {
-      "@id": "#sparql-star-construct-4",
+      "@id": "trs:sparql-star-construct-4",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - CONSTRUCT with annotation syntax",
       "action": {
@@ -269,7 +271,7 @@
       "result": "sparql-star-construct-4.ttl"
     },
     {
-      "@id": "#sparql-star-construct-5",
+      "@id": "trs:sparql-star-construct-5",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
       "action": {
@@ -279,7 +281,7 @@
       "result": "sparql-star-construct-5.ttl"
     },
     {
-      "@id": "#sparql-star-graphs-1",
+      "@id": "trs:sparql-star-graphs-1",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - GRAPH",
       "action": {
@@ -289,7 +291,7 @@
       "result": "sparql-star-graphs-1.srj"
     },
     {
-      "@id": "#sparql-star-graphs-2",
+      "@id": "trs:sparql-star-graphs-2",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - GRAPHs with blank node",
       "action": {
@@ -299,7 +301,7 @@
       "result": "sparql-star-graphs-2.srj"
     },
     {
-      "@id": "#sparql-star-expr-1",
+      "@id": "trs:sparql-star-expr-1",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
       "action": {
@@ -309,7 +311,7 @@
       "result": "sparql-star-expr-01.ttl"
     },
     {
-      "@id": "#sparql-star-expr-2",
+      "@id": "trs:sparql-star-expr-2",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Embedded triple - Functions",
       "action": {
@@ -319,7 +321,7 @@
       "result": "sparql-star-expr-02.srj"
     },
     {
-      "@id": "#sparql-star-order-1",
+      "@id": "trs:sparql-star-order-1",
       "@type": "QueryEvaluationTest",
       "name": "SPARQL-star - Embedded triple ORDER BY",
       "action": {
@@ -329,7 +331,7 @@
       "result": "sparql-star-order-1.srj"
     },
     {
-      "@id": "#sparql-star-update-1",
+      "@id": "trs:sparql-star-update-1",
       "@type": "UpdateEvaluationTest",
       "name": "SPARQL-star - Update",
       "action": {
@@ -341,7 +343,7 @@
       }
     },
     {
-      "@id": "#sparql-star-update-2",
+      "@id": "trs:sparql-star-update-2",
       "@type": "UpdateEvaluationTest",
       "name": "SPARQL-star - Update - annotation",
       "action": {
@@ -353,7 +355,7 @@
       }
     },
     {
-      "@id": "#sparql-star-update-3",
+      "@id": "trs:sparql-star-update-3",
       "@type": "UpdateEvaluationTest",
       "name": "SPARQL-star - Update - data",
       "action": {
@@ -364,6 +366,5 @@
         "ut:data": "update-result-3.trig"
       }
     }
-  ],
-  "label": "SPARQL-star Evaluation Tests"
+  ]
 }

--- a/tests/sparql/eval/manifest.ttl
+++ b/tests/sparql/eval/manifest.ttl
@@ -3,59 +3,58 @@
 ## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 ## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
 
-BASE           <https://w3c.github.io/rdf-star/tests/sparql/eval/manifest>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>
 PREFIX ut:     <http://www.w3.org/2009/sparql/tests/test-update#>
 PREFIX dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/sparql/eval#>
 
-PREFIX :       <#>
-
-<>  rdf:type mf:Manifest ;
+trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "SPARQL-star Evaluation Tests" ;
     mf:entries
     (
-        :sparql-star-results-1j
-        :sparql-star-results-1x
+        trs:sparql-star-results-1j
+        trs:sparql-star-results-1x
         
-        :sparql-star-basic-2
-        :sparql-star-basic-3
-        :sparql-star-basic-4
-        :sparql-star-basic-5
-        :sparql-star-basic-6
+        trs:sparql-star-basic-2
+        trs:sparql-star-basic-3
+        trs:sparql-star-basic-4
+        trs:sparql-star-basic-5
+        trs:sparql-star-basic-6
 
-        :sparql-star-pattern-1
-        :sparql-star-pattern-2
-        :sparql-star-pattern-3
-        :sparql-star-pattern-4
-        :sparql-star-pattern-5
-        :sparql-star-pattern-6
-        :sparql-star-pattern-7
-        :sparql-star-pattern-8
-        :sparql-star-pattern-9
+        trs:sparql-star-pattern-1
+        trs:sparql-star-pattern-2
+        trs:sparql-star-pattern-3
+        trs:sparql-star-pattern-4
+        trs:sparql-star-pattern-5
+        trs:sparql-star-pattern-6
+        trs:sparql-star-pattern-7
+        trs:sparql-star-pattern-8
+        trs:sparql-star-pattern-9
 
-        :sparql-star-construct-1
-        :sparql-star-construct-2
-        :sparql-star-construct-3
-        :sparql-star-construct-4
-        :sparql-star-construct-5
+        trs:sparql-star-construct-1
+        trs:sparql-star-construct-2
+        trs:sparql-star-construct-3
+        trs:sparql-star-construct-4
+        trs:sparql-star-construct-5
 
-        :sparql-star-graphs-1
-        :sparql-star-graphs-2
+        trs:sparql-star-graphs-1
+        trs:sparql-star-graphs-2
 
-        :sparql-star-expr-1
-        :sparql-star-expr-2
+        trs:sparql-star-expr-1
+        trs:sparql-star-expr-2
 
-        :sparql-star-order-1
+        trs:sparql-star-order-1
 
-        :sparql-star-update-1
-        :sparql-star-update-2
-        :sparql-star-update-3
+        trs:sparql-star-update-1
+        trs:sparql-star-update-2
+        trs:sparql-star-update-3
 ) .
 
-:sparql-star-results-1j rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-results-1j rdf:type mf:QueryEvaluationTest ;
     mf:name      "SPARQL-star - all graph triples (JSON results)" ;
     mf:action [
        qt:query  <sparql-star-results-1.rq> ;
@@ -64,7 +63,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-results-1.srj>
     .
 
-:sparql-star-results-1x rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-results-1x rdf:type mf:QueryEvaluationTest ;
     mf:name      "SPARQL-star - all graph triples (XML results)" ;
     mf:action [
        qt:query  <sparql-star-results-1.rq> ;
@@ -73,7 +72,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-results-1.srx>
     .
 
-:sparql-star-basic-2 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-basic-2 rdf:type mf:QueryEvaluationTest ;
     mf:name      "SPARQL-star - match constant embedded triple" ;
     mf:action [
        qt:query  <sparql-star-basic-2.rq> ;
@@ -82,7 +81,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-basic-2.srj>
     .
 
-:sparql-star-basic-3 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-basic-3 rdf:type mf:QueryEvaluationTest ;
     mf:name      "SPARQL-star - match embedded triple, var subject" ;
     mf:action [
        qt:query  <sparql-star-basic-3.rq> ;
@@ -91,7 +90,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-basic-3.srj>
     .
 
-:sparql-star-basic-4 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-basic-4 rdf:type mf:QueryEvaluationTest ;
     mf:name      "SPARQL-star - match embedded triple, var predicate" ;
     mf:action [
        qt:query  <sparql-star-basic-4.rq> ;
@@ -100,7 +99,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-basic-4.srj>
     .
 
-:sparql-star-basic-5 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-basic-5 rdf:type mf:QueryEvaluationTest ;
     mf:name      "SPARQL-star - match embedded triple, var object" ;
     mf:action [
        qt:query  <sparql-star-basic-5.rq> ;
@@ -109,7 +108,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-basic-5.srj>
     .
 
-:sparql-star-basic-6 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-basic-6 rdf:type mf:QueryEvaluationTest ;
     mf:name      "SPARQL-star - no match of embedded triple" ;
     mf:action [
        qt:query  <sparql-star-basic-6.rq> ;
@@ -118,7 +117,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-basic-6.srj>
     .
 
-:sparql-star-pattern-1 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-1 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Asserted and embedded triple" ;
     mf:action
         [ qt:query  <sparql-star-pattern-01.rq> ;
@@ -126,7 +125,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-01.srj>
     .
 
-:sparql-star-pattern-2 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-2 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star -  Asserted and embedded triple" ;
     mf:action
         [ qt:query  <sparql-star-pattern-02.rq> ;
@@ -134,7 +133,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-02.srj>
     .
 
-:sparql-star-pattern-3 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-3 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Pattern - Variable for embedded triple" ;
     mf:action
         [ qt:query  <sparql-star-pattern-03.rq> ;
@@ -142,7 +141,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-03.srj>
     .
 
-:sparql-star-pattern-4 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-4 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Pattern - No match" ;
     mf:action
         [ qt:query  <sparql-star-pattern-04.rq> ;
@@ -150,7 +149,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-04.srj>
     .
 
-:sparql-star-pattern-5 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-5 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Pattern - match variables in triple terms" ;
     mf:action
         [ qt:query  <sparql-star-pattern-05.rq> ;
@@ -158,7 +157,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-05.srj>
     .
 
-:sparql-star-pattern-6 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-6 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Pattern - Nesting 1" ;
     mf:action
         [ qt:query  <sparql-star-pattern-06.rq> ;
@@ -166,7 +165,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-06.srj>
     .
 
-:sparql-star-pattern-7 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-7 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Pattern - Nesting - 2" ;
     mf:action
         [ qt:query  <sparql-star-pattern-07.rq> ;
@@ -174,7 +173,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-07.srj>
     .
 
-:sparql-star-pattern-8 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-8 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Pattern - Match and nesting" ;
     mf:action
         [ qt:query  <sparql-star-pattern-08.rq> ;
@@ -182,7 +181,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-pattern-08.srj>
     .
 
-:sparql-star-pattern-9 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-pattern-9 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Pattern - Same variable" ;
     mf:action
         [ qt:query  <sparql-star-pattern-09.rq> ;
@@ -192,7 +191,7 @@ PREFIX :       <#>
 
 ## CONSTRUCT
 
-:sparql-star-construct-1 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-construct-1 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - CONSTRUCT with constant template" ;
     mf:action
         [ qt:query  <sparql-star-construct-1.rq> ;
@@ -200,7 +199,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-construct-1.ttl> ;
 .
 
-:sparql-star-construct-2 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-construct-2 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - CONSTRUCT WHERE with constant template" ;
     mf:action
         [ qt:query  <sparql-star-construct-2.rq> ;
@@ -208,7 +207,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-construct-2.ttl> ;
 .
 
-:sparql-star-construct-3 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-construct-3 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - CONSTRUCT - about every triple" ;
     mf:action
         [ qt:query  <sparql-star-construct-3.rq> ;
@@ -216,7 +215,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-construct-3.ttl> ;
 .
 
-:sparql-star-construct-4 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-construct-4 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - CONSTRUCT with annotation syntax" ;
     mf:action
         [ qt:query  <sparql-star-construct-4.rq> ;
@@ -224,7 +223,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-construct-4.ttl> ;
 .
 
-:sparql-star-construct-5 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-construct-5 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - CONSTRUCT WHERE with annotation syntax" ;
     mf:action
         [ qt:query  <sparql-star-construct-5.rq> ;
@@ -232,7 +231,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-construct-5.ttl> ;
     .
 
-:sparql-star-graphs-1 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-graphs-1 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - GRAPH" ;
     mf:action
         [ qt:query  <sparql-star-graphs-1.rq> ;
@@ -240,7 +239,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-graphs-1.srj> ;
     .
 
-:sparql-star-graphs-2 rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-graphs-2 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - GRAPHs with blank node" ;
     mf:action
         [ qt:query  <sparql-star-graphs-2.rq> ;
@@ -250,7 +249,7 @@ PREFIX :       <#>
 
 ## Expressions
 
-:sparql-star-expr-1  rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-expr-1  rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Embedded triple - BIND - CONSTRUCT" ;
     mf:action
         [ qt:query  <sparql-star-expr-01.rq> ;
@@ -258,7 +257,7 @@ PREFIX :       <#>
     mf:result  <sparql-star-expr-01.ttl> ;
     .
 
-:sparql-star-expr-2  rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-expr-2  rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Embedded triple - Functions" ;
     mf:action
         [ qt:query  <sparql-star-expr-02.rq> ;
@@ -268,7 +267,7 @@ PREFIX :       <#>
 
 ## ORDER BY
 
-:sparql-star-order-1  rdf:type mf:QueryEvaluationTest ;
+trs:sparql-star-order-1  rdf:type mf:QueryEvaluationTest ;
     mf:name    "SPARQL-star - Embedded triple ORDER BY" ;
     mf:action
         [ qt:query  <sparql-star-order-1.rq> ;
@@ -279,7 +278,7 @@ PREFIX :       <#>
 ## Update
 
 
-:sparql-star-update-1 rdf:type mf:UpdateEvaluationTest ;
+trs:sparql-star-update-1 rdf:type mf:UpdateEvaluationTest ;
     mf:name    "SPARQL-star - Update" ;
     mf:action [ ut:request <sparql-star-update-1.ru> ; 
                 ut:data <data-6.trig>
@@ -288,7 +287,7 @@ PREFIX :       <#>
               ] ;
     .
 
-:sparql-star-update-2 rdf:type mf:UpdateEvaluationTest ;
+trs:sparql-star-update-2 rdf:type mf:UpdateEvaluationTest ;
     mf:name    "SPARQL-star - Update - annotation" ;
     mf:action [ ut:request <sparql-star-update-2.ru> ; 
                 ut:data <data-6.trig>
@@ -297,7 +296,7 @@ PREFIX :       <#>
               ] ;
     .
 
-:sparql-star-update-3 rdf:type mf:UpdateEvaluationTest ;
+trs:sparql-star-update-3 rdf:type mf:UpdateEvaluationTest ;
     mf:name    "SPARQL-star - Update - data" ;
     mf:action [ ut:request <sparql-star-update-3.ru> ; 
                 ut:data <empty.nq>

--- a/tests/sparql/syntax/manifest.html
+++ b/tests/sparql/syntax/manifest.html
@@ -56,70 +56,70 @@
 <h1>manifest</h1>
 <p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
 <ul class="entries">
-<li class="proposed"><a href="#sparql-star-1">SPARQL-star - subject embedded triple</a>
-<li class="proposed"><a href="#sparql-star-2">SPARQL-star - object embedded triple</a>
-<li class="proposed"><a href="#sparql-star-3">SPARQL-star - subject embedded triple - vars</a>
-<li class="proposed"><a href="#sparql-star-4">SPARQL-star - object embedded triple - vars</a>
-<li class="proposed"><a href="#sparql-star-5">SPARQL-star - Embedded triple in VALUES</a>
-<li class="proposed"><a href="#sparql-star-6">SPARQL-star - Embedded triple in CONSTRUCT</a>
-<li class="proposed"><a href="#sparql-star-7">SPARQL-star - Embedded triples in CONSTRUCT WHERE</a>
-<li class="proposed"><a href="#sparql-star-inside-1">SPARQL-star - embedded triple inside blankNodePropertyList</a>
-<li class="proposed"><a href="#sparql-star-inside-2">SPARQL-star - embedded triple inside collection</a>
-<li class="proposed"><a href="#sparql-star-nested-1">SPARQL-star - nested embedded triple, subject position</a>
-<li class="proposed"><a href="#sparql-star-nested-2">SPARQL-star - nested embedded triple, object position</a>
-<li class="proposed"><a href="#sparql-star-compound-1">SPARQL-star - compound forms</a>
-<li class="proposed"><a href="#sparql-star-bnode-1">SPARQL-star - blank node subject</a>
-<li class="proposed"><a href="#sparql-star-bnode-2">SPARQL-star - blank node object</a>
-<li class="proposed"><a href="#sparql-star-bnode-3">SPARQL-star - blank node</a>
-<li class="proposed"><a href="#sparql-star-ann-01">SPARQL-star - Annotation form</a>
-<li class="proposed"><a href="#sparql-star-ann-02">SPARQL-star - Annotation example</a>
-<li class="proposed"><a href="#sparql-star-ann-03">SPARQL-star - Annotation example</a>
-<li class="proposed"><a href="#sparql-star-ann-04">SPARQL-star - Annotation with embedding</a>
-<li class="proposed"><a href="#sparql-star-ann-05">SPARQL-star - Annotation on triple with embedded object</a>
-<li class="proposed"><a href="#sparql-star-ann-06">SPARQL-star - Annotation with path</a>
-<li class="proposed"><a href="#sparql-star-ann-07">SPARQL-star - Annotation with nested path</a>
-<li class="proposed"><a href="#sparql-star-ann-08">SPARQL-star - Annotation in CONSTRUCT </a>
-<li class="proposed"><a href="#sparql-star-ann-09">SPARQL-star - Annotation in CONSTRUCT WHERE</a>
-<li class="proposed"><a href="#sparql-star-expr-1">SPARQL-star - Expressions - Embedded triple</a>
-<li class="proposed"><a href="#sparql-star-expr-2">SPARQL-star - Expressions - Embedded triple</a>
-<li class="proposed"><a href="#sparql-star-expr-3">SPARQL-star - Expressions - Functions</a>
-<li class="proposed"><a href="#sparql-star-expr-4">SPARQL-star - Expressions - TRIPLE</a>
-<li class="proposed"><a href="#sparql-star-expr-5">SPARQL-star - Expressions - Functions</a>
-<li class="proposed"><a href="#sparql-star-expr-6">SPARQL-star - Expressions - BIND - CONSTRUCT</a>
-<li class="proposed"><a href="#sparql-star-bad-1">SPARQL-star - bad - embedded triple as predicate</a>
-<li class="proposed"><a href="#sparql-star-bad-2">SPARQL-star - bad - embedded triple outside triple</a>
-<li class="proposed"><a href="#sparql-star-bad-3">SPARQL-star - bad - collection list in embedded triple</a>
-<li class="proposed"><a href="#sparql-star-bad-4">SPARQL-star - bad - literal in subject position of embedded triple</a>
-<li class="proposed"><a href="#sparql-star-bad-5">SPARQL-star - bad - blank node  as predicate in embedded triple</a>
-<li class="proposed"><a href="#sparql-star-bad-6">SPARQL-star - bad - compound blank node expression</a>
-<li class="proposed"><a href="#sparql-star-bad-7">SPARQL-star - bad - incomplete embedded triple</a>
-<li class="proposed"><a href="#sparql-star-bad-8">SPARQL-star - bad - quad embedded triple</a>
-<li class="proposed"><a href="#sparql-star-bad-9">SPARQL-star - bad - variable in embedded triple in VALUES </a>
-<li class="proposed"><a href="#sparql-star-bad-10">SPARQL-star - bad - blank node in embedded triple in VALUES </a>
-<li class="proposed"><a href="#sparql-star-bad-ann-1">SPARQL-star - bad - empty annotation</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-2">SPARQL-star - bad - triples in annotation</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-path-1">SPARQL-star - bad - path - seq</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-path-2">SPARQL-star - bad - path - alt</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-path-3">SPARQL-star - bad - path - p*</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-path-4">SPARQL-star - bad - path - p+</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-path-5">SPARQL-star - bad - path - p?</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-path-6">SPARQL-star - bad - path in CONSTRUCT</a>
-<li class="proposed"><a href="#sparql-star-bad-ann-path-7">SPARQL-star - bad - path in CONSTRUCT</a>
-<li class="proposed"><a href="#sparql-star-update-1">SPARQL-star - update</a>
-<li class="proposed"><a href="#sparql-star-update-2">SPARQL-star - update</a>
-<li class="proposed"><a href="#sparql-star-update-3">SPARQL-star - update</a>
-<li class="proposed"><a href="#sparql-star-update-4">SPARQL-star - update with embedding</a>
-<li class="proposed"><a href="#sparql-star-update-5">SPARQL-star - update with embedded object</a>
-<li class="proposed"><a href="#sparql-star-update-6">SPARQL-star - update with annotation template</a>
-<li class="proposed"><a href="#sparql-star-update-7">SPARQL-star - update with annotation, template and pattern</a>
-<li class="proposed"><a href="#sparql-star-update-8">SPARQL-star - update DATA with annotation</a>
-<li class="proposed"><a href="#sparql-star-bad-update-1">SPARQL-star - update - bad syntax</a>
-<li class="proposed"><a href="#sparql-star-bad-update-2">SPARQL-star - update - bad syntax</a>
-<li class="proposed"><a href="#sparql-star-bad-update-3">SPARQL-star - update - bad syntax</a>
-<li class="proposed"><a href="#sparql-star-bad-update-4">SPARQL-star - update - bad syntax</a>
+<li class="proposed"><a href="trs:sparql-star-1">SPARQL-star - subject embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-2">SPARQL-star - object embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-3">SPARQL-star - subject embedded triple - vars</a>
+<li class="proposed"><a href="trs:sparql-star-4">SPARQL-star - object embedded triple - vars</a>
+<li class="proposed"><a href="trs:sparql-star-5">SPARQL-star - Embedded triple in VALUES</a>
+<li class="proposed"><a href="trs:sparql-star-6">SPARQL-star - Embedded triple in CONSTRUCT</a>
+<li class="proposed"><a href="trs:sparql-star-7">SPARQL-star - Embedded triples in CONSTRUCT WHERE</a>
+<li class="proposed"><a href="trs:sparql-star-inside-1">SPARQL-star - embedded triple inside blankNodePropertyList</a>
+<li class="proposed"><a href="trs:sparql-star-inside-2">SPARQL-star - embedded triple inside collection</a>
+<li class="proposed"><a href="trs:sparql-star-nested-1">SPARQL-star - nested embedded triple, subject position</a>
+<li class="proposed"><a href="trs:sparql-star-nested-2">SPARQL-star - nested embedded triple, object position</a>
+<li class="proposed"><a href="trs:sparql-star-compound-1">SPARQL-star - compound forms</a>
+<li class="proposed"><a href="trs:sparql-star-bnode-1">SPARQL-star - blank node subject</a>
+<li class="proposed"><a href="trs:sparql-star-bnode-2">SPARQL-star - blank node object</a>
+<li class="proposed"><a href="trs:sparql-star-bnode-3">SPARQL-star - blank node</a>
+<li class="proposed"><a href="trs:sparql-star-ann-01">SPARQL-star - Annotation form</a>
+<li class="proposed"><a href="trs:sparql-star-ann-02">SPARQL-star - Annotation example</a>
+<li class="proposed"><a href="trs:sparql-star-ann-03">SPARQL-star - Annotation example</a>
+<li class="proposed"><a href="trs:sparql-star-ann-04">SPARQL-star - Annotation with embedding</a>
+<li class="proposed"><a href="trs:sparql-star-ann-05">SPARQL-star - Annotation on triple with embedded object</a>
+<li class="proposed"><a href="trs:sparql-star-ann-06">SPARQL-star - Annotation with path</a>
+<li class="proposed"><a href="trs:sparql-star-ann-07">SPARQL-star - Annotation with nested path</a>
+<li class="proposed"><a href="trs:sparql-star-ann-08">SPARQL-star - Annotation in CONSTRUCT </a>
+<li class="proposed"><a href="trs:sparql-star-ann-09">SPARQL-star - Annotation in CONSTRUCT WHERE</a>
+<li class="proposed"><a href="trs:sparql-star-expr-1">SPARQL-star - Expressions - Embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-expr-2">SPARQL-star - Expressions - Embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-expr-3">SPARQL-star - Expressions - Functions</a>
+<li class="proposed"><a href="trs:sparql-star-expr-4">SPARQL-star - Expressions - TRIPLE</a>
+<li class="proposed"><a href="trs:sparql-star-expr-5">SPARQL-star - Expressions - Functions</a>
+<li class="proposed"><a href="trs:sparql-star-expr-6">SPARQL-star - Expressions - BIND - CONSTRUCT</a>
+<li class="proposed"><a href="trs:sparql-star-bad-1">SPARQL-star - bad - embedded triple as predicate</a>
+<li class="proposed"><a href="trs:sparql-star-bad-2">SPARQL-star - bad - embedded triple outside triple</a>
+<li class="proposed"><a href="trs:sparql-star-bad-3">SPARQL-star - bad - collection list in embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-bad-4">SPARQL-star - bad - literal in subject position of embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-bad-5">SPARQL-star - bad - blank node  as predicate in embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-bad-6">SPARQL-star - bad - compound blank node expression</a>
+<li class="proposed"><a href="trs:sparql-star-bad-7">SPARQL-star - bad - incomplete embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-bad-8">SPARQL-star - bad - quad embedded triple</a>
+<li class="proposed"><a href="trs:sparql-star-bad-9">SPARQL-star - bad - variable in embedded triple in VALUES </a>
+<li class="proposed"><a href="trs:sparql-star-bad-10">SPARQL-star - bad - blank node in embedded triple in VALUES </a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-1">SPARQL-star - bad - empty annotation</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-2">SPARQL-star - bad - triples in annotation</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-path-1">SPARQL-star - bad - path - seq</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-path-2">SPARQL-star - bad - path - alt</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-path-3">SPARQL-star - bad - path - p*</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-path-4">SPARQL-star - bad - path - p+</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-path-5">SPARQL-star - bad - path - p?</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-path-6">SPARQL-star - bad - path in CONSTRUCT</a>
+<li class="proposed"><a href="trs:sparql-star-bad-ann-path-7">SPARQL-star - bad - path in CONSTRUCT</a>
+<li class="proposed"><a href="trs:sparql-star-update-1">SPARQL-star - update</a>
+<li class="proposed"><a href="trs:sparql-star-update-2">SPARQL-star - update</a>
+<li class="proposed"><a href="trs:sparql-star-update-3">SPARQL-star - update</a>
+<li class="proposed"><a href="trs:sparql-star-update-4">SPARQL-star - update with embedding</a>
+<li class="proposed"><a href="trs:sparql-star-update-5">SPARQL-star - update with embedded object</a>
+<li class="proposed"><a href="trs:sparql-star-update-6">SPARQL-star - update with annotation template</a>
+<li class="proposed"><a href="trs:sparql-star-update-7">SPARQL-star - update with annotation, template and pattern</a>
+<li class="proposed"><a href="trs:sparql-star-update-8">SPARQL-star - update DATA with annotation</a>
+<li class="proposed"><a href="trs:sparql-star-bad-update-1">SPARQL-star - update - bad syntax</a>
+<li class="proposed"><a href="trs:sparql-star-bad-update-2">SPARQL-star - update - bad syntax</a>
+<li class="proposed"><a href="trs:sparql-star-bad-update-3">SPARQL-star - update - bad syntax</a>
+<li class="proposed"><a href="trs:sparql-star-bad-update-4">SPARQL-star - update - bad syntax</a>
 </ul>
-<section id="sparql-star-1" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - subject embedded triple <a href="#sparql-star-1">🔗</a></h2>
+<section id="rs:sparql-star-1" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - subject embedded triple <a href="trs:sparql-star-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -133,8 +133,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-2" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - object embedded triple <a href="#sparql-star-2">🔗</a></h2>
+</section><section id="rs:sparql-star-2" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - object embedded triple <a href="trs:sparql-star-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -148,8 +148,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-3" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - subject embedded triple - vars <a href="#sparql-star-3">🔗</a></h2>
+</section><section id="rs:sparql-star-3" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - subject embedded triple - vars <a href="trs:sparql-star-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -163,8 +163,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-4" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - object embedded triple - vars <a href="#sparql-star-4">🔗</a></h2>
+</section><section id="rs:sparql-star-4" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - object embedded triple - vars <a href="trs:sparql-star-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -178,8 +178,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-5" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Embedded triple in VALUES <a href="#sparql-star-5">🔗</a></h2>
+</section><section id="rs:sparql-star-5" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Embedded triple in VALUES <a href="trs:sparql-star-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -198,8 +198,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-6" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Embedded triple in CONSTRUCT <a href="#sparql-star-6">🔗</a></h2>
+</section><section id="rs:sparql-star-6" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Embedded triple in CONSTRUCT <a href="trs:sparql-star-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -212,8 +212,8 @@ CONSTRUCT { &lt;&lt;:s :p :o &gt;&gt; :q :z }
 WHERE {}
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-7" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Embedded triples in CONSTRUCT WHERE <a href="#sparql-star-7">🔗</a></h2>
+</section><section id="rs:sparql-star-7" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Embedded triples in CONSTRUCT WHERE <a href="trs:sparql-star-7">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -228,8 +228,8 @@ CONSTRUCT WHERE {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-inside-1" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - embedded triple inside blankNodePropertyList <a href="#sparql-star-inside-1">🔗</a></h2>
+</section><section id="rs:sparql-star-inside-1" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - embedded triple inside blankNodePropertyList <a href="trs:sparql-star-inside-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -243,8 +243,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-inside-2" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - embedded triple inside collection <a href="#sparql-star-inside-2">🔗</a></h2>
+</section><section id="rs:sparql-star-inside-2" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - embedded triple inside collection <a href="trs:sparql-star-inside-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -258,8 +258,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-nested-1" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - nested embedded triple, subject position <a href="#sparql-star-nested-1">🔗</a></h2>
+</section><section id="rs:sparql-star-nested-1" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - nested embedded triple, subject position <a href="trs:sparql-star-nested-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -274,8 +274,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-nested-2" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - nested embedded triple, object position <a href="#sparql-star-nested-2">🔗</a></h2>
+</section><section id="rs:sparql-star-nested-2" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - nested embedded triple, object position <a href="trs:sparql-star-nested-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -290,8 +290,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-compound-1" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - compound forms <a href="#sparql-star-compound-1">🔗</a></h2>
+</section><section id="rs:sparql-star-compound-1" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - compound forms <a href="trs:sparql-star-compound-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -309,8 +309,8 @@ SELECT * {
   &lt;&lt; &lt;&lt;[] ?R :z &gt;&gt; :p &lt;&lt;:a :b [] &gt;&gt; &gt;&gt; .
 }</pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-bnode-1" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - blank node subject <a href="#sparql-star-bnode-1">🔗</a></h2>
+</section><section id="rs:sparql-star-bnode-1" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - blank node subject <a href="trs:sparql-star-bnode-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -324,8 +324,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-bnode-2" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - blank node object <a href="#sparql-star-bnode-2">🔗</a></h2>
+</section><section id="rs:sparql-star-bnode-2" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - blank node object <a href="trs:sparql-star-bnode-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -339,8 +339,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-bnode-3" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - blank node <a href="#sparql-star-bnode-3">🔗</a></h2>
+</section><section id="rs:sparql-star-bnode-3" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - blank node <a href="trs:sparql-star-bnode-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -354,8 +354,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-01" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation form <a href="#sparql-star-ann-01">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-01" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation form <a href="trs:sparql-star-ann-01">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -369,8 +369,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-02" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation example <a href="#sparql-star-ann-02">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-02" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation example <a href="trs:sparql-star-ann-02">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -390,8 +390,8 @@ SELECT * {
              |}
 }</pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-03" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation example <a href="#sparql-star-ann-03">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-03" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation example <a href="trs:sparql-star-ann-03">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -405,8 +405,8 @@ SELECT * {
    :s :p &lt;&lt;:a :b :c&gt;&gt; {| ?q ?z |}
 }</pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-04" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation with embedding <a href="#sparql-star-ann-04">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-04" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation with embedding <a href="trs:sparql-star-ann-04">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -420,8 +420,8 @@ SELECT * {
    :s :p &lt;&lt;:a :b :c&gt;&gt; {| ?q &lt;&lt;:s1 :p1 ?z&gt;&gt; |}
 }</pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-05" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation on triple with embedded object <a href="#sparql-star-ann-05">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-05" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation on triple with embedded object <a href="trs:sparql-star-ann-05">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -435,8 +435,8 @@ SELECT * {
    &lt;&lt;?s :p1 :o1&gt;&gt; ?p ?o {| :r ?Z |} .
 }</pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-06" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation with path <a href="#sparql-star-ann-06">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-06" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation with path <a href="trs:sparql-star-ann-06">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -450,8 +450,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-07" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation with nested path <a href="#sparql-star-ann-07">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-07" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation with nested path <a href="trs:sparql-star-ann-07">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -465,8 +465,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-08" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation in CONSTRUCT  <a href="#sparql-star-ann-08">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-08" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation in CONSTRUCT  <a href="trs:sparql-star-ann-08">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -481,8 +481,8 @@ CONSTRUCT {
 WHERE { GRAPH ?g { ?s ?p ?o } }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-ann-09" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Annotation in CONSTRUCT WHERE <a href="#sparql-star-ann-09">🔗</a></h2>
+</section><section id="rs:sparql-star-ann-09" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Annotation in CONSTRUCT WHERE <a href="trs:sparql-star-ann-09">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -496,8 +496,8 @@ CONSTRUCT WHERE {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-expr-1" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Expressions - Embedded triple <a href="#sparql-star-expr-1">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-1" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Expressions - Embedded triple <a href="trs:sparql-star-expr-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -512,8 +512,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-expr-2" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Expressions - Embedded triple <a href="#sparql-star-expr-2">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-2" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Expressions - Embedded triple <a href="trs:sparql-star-expr-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -528,8 +528,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-expr-3" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Expressions - Functions <a href="#sparql-star-expr-3">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-3" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Expressions - Functions <a href="trs:sparql-star-expr-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -544,8 +544,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-expr-4" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Expressions - TRIPLE <a href="#sparql-star-expr-4">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-4" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Expressions - TRIPLE <a href="trs:sparql-star-expr-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -560,8 +560,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-expr-5" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Expressions - Functions <a href="#sparql-star-expr-5">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-5" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Expressions - Functions <a href="trs:sparql-star-expr-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -579,8 +579,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-expr-6" class="entry proposed PositiveSyntaxTest11">
-<h2>SPARQL-star - Expressions - BIND - CONSTRUCT <a href="#sparql-star-expr-6">🔗</a></h2>
+</section><section id="rs:sparql-star-expr-6" class="entry proposed PositiveSyntaxTest11">
+<h2>SPARQL-star - Expressions - BIND - CONSTRUCT <a href="trs:sparql-star-expr-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveSyntaxTest11</td>
@@ -599,8 +599,8 @@ CONSTRUCT {
 }
 </pre>
 <div>MUST be accepted</div>
-</section><section id="sparql-star-bad-1" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - embedded triple as predicate <a href="#sparql-star-bad-1">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-1" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - embedded triple as predicate <a href="trs:sparql-star-bad-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -614,8 +614,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-2" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - embedded triple outside triple <a href="#sparql-star-bad-2">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-2" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - embedded triple outside triple <a href="trs:sparql-star-bad-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -629,8 +629,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-3" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - collection list in embedded triple <a href="#sparql-star-bad-3">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-3" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - collection list in embedded triple <a href="trs:sparql-star-bad-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -643,8 +643,8 @@ SELECT * {
    &lt;&lt;?s :p ("abc") &gt;&gt; :q 123 .
 }</pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-4" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - literal in subject position of embedded triple <a href="#sparql-star-bad-4">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-4" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - literal in subject position of embedded triple <a href="trs:sparql-star-bad-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -658,8 +658,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-5" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - blank node  as predicate in embedded triple <a href="#sparql-star-bad-5">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-5" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - blank node  as predicate in embedded triple <a href="trs:sparql-star-bad-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -672,8 +672,8 @@ SELECT * {
   &lt;&lt;:s [] :o&gt;&gt; :q 123 .
 }</pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-6" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - compound blank node expression <a href="#sparql-star-bad-6">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-6" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - compound blank node expression <a href="trs:sparql-star-bad-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -687,8 +687,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-7" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - incomplete embedded triple <a href="#sparql-star-bad-7">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-7" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - incomplete embedded triple <a href="trs:sparql-star-bad-7">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -702,8 +702,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-8" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - quad embedded triple <a href="#sparql-star-bad-8">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-8" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - quad embedded triple <a href="trs:sparql-star-bad-8">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -717,8 +717,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-9" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - variable in embedded triple in VALUES  <a href="#sparql-star-bad-9">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-9" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - variable in embedded triple in VALUES  <a href="trs:sparql-star-bad-9">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -732,8 +732,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-10" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - blank node in embedded triple in VALUES  <a href="#sparql-star-bad-10">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-10" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - blank node in embedded triple in VALUES  <a href="trs:sparql-star-bad-10">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -747,8 +747,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-1" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - empty annotation <a href="#sparql-star-bad-ann-1">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-1" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - empty annotation <a href="trs:sparql-star-bad-ann-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -763,8 +763,8 @@ SELECT * {
 
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-2" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - triples in annotation <a href="#sparql-star-bad-ann-2">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-2" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - triples in annotation <a href="trs:sparql-star-bad-ann-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -779,8 +779,8 @@ SELECT * {
 
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-path-1" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - path - seq <a href="#sparql-star-bad-ann-path-1">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-path-1" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - path - seq <a href="trs:sparql-star-bad-ann-path-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -794,8 +794,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-path-2" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - path - alt <a href="#sparql-star-bad-ann-path-2">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-path-2" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - path - alt <a href="trs:sparql-star-bad-ann-path-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -809,8 +809,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-path-3" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - path - p* <a href="#sparql-star-bad-ann-path-3">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-path-3" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - path - p* <a href="trs:sparql-star-bad-ann-path-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -824,8 +824,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-path-4" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - path - p+ <a href="#sparql-star-bad-ann-path-4">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-path-4" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - path - p+ <a href="trs:sparql-star-bad-ann-path-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -839,8 +839,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-path-5" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - path - p? <a href="#sparql-star-bad-ann-path-5">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-path-5" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - path - p? <a href="trs:sparql-star-bad-ann-path-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -854,8 +854,8 @@ SELECT * {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-path-6" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - path in CONSTRUCT <a href="#sparql-star-bad-ann-path-6">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-path-6" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - path in CONSTRUCT <a href="trs:sparql-star-bad-ann-path-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -871,8 +871,8 @@ CONSTRUCT {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-bad-ann-path-7" class="entry proposed NegativeSyntaxTest11">
-<h2>SPARQL-star - bad - path in CONSTRUCT <a href="#sparql-star-bad-ann-path-7">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-ann-path-7" class="entry proposed NegativeSyntaxTest11">
+<h2>SPARQL-star - bad - path in CONSTRUCT <a href="trs:sparql-star-bad-ann-path-7">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeSyntaxTest11</td>
@@ -886,8 +886,8 @@ CONSTRUCT WHERE {
 }
 </pre>
 <div>MUST be rejected</div>
-</section><section id="sparql-star-update-1" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update <a href="#sparql-star-update-1">🔗</a></h2>
+</section><section id="rs:sparql-star-update-1" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update <a href="trs:sparql-star-update-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -901,8 +901,8 @@ INSERT DATA {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-update-2" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update <a href="#sparql-star-update-2">🔗</a></h2>
+</section><section id="rs:sparql-star-update-2" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update <a href="trs:sparql-star-update-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -916,8 +916,8 @@ INSERT DATA {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-update-3" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update <a href="#sparql-star-update-3">🔗</a></h2>
+</section><section id="rs:sparql-star-update-3" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update <a href="trs:sparql-star-update-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -934,8 +934,8 @@ INSERT {
 
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-update-4" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update with embedding <a href="#sparql-star-update-4">🔗</a></h2>
+</section><section id="rs:sparql-star-update-4" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update with embedding <a href="trs:sparql-star-update-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -952,8 +952,8 @@ INSERT {
 
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-update-5" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update with embedded object <a href="#sparql-star-update-5">🔗</a></h2>
+</section><section id="rs:sparql-star-update-5" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update with embedded object <a href="trs:sparql-star-update-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -969,8 +969,8 @@ INSERT {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-update-6" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update with annotation template <a href="#sparql-star-update-6">🔗</a></h2>
+</section><section id="rs:sparql-star-update-6" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update with annotation template <a href="trs:sparql-star-update-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -986,8 +986,8 @@ INSERT {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-update-7" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update with annotation, template and pattern <a href="#sparql-star-update-7">🔗</a></h2>
+</section><section id="rs:sparql-star-update-7" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update with annotation, template and pattern <a href="trs:sparql-star-update-7">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -1003,8 +1003,8 @@ DELETE {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-update-8" class="entry proposed PositiveUpdateSyntaxTest11">
-<h2>SPARQL-star - update DATA with annotation <a href="#sparql-star-update-8">🔗</a></h2>
+</section><section id="rs:sparql-star-update-8" class="entry proposed PositiveUpdateSyntaxTest11">
+<h2>SPARQL-star - update DATA with annotation <a href="trs:sparql-star-update-8">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>PositiveUpdateSyntaxTest11</td>
@@ -1024,8 +1024,8 @@ INSERT DATA  {
 
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-bad-update-1" class="entry proposed NegativeUpdateSyntaxTest11">
-<h2>SPARQL-star - update - bad syntax <a href="#sparql-star-bad-update-1">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-update-1" class="entry proposed NegativeUpdateSyntaxTest11">
+<h2>SPARQL-star - update - bad syntax <a href="trs:sparql-star-bad-update-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeUpdateSyntaxTest11</td>
@@ -1039,8 +1039,8 @@ INSERT DATA {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-bad-update-2" class="entry proposed NegativeUpdateSyntaxTest11">
-<h2>SPARQL-star - update - bad syntax <a href="#sparql-star-bad-update-2">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-update-2" class="entry proposed NegativeUpdateSyntaxTest11">
+<h2>SPARQL-star - update - bad syntax <a href="trs:sparql-star-bad-update-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeUpdateSyntaxTest11</td>
@@ -1054,8 +1054,8 @@ INSERT DATA {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-bad-update-3" class="entry proposed NegativeUpdateSyntaxTest11">
-<h2>SPARQL-star - update - bad syntax <a href="#sparql-star-bad-update-3">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-update-3" class="entry proposed NegativeUpdateSyntaxTest11">
+<h2>SPARQL-star - update - bad syntax <a href="trs:sparql-star-bad-update-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeUpdateSyntaxTest11</td>
@@ -1069,8 +1069,8 @@ INSERT DATA {
 }
 </pre>
 <div>MUST result into</div>
-</section><section id="sparql-star-bad-update-4" class="entry proposed NegativeUpdateSyntaxTest11">
-<h2>SPARQL-star - update - bad syntax <a href="#sparql-star-bad-update-4">🔗</a></h2>
+</section><section id="rs:sparql-star-bad-update-4" class="entry proposed NegativeUpdateSyntaxTest11">
+<h2>SPARQL-star - update - bad syntax <a href="trs:sparql-star-bad-update-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>NegativeUpdateSyntaxTest11</td>

--- a/tests/sparql/syntax/manifest.jsonld
+++ b/tests/sparql/syntax/manifest.jsonld
@@ -8,7 +8,9 @@
     "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
     "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
     "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/sparql/syntax#",
     "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/sparql/syntax/",
     "include": {
       "@type": "@id",
       "@container": "@list"
@@ -62,378 +64,377 @@
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
-    "@base": "https://w3c.github.io/rdf-star/tests/sparql/syntax/manifest"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
   },
-  "@id": "manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
+  "label": "SPARQL-star Syntax Tests",
   "entries": [
     {
-      "@id": "#sparql-star-1",
+      "@id": "trs:sparql-star-1",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - subject embedded triple",
       "action": "sparql-star-syntax-basic-01.rq"
     },
     {
-      "@id": "#sparql-star-2",
+      "@id": "trs:sparql-star-2",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - object embedded triple",
       "action": "sparql-star-syntax-basic-02.rq"
     },
     {
-      "@id": "#sparql-star-3",
+      "@id": "trs:sparql-star-3",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - subject embedded triple - vars",
       "action": "sparql-star-syntax-basic-03.rq"
     },
     {
-      "@id": "#sparql-star-4",
+      "@id": "trs:sparql-star-4",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - object embedded triple - vars",
       "action": "sparql-star-syntax-basic-04.rq"
     },
     {
-      "@id": "#sparql-star-5",
+      "@id": "trs:sparql-star-5",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Embedded triple in VALUES",
       "action": "sparql-star-syntax-basic-05.rq"
     },
     {
-      "@id": "#sparql-star-6",
+      "@id": "trs:sparql-star-6",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Embedded triple in CONSTRUCT",
       "action": "sparql-star-syntax-basic-06.rq"
     },
     {
-      "@id": "#sparql-star-7",
+      "@id": "trs:sparql-star-7",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Embedded triples in CONSTRUCT WHERE",
       "action": "sparql-star-syntax-basic-07.rq"
     },
     {
-      "@id": "#sparql-star-inside-1",
+      "@id": "trs:sparql-star-inside-1",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - embedded triple inside blankNodePropertyList",
       "action": "sparql-star-syntax-inside-01.rq"
     },
     {
-      "@id": "#sparql-star-inside-2",
+      "@id": "trs:sparql-star-inside-2",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - embedded triple inside collection",
       "action": "sparql-star-syntax-inside-02.rq"
     },
     {
-      "@id": "#sparql-star-nested-1",
+      "@id": "trs:sparql-star-nested-1",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - nested embedded triple, subject position",
       "action": "sparql-star-syntax-nested-01.rq"
     },
     {
-      "@id": "#sparql-star-nested-2",
+      "@id": "trs:sparql-star-nested-2",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - nested embedded triple, object position",
       "action": "sparql-star-syntax-nested-02.rq"
     },
     {
-      "@id": "#sparql-star-compound-1",
+      "@id": "trs:sparql-star-compound-1",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - compound forms",
       "action": "sparql-star-syntax-compound.rq"
     },
     {
-      "@id": "#sparql-star-bnode-1",
+      "@id": "trs:sparql-star-bnode-1",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - blank node subject",
       "action": "sparql-star-syntax-bnode-01.rq"
     },
     {
-      "@id": "#sparql-star-bnode-2",
+      "@id": "trs:sparql-star-bnode-2",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - blank node object",
       "action": "sparql-star-syntax-bnode-02.rq"
     },
     {
-      "@id": "#sparql-star-bnode-3",
+      "@id": "trs:sparql-star-bnode-3",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - blank node",
       "action": "sparql-star-syntax-bnode-03.rq"
     },
     {
-      "@id": "#sparql-star-ann-01",
+      "@id": "trs:sparql-star-ann-01",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation form",
       "action": "sparql-star-annotation-01.rq"
     },
     {
-      "@id": "#sparql-star-ann-02",
+      "@id": "trs:sparql-star-ann-02",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation example",
       "action": "sparql-star-annotation-02.rq"
     },
     {
-      "@id": "#sparql-star-ann-03",
+      "@id": "trs:sparql-star-ann-03",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation example",
       "action": "sparql-star-annotation-03.rq"
     },
     {
-      "@id": "#sparql-star-ann-04",
+      "@id": "trs:sparql-star-ann-04",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation with embedding",
       "action": "sparql-star-annotation-04.rq"
     },
     {
-      "@id": "#sparql-star-ann-05",
+      "@id": "trs:sparql-star-ann-05",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation on triple with embedded object",
       "action": "sparql-star-annotation-05.rq"
     },
     {
-      "@id": "#sparql-star-ann-06",
+      "@id": "trs:sparql-star-ann-06",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation with path",
       "action": "sparql-star-annotation-06.rq"
     },
     {
-      "@id": "#sparql-star-ann-07",
+      "@id": "trs:sparql-star-ann-07",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation with nested path",
       "action": "sparql-star-annotation-07.rq"
     },
     {
-      "@id": "#sparql-star-ann-08",
+      "@id": "trs:sparql-star-ann-08",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation in CONSTRUCT ",
       "action": "sparql-star-annotation-08.rq"
     },
     {
-      "@id": "#sparql-star-ann-09",
+      "@id": "trs:sparql-star-ann-09",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Annotation in CONSTRUCT WHERE",
       "action": "sparql-star-annotation-09.rq"
     },
     {
-      "@id": "#sparql-star-expr-1",
+      "@id": "trs:sparql-star-expr-1",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Expressions - Embedded triple",
       "action": "sparql-star-syntax-expr-01.rq"
     },
     {
-      "@id": "#sparql-star-expr-2",
+      "@id": "trs:sparql-star-expr-2",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Expressions - Embedded triple",
       "action": "sparql-star-syntax-expr-02.rq"
     },
     {
-      "@id": "#sparql-star-expr-3",
+      "@id": "trs:sparql-star-expr-3",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Expressions - Functions",
       "action": "sparql-star-syntax-expr-03.rq"
     },
     {
-      "@id": "#sparql-star-expr-4",
+      "@id": "trs:sparql-star-expr-4",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Expressions - TRIPLE",
       "action": "sparql-star-syntax-expr-04.rq"
     },
     {
-      "@id": "#sparql-star-expr-5",
+      "@id": "trs:sparql-star-expr-5",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Expressions - Functions",
       "action": "sparql-star-syntax-expr-05.rq"
     },
     {
-      "@id": "#sparql-star-expr-6",
+      "@id": "trs:sparql-star-expr-6",
       "@type": "PositiveSyntaxTest11",
       "name": "SPARQL-star - Expressions - BIND - CONSTRUCT",
       "action": "sparql-star-syntax-expr-06.rq"
     },
     {
-      "@id": "#sparql-star-bad-1",
+      "@id": "trs:sparql-star-bad-1",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - embedded triple as predicate",
       "action": "sparql-star-syntax-bad-01.rq"
     },
     {
-      "@id": "#sparql-star-bad-2",
+      "@id": "trs:sparql-star-bad-2",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - embedded triple outside triple",
       "action": "sparql-star-syntax-bad-02.rq"
     },
     {
-      "@id": "#sparql-star-bad-3",
+      "@id": "trs:sparql-star-bad-3",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - collection list in embedded triple",
       "action": "sparql-star-syntax-bad-03.rq"
     },
     {
-      "@id": "#sparql-star-bad-4",
+      "@id": "trs:sparql-star-bad-4",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - literal in subject position of embedded triple",
       "action": "sparql-star-syntax-bad-04.rq"
     },
     {
-      "@id": "#sparql-star-bad-5",
+      "@id": "trs:sparql-star-bad-5",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - blank node  as predicate in embedded triple",
       "action": "sparql-star-syntax-bad-05.rq"
     },
     {
-      "@id": "#sparql-star-bad-6",
+      "@id": "trs:sparql-star-bad-6",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - compound blank node expression",
       "action": "sparql-star-syntax-bad-06.rq"
     },
     {
-      "@id": "#sparql-star-bad-7",
+      "@id": "trs:sparql-star-bad-7",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - incomplete embedded triple",
       "action": "sparql-star-syntax-bad-07.rq"
     },
     {
-      "@id": "#sparql-star-bad-8",
+      "@id": "trs:sparql-star-bad-8",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - quad embedded triple",
       "action": "sparql-star-syntax-bad-08.rq"
     },
     {
-      "@id": "#sparql-star-bad-9",
+      "@id": "trs:sparql-star-bad-9",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - variable in embedded triple in VALUES ",
       "action": "sparql-star-syntax-bad-09.rq"
     },
     {
-      "@id": "#sparql-star-bad-10",
+      "@id": "trs:sparql-star-bad-10",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - blank node in embedded triple in VALUES ",
       "action": "sparql-star-syntax-bad-10.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-1",
+      "@id": "trs:sparql-star-bad-ann-1",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - empty annotation",
       "action": "sparql-star-syntax-bad-ann-1.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-2",
+      "@id": "trs:sparql-star-bad-ann-2",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - triples in annotation",
       "action": "sparql-star-syntax-bad-ann-2.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-path-1",
+      "@id": "trs:sparql-star-bad-ann-path-1",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - path - seq",
       "action": "sparql-star-syntax-bad-ann-path-1.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-path-2",
+      "@id": "trs:sparql-star-bad-ann-path-2",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - path - alt",
       "action": "sparql-star-syntax-bad-ann-path-2.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-path-3",
+      "@id": "trs:sparql-star-bad-ann-path-3",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - path - p*",
       "action": "sparql-star-syntax-bad-ann-path-3.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-path-4",
+      "@id": "trs:sparql-star-bad-ann-path-4",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - path - p+",
       "action": "sparql-star-syntax-bad-ann-path-4.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-path-5",
+      "@id": "trs:sparql-star-bad-ann-path-5",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - path - p?",
       "action": "sparql-star-syntax-bad-ann-path-5.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-path-6",
+      "@id": "trs:sparql-star-bad-ann-path-6",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - path in CONSTRUCT",
       "action": "sparql-star-syntax-bad-ann-path-6.rq"
     },
     {
-      "@id": "#sparql-star-bad-ann-path-7",
+      "@id": "trs:sparql-star-bad-ann-path-7",
       "@type": "NegativeSyntaxTest11",
       "name": "SPARQL-star - bad - path in CONSTRUCT",
       "action": "sparql-star-syntax-bad-ann-path-7.rq"
     },
     {
-      "@id": "#sparql-star-update-1",
+      "@id": "trs:sparql-star-update-1",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update",
       "action": "sparql-star-syntax-update-1.ru"
     },
     {
-      "@id": "#sparql-star-update-2",
+      "@id": "trs:sparql-star-update-2",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update",
       "action": "sparql-star-syntax-update-2.ru"
     },
     {
-      "@id": "#sparql-star-update-3",
+      "@id": "trs:sparql-star-update-3",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update",
       "action": "sparql-star-syntax-update-3.ru"
     },
     {
-      "@id": "#sparql-star-update-4",
+      "@id": "trs:sparql-star-update-4",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update with embedding",
       "action": "sparql-star-syntax-update-4.ru"
     },
     {
-      "@id": "#sparql-star-update-5",
+      "@id": "trs:sparql-star-update-5",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update with embedded object",
       "action": "sparql-star-syntax-update-5.ru"
     },
     {
-      "@id": "#sparql-star-update-6",
+      "@id": "trs:sparql-star-update-6",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update with annotation template",
       "action": "sparql-star-syntax-update-6.ru"
     },
     {
-      "@id": "#sparql-star-update-7",
+      "@id": "trs:sparql-star-update-7",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update with annotation, template and pattern",
       "action": "sparql-star-syntax-update-7.ru"
     },
     {
-      "@id": "#sparql-star-update-8",
+      "@id": "trs:sparql-star-update-8",
       "@type": "PositiveUpdateSyntaxTest11",
       "name": "SPARQL-star - update DATA with annotation",
       "action": "sparql-star-syntax-update-8.ru"
     },
     {
-      "@id": "#sparql-star-bad-update-1",
+      "@id": "trs:sparql-star-bad-update-1",
       "@type": "NegativeUpdateSyntaxTest11",
       "name": "SPARQL-star - update - bad syntax",
       "action": "sparql-star-syntax-bad-update-1.ru"
     },
     {
-      "@id": "#sparql-star-bad-update-2",
+      "@id": "trs:sparql-star-bad-update-2",
       "@type": "NegativeUpdateSyntaxTest11",
       "name": "SPARQL-star - update - bad syntax",
       "action": "sparql-star-syntax-bad-update-2.ru"
     },
     {
-      "@id": "#sparql-star-bad-update-3",
+      "@id": "trs:sparql-star-bad-update-3",
       "@type": "NegativeUpdateSyntaxTest11",
       "name": "SPARQL-star - update - bad syntax",
       "action": "sparql-star-syntax-bad-update-3.ru"
     },
     {
-      "@id": "#sparql-star-bad-update-4",
+      "@id": "trs:sparql-star-bad-update-4",
       "@type": "NegativeUpdateSyntaxTest11",
       "name": "SPARQL-star - update - bad syntax",
       "action": "sparql-star-syntax-bad-update-4.ru"
     }
-  ],
-  "label": "SPARQL-star Syntax Tests"
+  ]
 }

--- a/tests/sparql/syntax/manifest.ttl
+++ b/tests/sparql/syntax/manifest.ttl
@@ -3,409 +3,408 @@
 ## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 ## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
 
-BASE           <https://w3c.github.io/rdf-star/tests/sparql/syntax/manifest>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
-PREFIX :       <#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/sparql/syntax#>
 
-<>  rdf:type mf:Manifest ;
+trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "SPARQL-star Syntax Tests" ;
     mf:entries
     (
-        :sparql-star-1
-        :sparql-star-2
-        :sparql-star-3
-        :sparql-star-4
-        :sparql-star-5
-        :sparql-star-6
-        :sparql-star-7
+        trs:sparql-star-1
+        trs:sparql-star-2
+        trs:sparql-star-3
+        trs:sparql-star-4
+        trs:sparql-star-5
+        trs:sparql-star-6
+        trs:sparql-star-7
 
-        :sparql-star-inside-1
-        :sparql-star-inside-2
+        trs:sparql-star-inside-1
+        trs:sparql-star-inside-2
 
-        :sparql-star-nested-1
-        :sparql-star-nested-2
+        trs:sparql-star-nested-1
+        trs:sparql-star-nested-2
 
-        :sparql-star-compound-1
+        trs:sparql-star-compound-1
 
-        :sparql-star-bnode-1
-        :sparql-star-bnode-2
-        :sparql-star-bnode-3
+        trs:sparql-star-bnode-1
+        trs:sparql-star-bnode-2
+        trs:sparql-star-bnode-3
 
-        :sparql-star-ann-01
-        :sparql-star-ann-02
-        :sparql-star-ann-03
-        :sparql-star-ann-04
-        :sparql-star-ann-05
-        :sparql-star-ann-06
-        :sparql-star-ann-07
-        :sparql-star-ann-08
-        :sparql-star-ann-09
+        trs:sparql-star-ann-01
+        trs:sparql-star-ann-02
+        trs:sparql-star-ann-03
+        trs:sparql-star-ann-04
+        trs:sparql-star-ann-05
+        trs:sparql-star-ann-06
+        trs:sparql-star-ann-07
+        trs:sparql-star-ann-08
+        trs:sparql-star-ann-09
 
-        :sparql-star-expr-1
-        :sparql-star-expr-2
-        :sparql-star-expr-3
-        :sparql-star-expr-4
-        :sparql-star-expr-5
-        :sparql-star-expr-6
+        trs:sparql-star-expr-1
+        trs:sparql-star-expr-2
+        trs:sparql-star-expr-3
+        trs:sparql-star-expr-4
+        trs:sparql-star-expr-5
+        trs:sparql-star-expr-6
 
-        :sparql-star-bad-1
-        :sparql-star-bad-2
-        :sparql-star-bad-3
-        :sparql-star-bad-4
-        :sparql-star-bad-5
-        :sparql-star-bad-6
-        :sparql-star-bad-7
-        :sparql-star-bad-8
-        :sparql-star-bad-9
-        :sparql-star-bad-10
+        trs:sparql-star-bad-1
+        trs:sparql-star-bad-2
+        trs:sparql-star-bad-3
+        trs:sparql-star-bad-4
+        trs:sparql-star-bad-5
+        trs:sparql-star-bad-6
+        trs:sparql-star-bad-7
+        trs:sparql-star-bad-8
+        trs:sparql-star-bad-9
+        trs:sparql-star-bad-10
 
-        :sparql-star-bad-ann-1
-        :sparql-star-bad-ann-2
+        trs:sparql-star-bad-ann-1
+        trs:sparql-star-bad-ann-2
 
-        :sparql-star-bad-ann-path-1
-        :sparql-star-bad-ann-path-2
-        :sparql-star-bad-ann-path-3
-        :sparql-star-bad-ann-path-4
-        :sparql-star-bad-ann-path-5
-        :sparql-star-bad-ann-path-6
-        :sparql-star-bad-ann-path-7
+        trs:sparql-star-bad-ann-path-1
+        trs:sparql-star-bad-ann-path-2
+        trs:sparql-star-bad-ann-path-3
+        trs:sparql-star-bad-ann-path-4
+        trs:sparql-star-bad-ann-path-5
+        trs:sparql-star-bad-ann-path-6
+        trs:sparql-star-bad-ann-path-7
 
-        :sparql-star-update-1
-        :sparql-star-update-2
-        :sparql-star-update-3
-        :sparql-star-update-4
-        :sparql-star-update-5
-        :sparql-star-update-6
-        :sparql-star-update-7
-        :sparql-star-update-8
+        trs:sparql-star-update-1
+        trs:sparql-star-update-2
+        trs:sparql-star-update-3
+        trs:sparql-star-update-4
+        trs:sparql-star-update-5
+        trs:sparql-star-update-6
+        trs:sparql-star-update-7
+        trs:sparql-star-update-8
         
-        :sparql-star-bad-update-1
-        :sparql-star-bad-update-2
-        :sparql-star-bad-update-3
-        :sparql-star-bad-update-4
+        trs:sparql-star-bad-update-1
+        trs:sparql-star-bad-update-2
+        trs:sparql-star-bad-update-3
+        trs:sparql-star-bad-update-4
          ) .
 
 ## Good Syntax
 
-:sparql-star-1 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-1 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - subject embedded triple" ;
     mf:action    <sparql-star-syntax-basic-01.rq> ;
     .
 
-:sparql-star-2 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-2 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - object embedded triple" ;
     mf:action    <sparql-star-syntax-basic-02.rq> ;
     .
 
-:sparql-star-3 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-3 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - subject embedded triple - vars" ;
     mf:action    <sparql-star-syntax-basic-03.rq> ;
     .
 
-:sparql-star-4 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-4 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - object embedded triple - vars" ;
     mf:action    <sparql-star-syntax-basic-04.rq> ;
     .
 
-:sparql-star-5 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-5 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Embedded triple in VALUES" ;
     mf:action    <sparql-star-syntax-basic-05.rq> ;
     .
 
-:sparql-star-6 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-6 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Embedded triple in CONSTRUCT" ;
     mf:action    <sparql-star-syntax-basic-06.rq> ;
     .
 
-:sparql-star-7 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-7 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Embedded triples in CONSTRUCT WHERE" ;
     mf:action    <sparql-star-syntax-basic-07.rq> ;
     .
 
 
-:sparql-star-inside-1 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-inside-1 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - embedded triple inside blankNodePropertyList" ;
     mf:action    <sparql-star-syntax-inside-01.rq> ;
     .
 
-:sparql-star-inside-2 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-inside-2 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - embedded triple inside collection" ;
     mf:action    <sparql-star-syntax-inside-02.rq> ;
     .
 
-:sparql-star-nested-1 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-nested-1 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - nested embedded triple, subject position" ;
     mf:action    <sparql-star-syntax-nested-01.rq> ;
     .
 
-:sparql-star-nested-2 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-nested-2 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - nested embedded triple, object position" ;
     mf:action     <sparql-star-syntax-nested-02.rq> ;
     .
 
-:sparql-star-compound-1 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-compound-1 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - compound forms" ;
     mf:action    <sparql-star-syntax-compound.rq> ;
     .
 
-:sparql-star-bnode-1 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-bnode-1 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - blank node subject" ;
     mf:action    <sparql-star-syntax-bnode-01.rq> ;
     .
 
-:sparql-star-bnode-2 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-bnode-2 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - blank node object" ;
     mf:action    <sparql-star-syntax-bnode-02.rq> ;
     .
 
-:sparql-star-bnode-3 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-bnode-3 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - blank node" ;
     mf:action    <sparql-star-syntax-bnode-03.rq> ;
     .
 
 ## Expressions
 
-:sparql-star-expr-1 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-expr-1 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Expressions - Embedded triple" ;
     mf:action    <sparql-star-syntax-expr-01.rq> ;
     .
 
-:sparql-star-expr-2 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-expr-2 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Expressions - Embedded triple" ;
     mf:action    <sparql-star-syntax-expr-02.rq> ;
     .
 
-:sparql-star-expr-3 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-expr-3 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Expressions - Functions" ;
     mf:action    <sparql-star-syntax-expr-03.rq> ;
     .
 
-:sparql-star-expr-4 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-expr-4 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Expressions - TRIPLE" ;
     mf:action    <sparql-star-syntax-expr-04.rq> ;
     .
 
-:sparql-star-expr-5 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-expr-5 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Expressions - Functions" ;
     mf:action    <sparql-star-syntax-expr-05.rq> ;
     .
 
-:sparql-star-expr-6 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-expr-6 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Expressions - BIND - CONSTRUCT" ;
     mf:action    <sparql-star-syntax-expr-06.rq> ;
     .
 
 ## Bad Syntax
 
-:sparql-star-bad-1 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-1 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - embedded triple as predicate" ;
     mf:action    <sparql-star-syntax-bad-01.rq> ;
     .
 
-:sparql-star-bad-2 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-2 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - embedded triple outside triple" ;
     mf:action    <sparql-star-syntax-bad-02.rq> ;
     .
 
-:sparql-star-bad-3 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-3 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - collection list in embedded triple" ;
 
 
 mf:action    <sparql-star-syntax-bad-03.rq> ;
     .
 
-:sparql-star-bad-4 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-4 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - literal in subject position of embedded triple" ;
     mf:action    <sparql-star-syntax-bad-04.rq> ;
     .
 
-:sparql-star-bad-5 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-5 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - blank node  as predicate in embedded triple";
     mf:action    <sparql-star-syntax-bad-05.rq> ;
     .
 
-:sparql-star-bad-6 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-6 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - compound blank node expression";
     mf:action    <sparql-star-syntax-bad-06.rq> ;
     .
 
-:sparql-star-bad-7 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-7 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - incomplete embedded triple";
     mf:action    <sparql-star-syntax-bad-07.rq> ;
     .
 
-:sparql-star-bad-8 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-8 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - quad embedded triple";
     mf:action    <sparql-star-syntax-bad-08.rq> ;
     .
 
-:sparql-star-bad-9 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-9 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - variable in embedded triple in VALUES ";
     mf:action    <sparql-star-syntax-bad-09.rq> ;
     .
 
-:sparql-star-bad-10 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-10 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - blank node in embedded triple in VALUES ";
     mf:action    <sparql-star-syntax-bad-10.rq> ;
     .
 
 ## Annotation syntax
 
-:sparql-star-ann-01 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-01 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation form" ;
     mf:action    <sparql-star-annotation-01.rq> ;
    .
 
-:sparql-star-ann-02 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-02 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation example" ;
     mf:action    <sparql-star-annotation-02.rq> ;
     .
 
-:sparql-star-ann-03 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-03 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation example" ;
     mf:action    <sparql-star-annotation-03.rq> ;
     .
 
-:sparql-star-ann-04 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-04 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation with embedding" ;
     mf:action    <sparql-star-annotation-04.rq> ;
     .
 
-:sparql-star-ann-05 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-05 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation on triple with embedded object" ;
     mf:action    <sparql-star-annotation-05.rq> ;
     .
 
-:sparql-star-ann-06 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-06 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation with path" ;
     mf:action    <sparql-star-annotation-06.rq> ;
     .
 
-:sparql-star-ann-07 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-07 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation with nested path" ;
     mf:action    <sparql-star-annotation-07.rq> ;
     .
 
-:sparql-star-ann-08 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-08 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation in CONSTRUCT " ;
     mf:action    <sparql-star-annotation-08.rq> ;
     .
 
-:sparql-star-ann-09 rdf:type mf:PositiveSyntaxTest11 ;
+trs:sparql-star-ann-09 rdf:type mf:PositiveSyntaxTest11 ;
     mf:name      "SPARQL-star - Annotation in CONSTRUCT WHERE" ;
     mf:action    <sparql-star-annotation-09.rq> ;
     .
 
 ## Bad annotation syntax
 
-:sparql-star-bad-ann-1 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-1 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - empty annotation";
     mf:action    <sparql-star-syntax-bad-ann-1.rq> ;
     .
 
-:sparql-star-bad-ann-2 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-2 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - triples in annotation";
     mf:action    <sparql-star-syntax-bad-ann-2.rq> ;
     .
 
-:sparql-star-bad-ann-path-1 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-path-1 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - path - seq";
     mf:action    <sparql-star-syntax-bad-ann-path-1.rq> ;
     .
 
-:sparql-star-bad-ann-path-2 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-path-2 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - path - alt";
     mf:action    <sparql-star-syntax-bad-ann-path-2.rq> ;
     .
 
-:sparql-star-bad-ann-path-3 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-path-3 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - path - p*";
     mf:action    <sparql-star-syntax-bad-ann-path-3.rq> ;
     .
 
-:sparql-star-bad-ann-path-4 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-path-4 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - path - p+";
     mf:action    <sparql-star-syntax-bad-ann-path-4.rq> ;
     .
 
-:sparql-star-bad-ann-path-5 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-path-5 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - path - p?";
     mf:action    <sparql-star-syntax-bad-ann-path-5.rq> ;
     .
 
-:sparql-star-bad-ann-path-6 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-path-6 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - path in CONSTRUCT";
     mf:action    <sparql-star-syntax-bad-ann-path-6.rq> ;
     .
 
-:sparql-star-bad-ann-path-7 rdf:type mf:NegativeSyntaxTest11 ;
+trs:sparql-star-bad-ann-path-7 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - path in CONSTRUCT";
     mf:action    <sparql-star-syntax-bad-ann-path-7.rq> ;
     .
 
 ## SPARQL-star Update
 
-:sparql-star-update-1  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-1  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update";
     mf:action    <sparql-star-syntax-update-1.ru> ;
     .
 
-:sparql-star-update-2  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-2  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update";
     mf:action    <sparql-star-syntax-update-2.ru> ;
     .
 
-:sparql-star-update-3  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-3  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update";
     mf:action    <sparql-star-syntax-update-3.ru> ;
     .
 
-:sparql-star-update-4  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-4  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update with embedding";
     mf:action    <sparql-star-syntax-update-4.ru> ;
     .
 
-:sparql-star-update-5  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-5  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update with embedded object";
     mf:action    <sparql-star-syntax-update-5.ru> ;
     .
 
-:sparql-star-update-6  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-6  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update with annotation template";
     mf:action    <sparql-star-syntax-update-6.ru> ;
     .
 
-:sparql-star-update-7  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-7  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update with annotation, template and pattern";
     mf:action    <sparql-star-syntax-update-7.ru> ;
     .
 
-:sparql-star-update-8  rdf:type mf:PositiveUpdateSyntaxTest11 ;
+trs:sparql-star-update-8  rdf:type mf:PositiveUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update DATA with annotation";
     mf:action    <sparql-star-syntax-update-8.ru> ;
     .
 
 ## SPARQL-star Update - bad syntax
 
-:sparql-star-bad-update-1  rdf:type mf:NegativeUpdateSyntaxTest11 ;
+trs:sparql-star-bad-update-1  rdf:type mf:NegativeUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update - bad syntax";
     mf:action    <sparql-star-syntax-bad-update-1.ru> ;
     .
     
-:sparql-star-bad-update-2  rdf:type mf:NegativeUpdateSyntaxTest11 ;
+trs:sparql-star-bad-update-2  rdf:type mf:NegativeUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update - bad syntax";
     mf:action    <sparql-star-syntax-bad-update-2.ru> ;
     .
 
-:sparql-star-bad-update-3  rdf:type mf:NegativeUpdateSyntaxTest11 ;
+trs:sparql-star-bad-update-3  rdf:type mf:NegativeUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update - bad syntax";
     mf:action    <sparql-star-syntax-bad-update-3.ru> ;
     .
     
-:sparql-star-bad-update-4  rdf:type mf:NegativeUpdateSyntaxTest11 ;
+trs:sparql-star-bad-update-4  rdf:type mf:NegativeUpdateSyntaxTest11 ;
     mf:name      "SPARQL-star - update - bad syntax";
     mf:action    <sparql-star-syntax-bad-update-4.ru> ;
     .

--- a/tests/turtle/eval/manifest.html
+++ b/tests/turtle/eval/manifest.html
@@ -56,21 +56,21 @@
 <h1>manifest</h1>
 <p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
 <ul class="entries">
-<li class="proposed"><a href="#turtle-star-1">Turtle-star - subject embedded triple</a>
-<li class="proposed"><a href="#turtle-star-2">Turtle-star - object embedded triple</a>
-<li class="proposed"><a href="#turtle-star-bnode-1">Turtle-star - blank node label</a>
-<li class="proposed"><a href="#turtle-star-bnode-2">Turtle-star - blank node labels</a>
-<li class="proposed"><a href="#turtle-star-annotation-1">Turtle-star - Annotation form</a>
-<li class="proposed"><a href="#turtle-star-annotation-2">Turtle-star - Annotation example</a>
-<li class="proposed"><a href="#turtle-star-annotation-3">Turtle-star - Annotation - predicate and object lists</a>
-<li class="proposed"><a href="#turtle-star-annotation-4">Turtle-star - Annotation - nested</a>
-<li class="proposed"><a href="#turtle-star-annotation-5">Turtle-star - Annotation object list</a>
-<li class="proposed"><a href="#turtle-star-embed-annotation-1">Turtle-star - Annotation with embedding</a>
-<li class="proposed"><a href="#turtle-star-embed-annotation-2">Turtle-star - Annotation on triple with embedded subject</a>
-<li class="proposed"><a href="#turtle-star-embed-annotation-3">Turtle-star - Annotation on triple with embedded object</a>
+<li class="proposed"><a href="trs:turtle-star-1">Turtle-star - subject embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-2">Turtle-star - object embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-bnode-1">Turtle-star - blank node label</a>
+<li class="proposed"><a href="trs:turtle-star-bnode-2">Turtle-star - blank node labels</a>
+<li class="proposed"><a href="trs:turtle-star-annotation-1">Turtle-star - Annotation form</a>
+<li class="proposed"><a href="trs:turtle-star-annotation-2">Turtle-star - Annotation example</a>
+<li class="proposed"><a href="trs:turtle-star-annotation-3">Turtle-star - Annotation - predicate and object lists</a>
+<li class="proposed"><a href="trs:turtle-star-annotation-4">Turtle-star - Annotation - nested</a>
+<li class="proposed"><a href="trs:turtle-star-annotation-5">Turtle-star - Annotation object list</a>
+<li class="proposed"><a href="trs:turtle-star-embed-annotation-1">Turtle-star - Annotation with embedding</a>
+<li class="proposed"><a href="trs:turtle-star-embed-annotation-2">Turtle-star - Annotation on triple with embedded subject</a>
+<li class="proposed"><a href="trs:turtle-star-embed-annotation-3">Turtle-star - Annotation on triple with embedded object</a>
 </ul>
-<section id="turtle-star-1" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - subject embedded triple <a href="#turtle-star-1">🔗</a></h2>
+<section id="rs:turtle-star-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - subject embedded triple <a href="trs:turtle-star-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -86,8 +86,8 @@ PREFIX : &lt;http://example/&gt;
 <pre class="result">
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
-</section><section id="turtle-star-2" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - object embedded triple <a href="#turtle-star-2">🔗</a></h2>
+</section><section id="rs:turtle-star-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - object embedded triple <a href="trs:turtle-star-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -103,8 +103,8 @@ PREFIX : &lt;http://example/&gt;
 <pre class="result">
 &lt;http://example/a&gt; &lt;http://example/q&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; .
 </pre>
-</section><section id="turtle-star-bnode-1" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - blank node label <a href="#turtle-star-bnode-1">🔗</a></h2>
+</section><section id="rs:turtle-star-bnode-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - blank node label <a href="trs:turtle-star-bnode-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -122,8 +122,8 @@ _:b :p :o .
 _:b9 &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; _:b9 &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
 </pre>
-</section><section id="turtle-star-bnode-2" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - blank node labels <a href="#turtle-star-bnode-2">🔗</a></h2>
+</section><section id="rs:turtle-star-bnode-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - blank node labels <a href="trs:turtle-star-bnode-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -141,8 +141,8 @@ _:a :p1 _:a .
 _:label1 &lt;http://example/p1&gt; _:label1 .
 &lt;&lt; _:label1 &lt;http://example/p1&gt; _:label1 &gt;&gt; &lt;http://example/q&gt; &lt;&lt; _:label1 &lt;http://example/p2&gt; &lt;http://example/o&gt; &gt;&gt; .
 </pre>
-</section><section id="turtle-star-annotation-1" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation form <a href="#turtle-star-annotation-1">🔗</a></h2>
+</section><section id="rs:turtle-star-annotation-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation form <a href="trs:turtle-star-annotation-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -159,8 +159,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
 </pre>
-</section><section id="turtle-star-annotation-2" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation example <a href="#turtle-star-annotation-2">🔗</a></h2>
+</section><section id="rs:turtle-star-annotation-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation example <a href="trs:turtle-star-annotation-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -189,8 +189,8 @@ _:b2 &lt;http://example/graph&gt; &lt;http://host2/&gt; .
 _:b2 &lt;http://example/date&gt; "2020-12-31"^^&lt;http://www.w3.org/2001/XMLSchema#date&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/source&gt; _:b2 .
 </pre>
-</section><section id="turtle-star-annotation-3" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation - predicate and object lists <a href="#turtle-star-annotation-3">🔗</a></h2>
+</section><section id="rs:turtle-star-annotation-3" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation - predicate and object lists <a href="trs:turtle-star-annotation-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -213,8 +213,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o3&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o3&gt; &gt;&gt; &lt;http://example/a3&gt; &lt;http://example/b3&gt; .
 </pre>
-</section><section id="turtle-star-annotation-4" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation - nested <a href="#turtle-star-annotation-4">🔗</a></h2>
+</section><section id="rs:turtle-star-annotation-4" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation - nested <a href="trs:turtle-star-annotation-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -232,8 +232,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
 &lt;&lt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; &gt;&gt; &lt;http://example/a2&gt; &lt;http://example/b2&gt; .
 </pre>
-</section><section id="turtle-star-annotation-5" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation object list <a href="#turtle-star-annotation-5">🔗</a></h2>
+</section><section id="rs:turtle-star-annotation-5" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation object list <a href="trs:turtle-star-annotation-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -252,8 +252,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; .
 &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
 </pre>
-</section><section id="turtle-star-embed-annotation-1" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation with embedding <a href="#turtle-star-embed-annotation-1">🔗</a></h2>
+</section><section id="rs:turtle-star-embed-annotation-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation with embedding <a href="trs:turtle-star-embed-annotation-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -270,8 +270,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt;&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; .
 </pre>
-</section><section id="turtle-star-embed-annotation-2" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation on triple with embedded subject <a href="#turtle-star-embed-annotation-2">🔗</a></h2>
+</section><section id="rs:turtle-star-embed-annotation-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation on triple with embedded subject <a href="trs:turtle-star-embed-annotation-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
@@ -288,8 +288,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
 &lt;&lt;&lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
 </pre>
-</section><section id="turtle-star-embed-annotation-3" class="entry proposed rdft:TestTurtleEval">
-<h2>Turtle-star - Annotation on triple with embedded object <a href="#turtle-star-embed-annotation-3">🔗</a></h2>
+</section><section id="rs:turtle-star-embed-annotation-3" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation on triple with embedded object <a href="trs:turtle-star-embed-annotation-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>

--- a/tests/turtle/eval/manifest.jsonld
+++ b/tests/turtle/eval/manifest.jsonld
@@ -8,7 +8,9 @@
     "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
     "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
     "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/turtle/eval#",
     "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/turtle/eval/",
     "include": {
       "@type": "@id",
       "@container": "@list"
@@ -62,96 +64,95 @@
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
-    "@base": "https://w3c.github.io/rdf-star/tests/turtle/eval/manifest"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
   },
-  "@id": "manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
+  "label": "Turtle-star Evaluation Tests",
   "entries": [
     {
-      "@id": "#turtle-star-1",
+      "@id": "trs:turtle-star-1",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - subject embedded triple",
       "action": "turtle-star-eval-01.ttl",
       "result": "turtle-star-eval-01.nt"
     },
     {
-      "@id": "#turtle-star-2",
+      "@id": "trs:turtle-star-2",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - object embedded triple",
       "action": "turtle-star-eval-02.ttl",
       "result": "turtle-star-eval-02.nt"
     },
     {
-      "@id": "#turtle-star-bnode-1",
+      "@id": "trs:turtle-star-bnode-1",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - blank node label",
       "action": "turtle-star-eval-bnode-1.ttl",
       "result": "turtle-star-eval-bnode-1.nt"
     },
     {
-      "@id": "#turtle-star-bnode-2",
+      "@id": "trs:turtle-star-bnode-2",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - blank node labels",
       "action": "turtle-star-eval-bnode-2.ttl",
       "result": "turtle-star-eval-bnode-2.nt"
     },
     {
-      "@id": "#turtle-star-annotation-1",
+      "@id": "trs:turtle-star-annotation-1",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation form",
       "action": "turtle-star-eval-annotation-1.ttl",
       "result": "turtle-star-eval-annotation-1.nt"
     },
     {
-      "@id": "#turtle-star-annotation-2",
+      "@id": "trs:turtle-star-annotation-2",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation example",
       "action": "turtle-star-eval-annotation-2.ttl",
       "result": "turtle-star-eval-annotation-2.nt"
     },
     {
-      "@id": "#turtle-star-annotation-3",
+      "@id": "trs:turtle-star-annotation-3",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation - predicate and object lists",
       "action": "turtle-star-eval-annotation-3.ttl",
       "result": "turtle-star-eval-annotation-3.nt"
     },
     {
-      "@id": "#turtle-star-annotation-4",
+      "@id": "trs:turtle-star-annotation-4",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation - nested",
       "action": "turtle-star-eval-annotation-4.ttl",
       "result": "turtle-star-eval-annotation-4.nt"
     },
     {
-      "@id": "#turtle-star-annotation-5",
+      "@id": "trs:turtle-star-annotation-5",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation object list",
       "action": "turtle-star-eval-annotation-5.ttl",
       "result": "turtle-star-eval-annotation-5.nt"
     },
     {
-      "@id": "#turtle-star-embed-annotation-1",
+      "@id": "trs:turtle-star-embed-annotation-1",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation with embedding",
       "action": "turtle-star-eval-embed-annotation-1.ttl",
       "result": "turtle-star-eval-embed-annotation-1.nt"
     },
     {
-      "@id": "#turtle-star-embed-annotation-2",
+      "@id": "trs:turtle-star-embed-annotation-2",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation on triple with embedded subject",
       "action": "turtle-star-eval-embed-annotation-2.ttl",
       "result": "turtle-star-eval-embed-annotation-2.nt"
     },
     {
-      "@id": "#turtle-star-embed-annotation-3",
+      "@id": "trs:turtle-star-embed-annotation-3",
       "@type": "rdft:TestTurtleEval",
       "name": "Turtle-star - Annotation on triple with embedded object",
       "action": "turtle-star-eval-embed-annotation-3.ttl",
       "result": "turtle-star-eval-embed-annotation-3.nt"
     }
-  ],
-  "label": "Turtle-star Evaluation Tests"
+  ]
 }

--- a/tests/turtle/eval/manifest.ttl
+++ b/tests/turtle/eval/manifest.ttl
@@ -3,98 +3,98 @@
 ## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 ## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
 
-BASE           <https://w3c.github.io/rdf-star/tests/turtle/eval/manifest>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX :       <#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/turtle/eval#>
 
-<>  rdf:type mf:Manifest ;
+trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "Turtle-star Evaluation Tests" ;
     mf:entries
     (
-        :turtle-star-1
-        :turtle-star-2
-        :turtle-star-bnode-1
-        :turtle-star-bnode-2
-        :turtle-star-annotation-1
-        :turtle-star-annotation-2
-        :turtle-star-annotation-3
-        :turtle-star-annotation-4
-        :turtle-star-annotation-5
-        :turtle-star-embed-annotation-1
-        :turtle-star-embed-annotation-2
-        :turtle-star-embed-annotation-3
+        trs:turtle-star-1
+        trs:turtle-star-2
+        trs:turtle-star-bnode-1
+        trs:turtle-star-bnode-2
+        trs:turtle-star-annotation-1
+        trs:turtle-star-annotation-2
+        trs:turtle-star-annotation-3
+        trs:turtle-star-annotation-4
+        trs:turtle-star-annotation-5
+        trs:turtle-star-embed-annotation-1
+        trs:turtle-star-embed-annotation-2
+        trs:turtle-star-embed-annotation-3
     ) .
 
-:turtle-star-1 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-1 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - subject embedded triple" ;
    mf:action    <turtle-star-eval-01.ttl> ;
    mf:result    <turtle-star-eval-01.nt> ;
    .
 
-:turtle-star-2 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-2 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - object embedded triple" ;
    mf:action    <turtle-star-eval-02.ttl> ;
    mf:result    <turtle-star-eval-02.nt> ;
    .
 
-:turtle-star-bnode-1 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-bnode-1 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - blank node label" ;
    mf:action    <turtle-star-eval-bnode-1.ttl> ;
    mf:result    <turtle-star-eval-bnode-1.nt> ;
    .
    
-:turtle-star-bnode-2 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-bnode-2 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - blank node labels" ;
    mf:action    <turtle-star-eval-bnode-2.ttl> ;
    mf:result    <turtle-star-eval-bnode-2.nt> ;
    .
 
-:turtle-star-annotation-1 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-annotation-1 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation form" ;
    mf:action    <turtle-star-eval-annotation-1.ttl> ;
    mf:result    <turtle-star-eval-annotation-1.nt> ;
    .
    
-:turtle-star-annotation-2 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-annotation-2 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation example" ;
    mf:action    <turtle-star-eval-annotation-2.ttl> ;
    mf:result    <turtle-star-eval-annotation-2.nt> ;
    .
    
-:turtle-star-annotation-3 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-annotation-3 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation - predicate and object lists" ;
    mf:action    <turtle-star-eval-annotation-3.ttl> ;
    mf:result    <turtle-star-eval-annotation-3.nt> ;
    .
    
-:turtle-star-annotation-4 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-annotation-4 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation - nested" ;
    mf:action    <turtle-star-eval-annotation-4.ttl> ;
    mf:result    <turtle-star-eval-annotation-4.nt> ;
    .
    
-:turtle-star-annotation-5 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-annotation-5 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation object list" ;
    mf:action    <turtle-star-eval-annotation-5.ttl> ;
    mf:result    <turtle-star-eval-annotation-5.nt> ;
    .
 
-:turtle-star-embed-annotation-1 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-embed-annotation-1 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation with embedding" ;
    mf:action    <turtle-star-eval-embed-annotation-1.ttl> ;
    mf:result    <turtle-star-eval-embed-annotation-1.nt> ;
    .
    
-:turtle-star-embed-annotation-2 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-embed-annotation-2 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation on triple with embedded subject" ;
    mf:action    <turtle-star-eval-embed-annotation-2.ttl> ;
    mf:result    <turtle-star-eval-embed-annotation-2.nt> ;
    .
    
-:turtle-star-embed-annotation-3 rdf:type rdft:TestTurtleEval ;
+trs:turtle-star-embed-annotation-3 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle-star - Annotation on triple with embedded object" ;
    mf:action    <turtle-star-eval-embed-annotation-3.ttl> ;
    mf:result    <turtle-star-eval-embed-annotation-3.nt> ;

--- a/tests/turtle/syntax/manifest.html
+++ b/tests/turtle/syntax/manifest.html
@@ -56,31 +56,31 @@
 <h1>manifest</h1>
 <p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
 <ul class="entries">
-<li class="proposed"><a href="#turtle-star-1">Turtle-star - subject embedded triple</a>
-<li class="proposed"><a href="#turtle-star-2">Turtle-star - object embedded triple</a>
-<li class="proposed"><a href="#turtle-star-inside-1">Turtle-star - embedded triple inside blankNodePropertyList</a>
-<li class="proposed"><a href="#turtle-star-inside-2">Turtle-star - embedded triple inside collection</a>
-<li class="proposed"><a href="#turtle-star-nested-1">Turtle-star - nested embedded triple, subject position</a>
-<li class="proposed"><a href="#turtle-star-nested-2">Turtle-star - nested embedded triple, object position</a>
-<li class="proposed"><a href="#turtle-star-compound-1">Turtle-star - compound forms</a>
-<li class="proposed"><a href="#turtle-star-bnode-1">Turtle-star - blank node subject</a>
-<li class="proposed"><a href="#turtle-star-bnode-2">Turtle-star - blank node object</a>
-<li class="proposed"><a href="#turtle-star-bnode-3">Turtle-star - blank node</a>
-<li class="proposed"><a href="#turtle-star-bad-1">Turtle-star - bad - embedded triple as predicate</a>
-<li class="proposed"><a href="#turtle-star-bad-2">Turtle-star - bad - embedded triple outside triple</a>
-<li class="proposed"><a href="#turtle-star-bad-3">Turtle-star - bad - collection list in embedded triple</a>
-<li class="proposed"><a href="#turtle-star-bad-4">Turtle-star - bad - literal in subject position of embedded triple</a>
-<li class="proposed"><a href="#turtle-star-bad-5">Turtle-star - bad - blank node  as predicate in embedded triple</a>
-<li class="proposed"><a href="#turtle-star-bad-6">Turtle-star - bad - compound blank node expression</a>
-<li class="proposed"><a href="#turtle-star-bad-7">Turtle-star - bad - incomplete embedded triple</a>
-<li class="proposed"><a href="#turtle-star-bad-8">Turtle-star - bad - over-long embedded triple</a>
-<li class="proposed"><a href="#turtle-star-ann-1">Turtle-star - Annotation form</a>
-<li class="proposed"><a href="#turtle-star-ann-2">Turtle-star - Annotation example</a>
-<li class="proposed"><a href="#turtle-star-bad-ann-1">Turtle-star - bad - empty annotation</a>
-<li class="proposed"><a href="#turtle-star-bad-ann-2">Turtle-star - bad - triple as annotation</a>
+<li class="proposed"><a href="trs:turtle-star-1">Turtle-star - subject embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-2">Turtle-star - object embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-inside-1">Turtle-star - embedded triple inside blankNodePropertyList</a>
+<li class="proposed"><a href="trs:turtle-star-inside-2">Turtle-star - embedded triple inside collection</a>
+<li class="proposed"><a href="trs:turtle-star-nested-1">Turtle-star - nested embedded triple, subject position</a>
+<li class="proposed"><a href="trs:turtle-star-nested-2">Turtle-star - nested embedded triple, object position</a>
+<li class="proposed"><a href="trs:turtle-star-compound-1">Turtle-star - compound forms</a>
+<li class="proposed"><a href="trs:turtle-star-bnode-1">Turtle-star - blank node subject</a>
+<li class="proposed"><a href="trs:turtle-star-bnode-2">Turtle-star - blank node object</a>
+<li class="proposed"><a href="trs:turtle-star-bnode-3">Turtle-star - blank node</a>
+<li class="proposed"><a href="trs:turtle-star-bad-1">Turtle-star - bad - embedded triple as predicate</a>
+<li class="proposed"><a href="trs:turtle-star-bad-2">Turtle-star - bad - embedded triple outside triple</a>
+<li class="proposed"><a href="trs:turtle-star-bad-3">Turtle-star - bad - collection list in embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-bad-4">Turtle-star - bad - literal in subject position of embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-bad-5">Turtle-star - bad - blank node  as predicate in embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-bad-6">Turtle-star - bad - compound blank node expression</a>
+<li class="proposed"><a href="trs:turtle-star-bad-7">Turtle-star - bad - incomplete embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-bad-8">Turtle-star - bad - over-long embedded triple</a>
+<li class="proposed"><a href="trs:turtle-star-ann-1">Turtle-star - Annotation form</a>
+<li class="proposed"><a href="trs:turtle-star-ann-2">Turtle-star - Annotation example</a>
+<li class="proposed"><a href="trs:turtle-star-bad-ann-1">Turtle-star - bad - empty annotation</a>
+<li class="proposed"><a href="trs:turtle-star-bad-ann-2">Turtle-star - bad - triple as annotation</a>
 </ul>
-<section id="turtle-star-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - subject embedded triple <a href="#turtle-star-1">🔗</a></h2>
+<section id="rs:turtle-star-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - subject embedded triple <a href="trs:turtle-star-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -93,8 +93,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;:s :p :o&gt;&gt; :q 123 .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - object embedded triple <a href="#turtle-star-2">🔗</a></h2>
+</section><section id="rs:turtle-star-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - object embedded triple <a href="trs:turtle-star-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -107,8 +107,8 @@ PREFIX : &lt;http://example/&gt;
 :x :p &lt;&lt;:s :p :o&gt;&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-inside-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - embedded triple inside blankNodePropertyList <a href="#turtle-star-inside-1">🔗</a></h2>
+</section><section id="rs:turtle-star-inside-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - embedded triple inside blankNodePropertyList <a href="trs:turtle-star-inside-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -121,8 +121,8 @@ PREFIX : &lt;http://example/&gt;
 [ :q &lt;&lt;:s :p :o&gt;&gt; ] :b :c .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-inside-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - embedded triple inside collection <a href="#turtle-star-inside-2">🔗</a></h2>
+</section><section id="rs:turtle-star-inside-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - embedded triple inside collection <a href="trs:turtle-star-inside-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -136,8 +136,8 @@ PREFIX : &lt;http://example/&gt;
 ( &lt;&lt;:s :p :o1&gt;&gt; &lt;&lt;:s :p :o2&gt;&gt; )  :q 123 .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-nested-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - nested embedded triple, subject position <a href="#turtle-star-nested-1">🔗</a></h2>
+</section><section id="rs:turtle-star-nested-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - nested embedded triple, subject position <a href="trs:turtle-star-nested-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -153,8 +153,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt; &lt;&lt;:s :p :o &gt;&gt; :r :z &gt;&gt; :q 1 .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-nested-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - nested embedded triple, object position <a href="#turtle-star-nested-2">🔗</a></h2>
+</section><section id="rs:turtle-star-nested-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - nested embedded triple, object position <a href="trs:turtle-star-nested-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -168,8 +168,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt; :a :q &lt;&lt;:s :p :o &gt;&gt;&gt;&gt; :r :z .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-compound-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - compound forms <a href="#turtle-star-compound-1">🔗</a></h2>
+</section><section id="rs:turtle-star-compound-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - compound forms <a href="trs:turtle-star-compound-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -189,8 +189,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt; &lt;&lt;:x :r :z &gt;&gt; :p &lt;&lt;:a :b :c&gt;&gt; &gt;&gt; .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-bnode-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - blank node subject <a href="#turtle-star-bnode-1">🔗</a></h2>
+</section><section id="rs:turtle-star-bnode-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node subject <a href="trs:turtle-star-bnode-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -203,8 +203,8 @@ _:a :p :o .
 &lt;&lt;_:a :p :o &gt;&gt; :q 456 .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-bnode-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - blank node object <a href="#turtle-star-bnode-2">🔗</a></h2>
+</section><section id="rs:turtle-star-bnode-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node object <a href="trs:turtle-star-bnode-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -217,8 +217,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;:s :p _:a &gt;&gt; :q 456 .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-bnode-3" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - blank node <a href="#turtle-star-bnode-3">🔗</a></h2>
+</section><section id="rs:turtle-star-bnode-3" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node <a href="trs:turtle-star-bnode-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -230,8 +230,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;[] :p [] &gt;&gt; :q :z .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-bad-1" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - embedded triple as predicate <a href="#turtle-star-bad-1">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-1" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - embedded triple as predicate <a href="trs:turtle-star-bad-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -244,8 +244,8 @@ PREFIX : &lt;http://example/&gt;
 :x &lt;&lt;:s :p :o&gt;&gt; 123 .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-2" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - embedded triple outside triple <a href="#turtle-star-bad-2">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-2" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - embedded triple outside triple <a href="trs:turtle-star-bad-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -258,8 +258,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;:s :p :o&gt;&gt; .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-3" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - collection list in embedded triple <a href="#turtle-star-bad-3">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-3" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - collection list in embedded triple <a href="trs:turtle-star-bad-3">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -272,8 +272,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;:s :p ("abc") &gt;&gt; :q 123 .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-4" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - literal in subject position of embedded triple <a href="#turtle-star-bad-4">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-4" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - literal in subject position of embedded triple <a href="trs:turtle-star-bad-4">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -286,8 +286,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;3 :p :o &gt;&gt; :q :z .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-5" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - blank node  as predicate in embedded triple <a href="#turtle-star-bad-5">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-5" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - blank node  as predicate in embedded triple <a href="trs:turtle-star-bad-5">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -299,8 +299,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;:s [] :o&gt;&gt; :q 123 .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-6" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - compound blank node expression <a href="#turtle-star-bad-6">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-6" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - compound blank node expression <a href="trs:turtle-star-bad-6">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -313,8 +313,8 @@ PREFIX : &lt;http://example/&gt;
 &lt;&lt;:s :p [ :p1 :o1 ]  &gt;&gt; :q 123 .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-7" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - incomplete embedded triple <a href="#turtle-star-bad-7">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-7" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - incomplete embedded triple <a href="trs:turtle-star-bad-7">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -326,8 +326,8 @@ PREFIX : &lt;http://example/&gt;
 :s :p &lt;&lt; :p :r &gt;&gt; .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-8" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - over-long embedded triple <a href="#turtle-star-bad-8">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-8" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - over-long embedded triple <a href="trs:turtle-star-bad-8">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -339,8 +339,8 @@ PREFIX : &lt;http://example/&gt;
 :s :p &lt;&lt; :g :s :p :o &gt;&gt; .
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-ann-1" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - Annotation form <a href="#turtle-star-ann-1">🔗</a></h2>
+</section><section id="rs:turtle-star-ann-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - Annotation form <a href="trs:turtle-star-ann-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -352,8 +352,8 @@ PREFIX : &lt;http://example/&gt;
 :s :p :o {| :r :z |} .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-ann-2" class="entry proposed TestTurtlePositiveSyntax">
-<h2>Turtle-star - Annotation example <a href="#turtle-star-ann-2">🔗</a></h2>
+</section><section id="rs:turtle-star-ann-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - Annotation example <a href="trs:turtle-star-ann-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
@@ -372,8 +372,8 @@ PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
           |} .
 </pre>
 <div>MUST be accepted</div>
-</section><section id="turtle-star-bad-ann-1" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - empty annotation <a href="#turtle-star-bad-ann-1">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-ann-1" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - empty annotation <a href="trs:turtle-star-bad-ann-1">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
@@ -388,8 +388,8 @@ SELECT * {
 
 </pre>
 <div>MUST be rejected</div>
-</section><section id="turtle-star-bad-ann-2" class="entry proposed TestTurtleNegativeSyntax">
-<h2>Turtle-star - bad - triple as annotation <a href="#turtle-star-bad-ann-2">🔗</a></h2>
+</section><section id="rs:turtle-star-bad-ann-2" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - triple as annotation <a href="trs:turtle-star-bad-ann-2">🔗</a></h2>
 <table class="properties">
 <tr class="status"><th>status:</th><td>proposed</td>
 <tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>

--- a/tests/turtle/syntax/manifest.jsonld
+++ b/tests/turtle/syntax/manifest.jsonld
@@ -8,7 +8,9 @@
     "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
     "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
     "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/turtle/syntax#",
     "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/turtle/syntax/",
     "include": {
       "@type": "@id",
       "@container": "@list"
@@ -62,144 +64,143 @@
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
-    "@base": "https://w3c.github.io/rdf-star/tests/turtle/syntax/manifest"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
   },
-  "@id": "manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
+  "label": "Turtle-star Syntax Tests",
   "entries": [
     {
-      "@id": "#turtle-star-1",
+      "@id": "trs:turtle-star-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - subject embedded triple",
       "action": "turtle-star-syntax-basic-01.ttl"
     },
     {
-      "@id": "#turtle-star-2",
+      "@id": "trs:turtle-star-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - object embedded triple",
       "action": "turtle-star-syntax-basic-02.ttl"
     },
     {
-      "@id": "#turtle-star-inside-1",
+      "@id": "trs:turtle-star-inside-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - embedded triple inside blankNodePropertyList",
       "action": "turtle-star-syntax-inside-01.ttl"
     },
     {
-      "@id": "#turtle-star-inside-2",
+      "@id": "trs:turtle-star-inside-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - embedded triple inside collection",
       "action": "turtle-star-syntax-inside-02.ttl"
     },
     {
-      "@id": "#turtle-star-nested-1",
+      "@id": "trs:turtle-star-nested-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - nested embedded triple, subject position",
       "action": "turtle-star-syntax-nested-01.ttl"
     },
     {
-      "@id": "#turtle-star-nested-2",
+      "@id": "trs:turtle-star-nested-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - nested embedded triple, object position",
       "action": "turtle-star-syntax-nested-02.ttl"
     },
     {
-      "@id": "#turtle-star-compound-1",
+      "@id": "trs:turtle-star-compound-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - compound forms",
       "action": "turtle-star-syntax-compound.ttl"
     },
     {
-      "@id": "#turtle-star-bnode-1",
+      "@id": "trs:turtle-star-bnode-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - blank node subject",
       "action": "turtle-star-syntax-bnode-01.ttl"
     },
     {
-      "@id": "#turtle-star-bnode-2",
+      "@id": "trs:turtle-star-bnode-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - blank node object",
       "action": "turtle-star-syntax-bnode-02.ttl"
     },
     {
-      "@id": "#turtle-star-bnode-3",
+      "@id": "trs:turtle-star-bnode-3",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - blank node",
       "action": "turtle-star-syntax-bnode-03.ttl"
     },
     {
-      "@id": "#turtle-star-bad-1",
+      "@id": "trs:turtle-star-bad-1",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - embedded triple as predicate",
       "action": "turtle-star-syntax-bad-01.ttl"
     },
     {
-      "@id": "#turtle-star-bad-2",
+      "@id": "trs:turtle-star-bad-2",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - embedded triple outside triple",
       "action": "turtle-star-syntax-bad-02.ttl"
     },
     {
-      "@id": "#turtle-star-bad-3",
+      "@id": "trs:turtle-star-bad-3",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - collection list in embedded triple",
       "action": "turtle-star-syntax-bad-03.ttl"
     },
     {
-      "@id": "#turtle-star-bad-4",
+      "@id": "trs:turtle-star-bad-4",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - literal in subject position of embedded triple",
       "action": "turtle-star-syntax-bad-04.ttl"
     },
     {
-      "@id": "#turtle-star-bad-5",
+      "@id": "trs:turtle-star-bad-5",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - blank node  as predicate in embedded triple",
       "action": "turtle-star-syntax-bad-05.ttl"
     },
     {
-      "@id": "#turtle-star-bad-6",
+      "@id": "trs:turtle-star-bad-6",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - compound blank node expression",
       "action": "turtle-star-syntax-bad-06.ttl"
     },
     {
-      "@id": "#turtle-star-bad-7",
+      "@id": "trs:turtle-star-bad-7",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - incomplete embedded triple",
       "action": "turtle-star-syntax-bad-07.ttl"
     },
     {
-      "@id": "#turtle-star-bad-8",
+      "@id": "trs:turtle-star-bad-8",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - over-long embedded triple",
       "action": "turtle-star-syntax-bad-08.ttl"
     },
     {
-      "@id": "#turtle-star-ann-1",
+      "@id": "trs:turtle-star-ann-1",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - Annotation form",
       "action": "turtle-star-annotation-1.ttl"
     },
     {
-      "@id": "#turtle-star-ann-2",
+      "@id": "trs:turtle-star-ann-2",
       "@type": "TestTurtlePositiveSyntax",
       "name": "Turtle-star - Annotation example",
       "action": "turtle-star-annotation-2.ttl"
     },
     {
-      "@id": "#turtle-star-bad-ann-1",
+      "@id": "trs:turtle-star-bad-ann-1",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - empty annotation",
       "action": "turtle-star-syntax-bad-ann-1.ttl"
     },
     {
-      "@id": "#turtle-star-bad-ann-2",
+      "@id": "trs:turtle-star-bad-ann-2",
       "@type": "TestTurtleNegativeSyntax",
       "name": "Turtle-star - bad - triple as annotation",
       "action": "turtle-star-syntax-bad-ann-2.ttl"
     }
-  ],
-  "label": "Turtle-star Syntax Tests"
+  ]
 }

--- a/tests/turtle/syntax/manifest.ttl
+++ b/tests/turtle/syntax/manifest.ttl
@@ -3,162 +3,162 @@
 ## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 ## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
 
-BASE           <https://w3c.github.io/rdf-star/tests/turtle/syntax/manifest>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX :       <#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/turtle/syntax#>
 
-<>  rdf:type mf:Manifest ;
+trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "Turtle-star Syntax Tests" ;
     mf:entries
     (
-        :turtle-star-1
-        :turtle-star-2
+        trs:turtle-star-1
+        trs:turtle-star-2
 
-        :turtle-star-inside-1
-        :turtle-star-inside-2
+        trs:turtle-star-inside-1
+        trs:turtle-star-inside-2
 
-        :turtle-star-nested-1
-        :turtle-star-nested-2
+        trs:turtle-star-nested-1
+        trs:turtle-star-nested-2
 
-        :turtle-star-compound-1
+        trs:turtle-star-compound-1
 
-        :turtle-star-bnode-1
-        :turtle-star-bnode-2
-        :turtle-star-bnode-3
+        trs:turtle-star-bnode-1
+        trs:turtle-star-bnode-2
+        trs:turtle-star-bnode-3
 
-        :turtle-star-bad-1
-        :turtle-star-bad-2
-        :turtle-star-bad-3
-        :turtle-star-bad-4
-        :turtle-star-bad-5
-        :turtle-star-bad-6
-        :turtle-star-bad-7
-        :turtle-star-bad-8
+        trs:turtle-star-bad-1
+        trs:turtle-star-bad-2
+        trs:turtle-star-bad-3
+        trs:turtle-star-bad-4
+        trs:turtle-star-bad-5
+        trs:turtle-star-bad-6
+        trs:turtle-star-bad-7
+        trs:turtle-star-bad-8
 
-        :turtle-star-ann-1
-        :turtle-star-ann-2
+        trs:turtle-star-ann-1
+        trs:turtle-star-ann-2
         
-        :turtle-star-bad-ann-1
-        :turtle-star-bad-ann-2
+        trs:turtle-star-bad-ann-1
+        trs:turtle-star-bad-ann-2
     ) .
 
 ## Good Syntax
 
-:turtle-star-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - subject embedded triple" ;
    mf:action    <turtle-star-syntax-basic-01.ttl> ;
    .
 
-:turtle-star-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-2 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - object embedded triple" ;
    mf:action    <turtle-star-syntax-basic-02.ttl> ;
    .
 
-:turtle-star-inside-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-inside-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - embedded triple inside blankNodePropertyList" ;
    mf:action    <turtle-star-syntax-inside-01.ttl> ;
    .
 
-:turtle-star-inside-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-inside-2 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - embedded triple inside collection" ;
    mf:action    <turtle-star-syntax-inside-02.ttl> ;
    .
 
-:turtle-star-nested-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-nested-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - nested embedded triple, subject position" ;
    mf:action    <turtle-star-syntax-nested-01.ttl> ;
    .
 
-:turtle-star-nested-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-nested-2 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - nested embedded triple, object position" ;
    mf:action     <turtle-star-syntax-nested-02.ttl> ;
    .
 
-:turtle-star-compound-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-compound-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - compound forms" ;
    mf:action    <turtle-star-syntax-compound.ttl> ;
    .
 
-:turtle-star-bnode-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-bnode-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - blank node subject" ;
    mf:action    <turtle-star-syntax-bnode-01.ttl> ;
    .
 
-:turtle-star-bnode-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-bnode-2 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - blank node object" ;
    mf:action    <turtle-star-syntax-bnode-02.ttl> ;
    .
 
-:turtle-star-bnode-3 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-bnode-3 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle-star - blank node" ;
    mf:action    <turtle-star-syntax-bnode-03.ttl> ;
    .
 
 ## Bad Syntax
 
-:turtle-star-bad-1 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-1 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - embedded triple as predicate" ;
     mf:action    <turtle-star-syntax-bad-01.ttl> ;
     .
 
-:turtle-star-bad-2 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-2 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - embedded triple outside triple" ;
     mf:action    <turtle-star-syntax-bad-02.ttl> ;
     .
 
-:turtle-star-bad-3 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-3 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - collection list in embedded triple" ;
     mf:action    <turtle-star-syntax-bad-03.ttl> ;
     .
 
-:turtle-star-bad-4 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-4 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - literal in subject position of embedded triple" ;
     mf:action    <turtle-star-syntax-bad-04.ttl> ;
     .
 
-:turtle-star-bad-5 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-5 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - blank node  as predicate in embedded triple";
     mf:action    <turtle-star-syntax-bad-05.ttl> ;
     .
 
-:turtle-star-bad-6 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-6 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - compound blank node expression";
     mf:action    <turtle-star-syntax-bad-06.ttl> ;
     .
 
-:turtle-star-bad-7 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-7 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - incomplete embedded triple";
     mf:action    <turtle-star-syntax-bad-07.ttl> ;
     .
 
-:turtle-star-bad-8 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-8 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - over-long embedded triple";
     mf:action    <turtle-star-syntax-bad-08.ttl> ;
     .
 
 ## Annotation syntax
 
-:turtle-star-ann-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-ann-1 rdf:type rdft:TestTurtlePositiveSyntax ;
     mf:name      "Turtle-star - Annotation form" ;
     mf:action    <turtle-star-annotation-1.ttl> ;
    .
 
-:turtle-star-ann-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+trs:turtle-star-ann-2 rdf:type rdft:TestTurtlePositiveSyntax ;
     mf:name      "Turtle-star - Annotation example" ;
     mf:action    <turtle-star-annotation-2.ttl> ;
     .
 
 ## Bad annotation syntax
 
-:turtle-star-bad-ann-1 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-ann-1 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - empty annotation" ;
     mf:action    <turtle-star-syntax-bad-ann-1.ttl> ;
    .
 
-:turtle-star-bad-ann-2 rdf:type rdft:TestTurtleNegativeSyntax ;
+trs:turtle-star-bad-ann-2 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "Turtle-star - bad - triple as annotation" ;
     mf:action    <turtle-star-syntax-bad-ann-2.ttl> ;
    .


### PR DESCRIPTION
Follow on to #130.

1. Use `PREFIX trs:` ("test rdf star") for the test entries in manifest.ttl
2. Remove BASE usage so local files are accessed

Typical entry: URI is `<area#>`:
```
PREFIX trs:    <https://w3c.github.io/rdf-star/tests/semantics#>
```
