### PR TITLE
Add/improve instructions on submitting earl reports

### DIFF
--- a/reports/index.html
+++ b/reports/index.html
@@ -284,7 +284,11 @@ each supports.</p></li>
 
 <p>Reports should be submitted in Turtle format to
   <a href="mailto:public-rdf-star@w3.org">RDF-DEV CG</a> or via a Pull
-  Request to the <a href="https://github.com/w3c/rdf-star/pulls">w3c/rdf-star</a>.</p>
+  Request to the <a href="https://github.com/w3c/rdf-star/pulls">w3c/rdf-star</a>.
+  Add or update a file in the /releases directory named so that it can
+  be identified with your implementation.
+  See instructions on using the <a href="https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">GitHub web interface</a>
+  or submit a pull request from a forked repository using a branch other than &quot;main&quot;.</p>
 
 <p>Tests should be run using the test manifests defined in the
   <a href="#test-manifests">Test Manifests</a> Section.</p>

--- a/reports/index.html
+++ b/reports/index.html
@@ -286,9 +286,9 @@ each supports.</p></li>
   <a href="mailto:public-rdf-star@w3.org">RDF-DEV CG</a> or via a Pull
   Request to the <a href="https://github.com/w3c/rdf-star/pulls">w3c/rdf-star</a>.
   Add or update a file in the /releases directory named so that it can
-  be identified with your implementation.
-  See instructions on using the <a href="https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">GitHub web interface</a>
-  or submit a pull request from a forked repository using a branch other than &quot;main&quot;.</p>
+  be identified with your implementation.  See instructions on using the <a 
+  href="https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">GitHub 
+  web interface</a> or submit a pull request from a forked repository using a branch other than &quot;main&quot;.</p>
 
 <p>Tests should be run using the test manifests defined in the
   <a href="#test-manifests">Test Manifests</a> Section.</p>

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -231,6 +231,10 @@
           Reports should be submitted in Turtle format to
           [RDF-DEV CG](mailto:public-rdf-star@w3.org) or via a Pull
           Request to the [w3c/rdf-star](https://github.com/w3c/rdf-star/pulls).
+          Add or update a file in the /releases directory named so that it can
+          be identified with your implementation.
+          See instructions on using the [GitHub web interface](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
+          or submit a pull request from a forked repository using a branch other than "main".
 
           Tests should be run using the test manifests defined in the
           [Test Manifests](#test-manifests) Section.

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -231,10 +231,9 @@
           Reports should be submitted in Turtle format to
           [RDF-DEV CG](mailto:public-rdf-star@w3.org) or via a Pull
           Request to the [w3c/rdf-star](https://github.com/w3c/rdf-star/pulls).
-          Add or update a file in the /releases directory named so that it can
-  be identified with your implementation.  See instructions on using the <a 
-  href="https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">GitHub 
-  web interface</a> or submit a pull request from a forked repository using a branch other than &quot;main&quot;.</p>
+          Add or update a file in the /releases directory named so that it can be identified with your implementation.
+          See instructions on using the [GitHub web interface](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
+          or submit a pull request from a forked repository using a branch other than "main".
 
           Tests should be run using the test manifests defined in the
           [Test Manifests](#test-manifests) Section.

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -232,9 +232,9 @@
           [RDF-DEV CG](mailto:public-rdf-star@w3.org) or via a Pull
           Request to the [w3c/rdf-star](https://github.com/w3c/rdf-star/pulls).
           Add or update a file in the /releases directory named so that it can
-          be identified with your implementation.
-          See instructions on using the [GitHub web interface](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
-          or submit a pull request from a forked repository using a branch other than "main".
+  be identified with your implementation.  See instructions on using the <a 
+  href="https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">GitHub 
+  web interface</a> or submit a pull request from a forked repository using a branch other than &quot;main&quot;.</p>
 
           Tests should be run using the test manifests defined in the
           [Test Manifests](#test-manifests) Section.


### PR DESCRIPTION
 in the report template:

>  Reports should be submitted in Turtle format to [RDF-DEV CG](mailto:public-rdf-star@w3.org) or via a Pull Request to the [w3c/rdf-star](https://github.com/w3c/rdf-star/pulls). Add or update a file in the /releases directory named so that it can be identified with your implementation. See instructions on using the [GitHub web interface](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) or submit a pull request from a forked repository using a branch other than "main".
