### PR TITLE
Trig star

### DIFF
--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -480,7 +480,7 @@ SELECT ?claimer WHERE {
     <p>The TriG-star grammar contains exactly the same productions updates
       described in <a href="#turtle-star-grammar" class="sectionRef"></a>.</p>
 
-    <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to the <a data-cite="TRIG#sec-parsing">TriG Parsing</a>.</p>
+    <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
 
     <p>A conforming TriG-star parser MUST parse any
       valid <strong>TriG document</strong> and any

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -704,7 +704,7 @@ SELECT ?claimer WHERE {
         <li>(|b|, `http://example.org/#name`, `"Alice"`),
           where |b| is a blank node</li>
         <li>((|b|, `http://example.org/#name`, `"Alice"`), `http://example.org/#statedBy`, `http://example.org/#bob/`),
-          where |b| is a blank node</li>
+          where |b| is the same blank node</li>
       </ol>
     </section>
   </section>

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -678,7 +678,7 @@ SELECT ?claimer WHERE {
     <section id="trig-star-discussion" class="informative">
       <h3>Discussion</h3>
 
-      <p>TriG-star allows the same expresivity of Turtle-star
+      <p>TriG-star allows the same expressivity of Turtle-star
         with the addition of allowing <a>embedded triples</a>
         and <a href="#grammar-production-annotation">annotations</a>
         within named graphs.</p>

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -698,9 +698,11 @@ SELECT ?claimer WHERE {
 
       The resulting RDF-star dataset consists of
       an empty default graph, and a graph named `http://example.org/#G`
-      with a single RDF-star triple:</p>
+      with two RDF-star triples:</p>
 
       <ol>
+        <li>(|b|, `http://example.org/#name`, `"Alice"`),
+          where |b| is a blank node</li>
         <li>((|b|, `http://example.org/#name`, `"Alice"`), `http://example.org/#statedBy`, `http://example.org/#bob/`),
           where |b| is a blank node</li>
       </ol>

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -356,7 +356,7 @@ SELECT ?claimer WHERE {
           </td>
         </tr>
         <tr id="grammar-production-embTriple">
-          <td>[27]</td>
+          <td>[27t]</td>
           <td>`embTriple`</td>
           <td>::=</td>
           <td>
@@ -368,7 +368,7 @@ SELECT ?claimer WHERE {
           </td>
         </tr>
         <tr id="grammar-production-embSubject">
-          <td>[28]</td>
+          <td>[28t]</td>
           <td>`embSubject`</td>
           <td>::=</td>
           <td>
@@ -378,7 +378,7 @@ SELECT ?claimer WHERE {
           </td>
         </tr>
         <tr id="grammar-production-embObject">
-          <td>[29]</td>
+          <td>[29t]</td>
           <td>`embObject`</td>
           <td>::=</td>
           <td>
@@ -389,7 +389,7 @@ SELECT ?claimer WHERE {
           </td>
         </tr>
         <tr id="grammar-production-annotation">
-          <td>[31]</td>
+          <td>[30t]</td>
           <td>`annotation`</td>
           <td>::=</td>
           <td>

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -482,7 +482,7 @@ SELECT ?claimer WHERE {
 
     <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
 
-    <p class="note">As with Turtle-star, the <a href="#grammar-production-embTriple">`embTriple`</a> and annotation <a href="#grammar-production-annotation">`annotation`</a> yield <a>RDF-star triples</a> which are not directly added to `curGraph`.</p>
+    <p class="note">As with Turtle-star, the <a href="#grammar-production-embTriple">`embTriple`</a> and <a href="#grammar-production-annotation">`annotation`</a> yield <a>RDF-star triples</a> which are not directly added to `curGraph`.</p>
     <p>A conforming TriG-star parser MUST parse any
       valid <strong>TriG document</strong> and any
       valid <a>Turtle-star document</a> in addition

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -411,7 +411,7 @@ SELECT ?claimer WHERE {
       </ul>
       <p>Additionally, the <a data-cite="TURTLE#curSubject">|curSubject|</a> can be bound to any <a>RDF-star term</a> (including an <a>embedded triple</a>).</p>
 
-      <p>A <dfn>Turtle-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|. The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>. The <a href="#grammar-production-object">`object`</a> and <a href="#grammar-production-embObject">`embObject`</a> productions set the |curObject|. Finishing the <a href="#grammar-production-object">`object`</a> production, an <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| is generated and added to the <a>RDF-star graph</a>.</p>
+      <p>A <dfn>Turtle-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|. The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>. The <a href="#grammar-production-object">`object`</a> and <a href="#grammar-production-embObject">`embObject`</a> productions set the |curObject|. Finishing the <a href="#grammar-production-object">`object`</a> production, an <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| is produced (added to the <a>RDF-star graph</a>).</p>
 
       <p>Beginning the <a href="#grammar-production-embTriple">`embTriple`</a> production records the |curSubject| and |curPredicate|. Finishing the <a href="#grammar-production-embTriple">`embTriple`</a> production yields the <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| and restores the recorded values of |curSubject| and |curPredicate|.</p>
 
@@ -473,11 +473,11 @@ SELECT ?claimer WHERE {
       which are not necessarily described within any specific graph,
       either named or default.</p>
 
-    <p>A <dfn>TriG-star document</dfn> defines an <a>RDF-star dataset</a> composed of
-      a single <a>default graph</a>, and zero or more <a>named graphs</a>,
+    <p>A <dfn>TriG-star document</dfn> defines an <a>RDF-star dataset</a>, composed of
+      a single <a>default graph</a> and zero or more <a>named graphs</a>,
       all of which are <a>RDF-star graphs</a>.</p>
 
-    <p>The TriG-star grammar contains exactly the same productions updates
+    <p>The TriG-star grammar contains exactly the same production updates
       described in <a href="#turtle-star-grammar" class="sectionRef"></a>.</p>
 
     <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
@@ -547,7 +547,7 @@ SELECT ?claimer WHERE {
       <h2>Parsing</h2>
       <p>In contrast to [[N-TRIPLES]], N-Triples-star allows recursion on the <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions.</p>
 
-      <p>An <dfn>N-Triples-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF-star triple</a> composed of a <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
+      <p>An <dfn>N-Triples-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF-star triple</a> composed of a <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a>, and <a href="#grammar-production-nt-object">`object`</a>.</p>
 
       <p>In addition to the <a data-cite="N-TRIPLES#sec-parsing-terms">Term Constructors</a> defined in [[N-TRIPLES]], an additional constructor is defined for <a href="#grammar-production-nt-embTriple">`embTriple`</a> of type <a>RDF-star triple</a> defined by the terms constructed for <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
 
@@ -562,8 +562,8 @@ SELECT ?claimer WHERE {
 
     <p class="note">As RDF-star describes <a>embedded triples</a> and not embedded quads, the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a> component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a> does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
 
-    <p>An <dfn>N-Quads-star document</dfn> defines an <a>RDF-star dataset</a> composed of
-      a single <a>default graph</a>, and zero or more <a>named graphs</a>,
+    <p>An <dfn>N-Quads-star document</dfn> defines an <a>RDF-star dataset</a>, composed of
+      a single <a>default graph</a> and zero or more <a>named graphs</a>,
       all of which are <a>RDF-star graphs</a>.</p>
 
     <p>A conforming N-Quads-star parser MUST parse any valid

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -403,7 +403,7 @@ SELECT ?claimer WHERE {
       <p class="note">The changes are that <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-object">`object`</a> productions have been extended to accept <a>embedded triples</a>, which are described by the new productions <a href="#grammar-production-embTriple">27</a> to <a href="#grammar-production-embObject">29</a>. Note that <a>embedded triples</a> accept a more restricted range of <a>subject</a> and <a>object</a> expressions than <a>asserted triples</a>. Additionally, the <a href="#grammar-production-objectList">`objectList`</a> production now accepts an optional <a href="#grammar-production-annotation">annotation</a> after each object.</p>
     </section>
 
-    <section>
+    <section id="turtle-star-parsing">
       <h2>Parsing</h2>
       <p>A Turtle-star parser is similar to a Turtle parser as defined in <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]], with an additional item in its state :</p>
       <ul>
@@ -411,7 +411,7 @@ SELECT ?claimer WHERE {
       </ul>
       <p>Additionally, the <a data-cite="TURTLE#curSubject">|curSubject|</a> can be bound to any <a>RDF-star term</a> (including an <a>embedded triple</a>).</p>
 
-      <p>A Turtle-star document defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|. The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>. The <a href="#grammar-production-object">`object`</a> and <a href="#grammar-production-embObject">`embObject`</a> productions set the |curObject|. Finishing the <a href="#grammar-production-object">`object`</a> production, an <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| is generated and added to the <a>RDF-star graph</a>.</p>
+      <p>A <dfn>Turtle-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|. The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>. The <a href="#grammar-production-object">`object`</a> and <a href="#grammar-production-embObject">`embObject`</a> productions set the |curObject|. Finishing the <a href="#grammar-production-object">`object`</a> production, an <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| is generated and added to the <a>RDF-star graph</a>.</p>
 
       <p>Beginning the <a href="#grammar-production-embTriple">`embTriple`</a> production records the |curSubject| and |curPredicate|. Finishing the <a href="#grammar-production-embTriple">`embTriple`</a> production yields the <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| and restores the recorded values of |curSubject| and |curPredicate|.</p>
 
@@ -419,10 +419,10 @@ SELECT ?claimer WHERE {
 
       <p>All other productions MUST be handled as specified by <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]], while still applying the changes above recursively.</p>
 
-      <section class="informative">
+      <section id="turtle-star-parsing-discussion" class="informative">
       <h2>Discussion</h2>
 
-      <p>This section describes parser behavior when parsing a Turtle-star document that contains <a>embedded triples</a> and <a href="#grammar-production-annotation">annotations</a>.</p>
+      <p>This section describes parser behavior when parsing a <a>Turtle-star document</a> that contains <a>embedded triples</a> and <a href="#grammar-production-annotation">annotations</a>.</p>
 
       <p>Consider a Turtle-star document that describes an RDF triple, and also uses that triple as an <a>embedded triple</a> as the subject of another RDF-star triple:</p>
 
@@ -462,7 +462,52 @@ SELECT ?claimer WHERE {
     </section>
   </section>
 
-    <section id="n-triples-star">
+  <section id="trig-star">
+    <h2>TriG-star</h2>
+
+    <p>This section describes TriG-star,
+      a minimal extension of the TriG format [[TRIG]]
+      using the same production updates described in <a href="#turtle-star" class="sectionRef"></a>.</p>
+
+    <p class="note">As RDF-star describes <a>embedded triples</a>,
+      which are not necessarily described within any specific graph,
+      either named or default.</p>
+
+    <p>A <dfn>TriG-star document</dfn> defines an <a>RDF-star dataset</a> composed of
+      a single <a>default graph</a>, and zero or more <a>named graphs</a>,
+      all of which are <a>RDF-star graphs</a>.</p>
+
+    <p>The TriG-star grammar contains exactly the same productions updates
+      described in <a href="#turtle-star-grammar" class="sectionRef"></a>.</p>
+
+    <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to the <a data-cite="TRIG#sec-parsing">TriG Parsing</a>.</p>
+
+    <p>A conforming TriG-star parser MUST parse any
+      valid <strong>TriG document</strong> and any
+      valid <a>Turtle-star document</a> in addition
+      to the <a href="#turtle-star-grammar">Turtle-star grammar</a> productions contained within a <a>named graph</a>.</p>
+
+    <section id="trig-star-discussion" class="informative">
+      <h3>Discussion</h3>
+
+      <p>TriG-star allows the same expresivity of Turtle-star with the addition of allowing <a>embedded triples</a> and <a href="#grammar-production-annotation">annotations</a> within named graphs.</p>
+
+      <pre class="example"
+           data-transform="updateExample"
+           data-content-type="text/turtle"
+           title="TriG-star annotated triples">
+      <!--
+        @base <http://example.org/> .
+        @prefix : <#> .
+        :G {
+          _:a :name "Alice" {| :statedBy :bob |} .
+        }
+      -->
+      </pre>
+    </section>
+  </section>
+
+  <section id="n-triples-star">
     <h2>N-Triples-star</h2>
 
     <p>This section describes N-Triples-star, a minimal extension of the N-Triples format [[N-TRIPLES]] allowing a <a>subject</a> or an <a>object</a> of an <a>RDF-star triple</a> to be an <a>embedded triple</a>.</p>
@@ -501,22 +546,22 @@ SELECT ?claimer WHERE {
       <h2>Parsing</h2>
       <p>In contrast to [[N-TRIPLES]], N-Triples-star allows recursion on the <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions.</p>
 
-      <p>An N-Triples-star document defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF-star triple</a> composed of a <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
+      <p>An <dfn>N-Triples-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF-star triple</a> composed of a <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
 
       <p>In addition to the <a data-cite="N-TRIPLES#sec-parsing-terms">Term Constructors</a> defined in [[N-TRIPLES]], an additional constructor is defined for <a href="#grammar-production-nt-embTriple">`embTriple`</a> of type <a>RDF-star triple</a> defined by the terms constructed for <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
 
     <p>All other productions MUST be handled as specified by <a data-cite="N-TRIPLES#sec-parsing-terms">Section 8.1 of the N-Triples specification</a> [[N-TRIPLES]], while still applying the changes above recursively.</p>
     </section>
-    </section>
+  </section>
 
-    <section id="n-quads-star">
+  <section id="n-quads-star">
     <h2>N-Quads-star</h2>
 
     <p>The [[N-QUADS]] format is extended to describe the N-Quads-star format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples-star Grammar</a>.</p>
 
     <p class="note">As RDF-star describes <a>embedded triples</a> and not embedded quads, the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a> component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a> does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
 
-    <p>An N-Quads-star document defines an <a>RDF-star dataset</a> composed of
+    <p>An <dfn>N-Quads-star document</dfn> defines an <a>RDF-star dataset</a> composed of
       a single <a>default graph</a>, and zero or more <a>named graphs</a>,
       all of which are <a>RDF-star graphs</a>.</p>
 

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -308,13 +308,135 @@ SELECT ?claimer WHERE {
 
   <section>
   <h2>Concrete Syntaxes</h2>
-    <section id="turtle-star">
+
+  <p>This section defines the following concrete syntaxes:</p>
+  <ul>
+    <li><a href="#n-triples-star" class="sectionRef"></a></li>
+    <li><a href="#n-quads-star" class="sectionRef"></a></li>
+    <li><a href="#turtle-star" class="sectionRef"></a></li>
+    <li><a href="#trig-star" class="sectionRef"></a></li>
+  </ul>
+
+  <p>Other specifications may define RDF-star concrete syntaxes.
+    In particular, syntaxes such as
+    RDF/XML [[RDF-SYNTAX-GRAMMAR]],
+    and JSON-LD [[JSON-LD]],
+    could be extended to support RDF-star.</p>
+
+  <section id="n-triples-star">
+    <h2>N-Triples-star</h2>
+
+    <p>This section describes N-Triples-star,
+      a minimal extension of the N-Triples format [[N-TRIPLES]]
+      allowing a <a>subject</a> or an <a>object</a>
+      of an <a>RDF-star triple</a> to be an <a>embedded triple</a>.</p>
+
+    <section id="n-triples-star-grammar">
+      <h2>Grammar</h2>
+      <p>N-Triples-star is defined to follow the same grammar as
+        the <a data-cite="N-TRIPLES#n-triples-grammar">N-Triples Grammar</a>,
+        except for the <a data-cite="XML#sec-notation"><abbr title="Extended Backus-Naur Form">EBNF</abbr> productions</a> specified below,
+        which replace the productions having the same number
+        (if any) in the original grammar.</p>
+
+      <table class="n-triples-star-ebnf">
+        <tbody id="grammar-productions" class="ebnf">
+          <tr id="grammar-production-nt-subject">
+            <td>[3]</td>
+            <td>`subject`</td>
+            <td>::=</td>
+            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
+          </tr>
+          <tr id="grammar-production-nt-object">
+            <td>[5]</td>
+            <td>`object`</td>
+            <td>::=</td>
+            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
+          </tr>
+          <tr id="grammar-production-nt-embTriple">
+            <td>[7t]</td>
+            <td>`embTriple`</td>
+            <td>::=</td>
+            <td>&quot;&lt;&lt;&quot; <a href="#grammar-production-nt-subject">subject</a> <a data-cite="N-TRIPLES#grammar-production-predicate">predicate</a> <a href="#grammar-production-nt-object">object</a> &quot;&gt;&gt;&quot;</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="note">The changes are
+        <a href="#grammar-production-nt-subject">`subject`</a>
+        and <a href="#grammar-production-nt-object">`object`</a> productions
+        have been extended to accept <a>embedded triples</a>,
+        which are described by the new production
+        <a href="#grammar-production-nt-embTriple">7</a>.</p>
+    </section>
+
+    <section id="n-triples-star-parsing">
+      <h2>Parsing</h2>
+      <p>In contrast to [[N-TRIPLES]],
+        N-Triples-star allows recursion on the
+        <a href="#grammar-production-nt-subject">`subject`</a>
+        and <a href="#grammar-production-nt-object">`object`</a> productions.</p>
+
+      <p>An <dfn>N-Triples-star document</dfn> defines an <a>RDF-star graph</a>
+        composed of a set of <a>RDF-star triples</a>.
+        The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production
+        produces an <a>RDF-star triple</a>
+        composed of a <a href="#grammar-production-nt-subject">`subject`</a>,
+        <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a>,
+        and <a href="#grammar-production-nt-object">`object`</a>.</p>
+
+      <p>In addition to the <a data-cite="N-TRIPLES#sec-parsing-terms">Term Constructors</a> defined in [[N-TRIPLES]],
+        an additional constructor is defined for <a href="#grammar-production-nt-embTriple">`embTriple`</a>
+        of type <a>RDF-star triple</a>
+        defined by the terms constructed
+        for <a href="#grammar-production-nt-subject">`subject`</a>,
+        <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a>,
+        and <a href="#grammar-production-nt-object">`object`</a>.</p>
+
+    <p>All other productions MUST be handled as specified by
+      <a data-cite="N-TRIPLES#sec-parsing-terms">Section 8.1 of the N-Triples specification</a> [[N-TRIPLES]],
+      while still applying the changes above recursively.</p>
+    </section>
+  </section>
+
+  <section id="n-quads-star">
+    <h2>N-Quads-star</h2>
+
+    <p>The [[N-QUADS]] format is extended to describe the
+      N-Quads-star format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples-star Grammar</a>.</p>
+
+    <p class="note">As RDF-star describes <a>embedded triples</a> and not embedded quads,
+      the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a>
+      component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a>
+      does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
+
+    <p>An <dfn>N-Quads-star document</dfn> defines an <a>RDF-star dataset</a>,
+      composed of a single <a>default graph</a>
+      and zero or more <a>named graphs</a>,
+      all of which are <a>RDF-star graphs</a>.</p>
+
+    <p>A conforming N-Quads-star parser MUST parse any valid
+      <strong>N-Quads document</strong> and additionally parse the 
+      <a href="#grammar-production-nt-subject"><code>subject</code></a> and 
+      <a href="#grammar-production-nt-object"><code>object</code></a> productions
+      from N-Triples-star to generate <a>RDF-star triples</a> which are
+      added to either the <a>default graph</a> or associated
+      <a>named graph</a>, as appropriate.</p>
+  </section>
+
+  <section id="turtle-star">
     <h2>Turtle-star</h2>
-    <p>In this section, we present Turtle-star, an extension of the Turtle format [[TURTLE]] allowing the representation of <a>RDF-star graphs</a>. For the sake of conciseness, we only describe here the differences between Turtle-star and Turtle.</p>
+    <p>In this section, we present Turtle-star,
+      an extension of the Turtle format [[TURTLE]]
+      allowing the representation of <a>RDF-star graphs</a>.
+      For the sake of conciseness,
+      we only describe here the differences between Turtle-star and Turtle.</p>
 
     <section id="turtle-star-grammar">
       <h2>Grammar</h2>
-      <p>Turtle-star is defined to follow the <a data-cite="TURTLE#h3_sec-grammar-grammar">same grammar</a> as Turtle, <em>except</em> for the <a data-cite="XML#sec-notation"><abbr title="Extended Backus-Naur Form">EBNF</abbr> productions</a> specified below, which replace the productions having the same number (if any) in the original grammar.</p>
+      <p>Turtle-star is defined to follow the <a data-cite="TURTLE#h3_sec-grammar-grammar">same grammar</a> as Turtle,
+        <em>except</em> for the <a data-cite="XML#sec-notation"><abbr title="Extended Backus-Naur Form">EBNF</abbr> productions</a> specified below,
+        which replace the productions having the same number (if any) in the original grammar.</p>
 
       <table class="grammar">
         <tr id="grammar-production-objectList">
@@ -400,31 +522,72 @@ SELECT ?claimer WHERE {
         </tr>
       </table>
 
-      <p class="note">The changes are that <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-object">`object`</a> productions have been extended to accept <a>embedded triples</a>, which are described by the new productions <a href="#grammar-production-embTriple">27</a> to <a href="#grammar-production-embObject">29</a>. Note that <a>embedded triples</a> accept a more restricted range of <a>subject</a> and <a>object</a> expressions than <a>asserted triples</a>. Additionally, the <a href="#grammar-production-objectList">`objectList`</a> production now accepts an optional <a href="#grammar-production-annotation">annotation</a> after each object.</p>
+      <p class="note">As with N-Triples-star,
+        the changes are that <a href="#grammar-production-subject">`subject`</a>
+        and <a href="#grammar-production-object">`object`</a> productions
+        have been extended to accept <a>embedded triples</a>,
+        which are described by the new productions <a href="#grammar-production-embTriple">27t</a>
+        to <a href="#grammar-production-embObject">30t</a>.
+        Note that <a>embedded triples</a> accept a more restricted range of
+        <a>subject</a> and <a>object</a> expressions
+        than <a>asserted triples</a>.
+        Additionally, the <a href="#grammar-production-objectList">`objectList`</a> production
+        now accepts an optional <a href="#grammar-production-annotation">annotation</a> after each <a>object</a>.</p>
     </section>
 
     <section id="turtle-star-parsing">
       <h2>Parsing</h2>
-      <p>A Turtle-star parser is similar to a Turtle parser as defined in <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]], with an additional item in its state :</p>
+      <p>A Turtle-star parser is similar to a Turtle parser
+        as defined in <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]],
+        with an additional item in its state :</p>
       <ul>
-        <li id="curObject"><a>RDF-star Term</a> |curObject| — The |curObject| is bound to the <a href="#grammar-production-embObject">`embObject`</a> production.</li>
+        <li id="curObject">
+          <a>RDF-star Term</a> |curObject| —
+          The |curObject| is bound to the <a href="#grammar-production-embObject">`embObject`</a> production.</li>
       </ul>
-      <p>Additionally, the <a data-cite="TURTLE#curSubject">|curSubject|</a> can be bound to any <a>RDF-star term</a> (including an <a>embedded triple</a>).</p>
+      <p>Additionally, the <a data-cite="TURTLE#curSubject">|curSubject|</a>
+        can be bound to any <a>RDF-star term</a>
+        (including an <a>embedded triple</a>).</p>
 
-      <p>A <dfn>Turtle-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="#grammar-production-subject">`subject`</a> and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|. The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>. The <a href="#grammar-production-object">`object`</a> and <a href="#grammar-production-embObject">`embObject`</a> productions set the |curObject|. Finishing the <a href="#grammar-production-object">`object`</a> production, an <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| is produced (added to the <a>RDF-star graph</a>).</p>
+      <p>A <dfn>Turtle-star document</dfn> defines an <a>RDF-star graph</a>
+        composed of a set of <a>RDF-star triples</a>.
+        The <a href="#grammar-production-subject">`subject`</a>
+        and <a href="#grammar-production-embSubject">`embSubject`</a> productions set the |curSubject|.
+        The <a data-cite="TURTLE#grammar-production-verb">`verb`</a> production
+        sets the <a data-cite="TURTLE#curPredicate">|curPredicate|</a>.
+        The <a href="#grammar-production-object">`object`</a>
+        and <a href="#grammar-production-embObject">`embObject`</a> productions
+        set the |curObject|.
+        Finishing the <a href="#grammar-production-object">`object`</a> production,
+        an <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| is produced
+        (added to the <a>RDF-star graph</a>).</p>
 
-      <p>Beginning the <a href="#grammar-production-embTriple">`embTriple`</a> production records the |curSubject| and |curPredicate|. Finishing the <a href="#grammar-production-embTriple">`embTriple`</a> production yields the <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject| and restores the recorded values of |curSubject| and |curPredicate|.</p>
+      <p>Beginning the <a href="#grammar-production-embTriple">`embTriple`</a> production
+        records the |curSubject| and |curPredicate|.
+        Finishing the <a href="#grammar-production-embTriple">`embTriple`</a> production
+        yields the <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject|
+        and restores the recorded values of |curSubject| and |curPredicate|.</p>
 
-      <p>Beginning the <a href="#grammar-production-annotation">`annotation`</a> production records the |curSubject| and |curPredicate|, and sets the |curSubject| to the <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject|. Finishing the <a href="#grammar-production-annotation">`annotation`</a> production restores the recorded values of |curSubject| and |curPredicate|.</p>
+      <p>Beginning the <a href="#grammar-production-annotation">`annotation`</a> production
+        records the |curSubject| and |curPredicate|,
+        and sets the |curSubject| to the <a>RDF-star triple</a> |curSubject| |curPredicate| |curObject|.
+        Finishing the <a href="#grammar-production-annotation">`annotation`</a> production
+        restores the recorded values of |curSubject| and |curPredicate|.</p>
 
-      <p>All other productions MUST be handled as specified by <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]], while still applying the changes above recursively.</p>
+      <p>All other productions MUST be handled as specified
+        by <a data-cite="TURTLE#h2_sec-parsing">Section 7 of the Turtle specification</a> [[TURTLE]],
+        while still applying the changes above recursively.</p>
 
       <section id="turtle-star-parsing-discussion" class="informative">
       <h2>Discussion</h2>
 
-      <p>This section describes parser behavior when parsing a <a>Turtle-star document</a> that contains <a>embedded triples</a> and <a href="#grammar-production-annotation">annotations</a>.</p>
+      <p>This section describes parser behavior when parsing
+        a <a>Turtle-star document</a> that contains <a>embedded triples</a>
+        and <a href="#grammar-production-annotation">annotations</a>.</p>
 
-      <p>Consider a Turtle-star document that describes an RDF triple, and also uses that triple as an <a>embedded triple</a> as the subject of another RDF-star triple:</p>
+      <p>Consider a Turtle-star document that describes an RDF triple,
+        and also uses that triple as an <a>embedded triple</a>
+        as the subject of another RDF-star triple:</p>
 
       <pre class="example" title="Turtle-star embedded triples"
            data-transform="updateExample"
@@ -437,14 +600,23 @@ SELECT ?claimer WHERE {
       -->
       </pre>
 
-      <p>The usual process of parsing a Turtle document applies with the addition of matching the embedded triple `&lt;&lt; _:a :name "Alice" >>` as part of the <a href="#grammar-production-subject">`subject`</a> production. The resulting RDF-star graph consists of two RDF-star triples:</p>
+      <p>The usual process of parsing a Turtle document
+        applies with the addition of matching the embedded triple
+        `&lt;&lt; _:a :name "Alice" >>`
+        as part of the <a href="#grammar-production-subject">`subject`</a> production.
+        The resulting RDF-star graph consists of two RDF-star triples:</p>
 
       <ol>
-        <li>(|b|, `http://example.org/#name`, `"Alice"`), where |b| is a blank node</li>
-        <li>((|b|, `http://example.org/#name`, `"Alice"`), `http://example.org/#statedBy`, `http://example.org/#bob/`), where |b| is the same blank node</li>
+        <li>(|b|, `http://example.org/#name`, `"Alice"`),
+          where |b| is a blank node</li>
+        <li>((|b|, `http://example.org/#name`, `"Alice"`), `http://example.org/#statedBy`, `http://example.org/#bob/`),
+          where |b| is the same blank node</li>
       </ol>
 
-      <p>Because the above example includes the triple (|b|, `http://example.org/#name`, `"Alice"`) as an asserted triple, the same RDF-star graph may also be represented by using the Turtle-star annotation syntax as follows:</p>
+      <p>Because the above example includes the triple (|b|, `http://example.org/#name`, `"Alice"`)
+        as an asserted triple,
+        the same RDF-star graph may also be represented
+        by using the Turtle-star annotation syntax as follows:</p>
 
       <pre class="example"
            data-transform="updateExample"
@@ -457,7 +629,13 @@ SELECT ?claimer WHERE {
       -->
       </pre>
 
-      <p>In this case, the <a href="#grammar-production-objectList">`objectList`</a> production matches the <a href="#grammar-production-annotation">`annotation`</a> production on `{| :source :bob |}` after parsing the <a href="#grammar-production-object">`object`</a> production on `"Alice"`. At this point, the |curSubject|, |curPredicate|, and |curObject| are saved, and a new RDF-star triple `_:a :name "Alice"` is created and used as |curSubject| while processing the <a href="#grammar-production-annotation">`annotation`</a> production.</p>
+      <p>In this case, the <a href="#grammar-production-objectList">`objectList`</a> production
+        matches the <a href="#grammar-production-annotation">`annotation`</a> production on `{| :source :bob |}`
+        after parsing the <a href="#grammar-production-object">`object`</a> production on `"Alice"`.
+        At this point, the |curSubject|, |curPredicate|, and |curObject| are saved,
+        and a new RDF-star triple `_:a :name "Alice"` is created
+        and used as |curSubject| while processing
+        the <a href="#grammar-production-annotation">`annotation`</a> production.</p>
       </section>
     </section>
   </section>
@@ -480,7 +658,9 @@ SELECT ?claimer WHERE {
     <p>The TriG-star grammar contains exactly the same production updates
       described in <a href="#turtle-star-grammar" class="sectionRef"></a>.</p>
 
-    <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
+    <p>TriG-star parsing uses the same updates described
+      in <a href="#turtle-star-parsing" class="sectionRef"></a>
+      as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
 
     <p class="note">As with Turtle-star,
       the <a href="#grammar-production-embTriple">`embTriple`</a>
@@ -498,7 +678,10 @@ SELECT ?claimer WHERE {
     <section id="trig-star-discussion" class="informative">
       <h3>Discussion</h3>
 
-      <p>TriG-star allows the same expresivity of Turtle-star with the addition of allowing <a>embedded triples</a> and <a href="#grammar-production-annotation">annotations</a> within named graphs.</p>
+      <p>TriG-star allows the same expresivity of Turtle-star
+        with the addition of allowing <a>embedded triples</a>
+        and <a href="#grammar-production-annotation">annotations</a>
+        within named graphs.</p>
 
       <pre class="example"
            data-transform="updateExample"
@@ -514,79 +697,6 @@ SELECT ?claimer WHERE {
       </pre>
     </section>
   </section>
-
-  <section id="n-triples-star">
-    <h2>N-Triples-star</h2>
-
-    <p>This section describes N-Triples-star, a minimal extension of the N-Triples format [[N-TRIPLES]] allowing a <a>subject</a> or an <a>object</a> of an <a>RDF-star triple</a> to be an <a>embedded triple</a>.</p>
-
-    <section id="n-triples-star-grammar">
-      <h2>Grammar</h2>
-      <p>N-Triples-star is defined to follow the same grammar as the <a data-cite="N-TRIPLES#n-triples-grammar">N-Triples Grammar</a>, except for the EBNF productions specified below, which replace the productions having the same number (if any) in the original grammar.</p>
-
-      <table class="n-triples-star-ebnf">
-        <tbody id="grammar-productions" class="ebnf">
-          <tr id="grammar-production-nt-subject">
-            <td>[3]</td>
-            <td><code>subject</code></td>
-            <td>::=</td>
-            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
-          </tr>
-          <tr id="grammar-production-nt-object">
-            <td>[5]</td>
-            <td><code>object</code></td>
-            <td>::=</td>
-            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
-          </tr>
-          <tr id="grammar-production-nt-embTriple">
-            <td>[7]</td>
-            <td><code>embTriple</code></td>
-            <td>::=</td>
-            <td>&quot;&lt;&lt;&quot; <a href="#grammar-production-nt-subject">subject</a> <a data-cite="N-TRIPLES#grammar-production-predicate">predicate</a> <a href="#grammar-production-nt-object">object</a> &quot;&gt;&gt;&quot;</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p class="note">As with Turtle-star, the changes are that <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions have been extended to accept <a>embedded triples</a>, which are described by the new production <a href="#grammar-production-nt-embTriple">7</a>. N-Triples-star does not include an <a href="#grammar-production-annotation">annotation</a> form.</p>
-    </section>
-
-    <section id="n-triples-star-parsing">
-      <h2>Parsing</h2>
-      <p>In contrast to [[N-TRIPLES]], N-Triples-star allows recursion on the <a href="#grammar-production-nt-subject">`subject`</a> and <a href="#grammar-production-nt-object">`object`</a> productions.</p>
-
-      <p>An <dfn>N-Triples-star document</dfn> defines an <a>RDF-star graph</a> composed of a set of <a>RDF-star triples</a>. The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production produces an <a>RDF-star triple</a> composed of a <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a>, and <a href="#grammar-production-nt-object">`object`</a>.</p>
-
-      <p>In addition to the <a data-cite="N-TRIPLES#sec-parsing-terms">Term Constructors</a> defined in [[N-TRIPLES]], an additional constructor is defined for <a href="#grammar-production-nt-embTriple">`embTriple`</a> of type <a>RDF-star triple</a> defined by the terms constructed for <a href="#grammar-production-nt-subject">`subject`</a>, <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a> and <a href="#grammar-production-nt-object">`object`</a>.</p>
-
-    <p>All other productions MUST be handled as specified by <a data-cite="N-TRIPLES#sec-parsing-terms">Section 8.1 of the N-Triples specification</a> [[N-TRIPLES]], while still applying the changes above recursively.</p>
-    </section>
-  </section>
-
-  <section id="n-quads-star">
-    <h2>N-Quads-star</h2>
-
-    <p>The [[N-QUADS]] format is extended to describe the N-Quads-star format using the same production updates described in the <a href="#n-triples-star-grammar">N-Triples-star Grammar</a>.</p>
-
-    <p class="note">As RDF-star describes <a>embedded triples</a> and not embedded quads, the <a data-cite="N-QUADS#grammar-production-graphLabel">`graphLabel`</a> component of an N-Quads <a data-cite="N-QUADS#grammar-production-statement">`statement`</a> does not apply to the <a href="#grammar-production-nt-embTriple">`embTriple`</a> component.</p>
-
-    <p>An <dfn>N-Quads-star document</dfn> defines an <a>RDF-star dataset</a>, composed of
-      a single <a>default graph</a> and zero or more <a>named graphs</a>,
-      all of which are <a>RDF-star graphs</a>.</p>
-
-    <p>A conforming N-Quads-star parser MUST parse any valid
-      <strong>N-Quads document</strong> and additionally parse the 
-      <a href="#grammar-production-nt-subject"><code>subject</code></a> and 
-      <a href="#grammar-production-nt-object"><code>object</code></a> productions
-      from N-Triples-star to generate <a>RDF-star triples</a> which are
-      added to either the <a>default graph</a> or associated
-      <a>named graph</a>, as appropriate.</p>
-  </section>
-
-    <section class="informative">
-      <h2>Other Concrete Syntaxes</h2>
-
-      <p>While this document specifies a small number of concrete syntaxes, nothing prevents other concrete syntaxes of RDF-star from being proposed. In particular, other existing concrete syntaxes for RDF, such as RDF/XML [[RDF-SYNTAX-GRAMMAR]], could be extended to support RDF-star.</p>
-    </section>
 
   </section>
 

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -695,6 +695,15 @@ SELECT ?claimer WHERE {
         }
       -->
       </pre>
+
+      The resulting RDF-star dataset consists of
+      an empty default graph, and a graph named `http://example.org/#G`
+      with a single RDF-star triple:</p>
+
+      <ol>
+        <li>((|b|, `http://example.org/#name`, `"Alice"`), `http://example.org/#statedBy`, `http://example.org/#bob/`),
+          where |b| is a blank node</li>
+      </ol>
     </section>
   </section>
 

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -482,6 +482,7 @@ SELECT ?claimer WHERE {
 
     <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
 
+    <p class="note">As with Turtle-star, the <a href="#grammar-production-embTriple">`embTriple`</a> and annotation <a href="#grammar-production-annotation">`annotation`</a> yield <a>RDF-star triples</a> which are not directly added to `curGraph`.</p>
     <p>A conforming TriG-star parser MUST parse any
       valid <strong>TriG document</strong> and any
       valid <a>Turtle-star document</a> in addition

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -1831,11 +1831,11 @@ SELECT ?claimer WHERE {
 
       <p>We consider six <a>IRIs</a> |ST:subject term|, |PT:predicate term|, |OT:object term|, |SS:subject string|, |PS:predicate string| and |OS:object string| that will have a special meaning in our mapping.</p>
 
-      <p>We define a mapping |L| that maps any <a>IRI</a> or <a>literal</a> |t| to a literal with <ul>
+      <p>We define a mapping |L| that maps any <a>IRI</a> or <a>literal</a> |t| to a literal with:</p>
+      <ul>
         <li>`xsd:string` as its <a>datatype</a>, and</li>
         <li>the <a data-cite="N-TRIPLES#canonical-ntriples">canonical N-Triples</a> representation of |t| as its <a>lexical form</a> [[N-TRIPLES]]. If |t| is itself a literal with the `xsd:string` <a>datatype</a>, the representation MUST be a <a>simple literal</a>.</li>
       </ul>
-      </p>
 
       <p>Given an <a>RDF-star graph</a> |G|, the following steps transform it into an <a>RDF graph</a> that we call |unstar|(|G|).</p>
 

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -469,9 +469,9 @@ SELECT ?claimer WHERE {
       a minimal extension of the TriG format [[TRIG]]
       using the same production updates described in <a href="#turtle-star" class="sectionRef"></a>.</p>
 
-    <p class="note">As RDF-star describes <a>embedded triples</a>,
-      which are not necessarily described within any specific graph,
-      either named or default.</p>
+    <p class="note">RDF-star describes <a>embedded triples</a>,
+      which are not necessarily present in any <a>named graph</a>,
+      or within the <a>default graph</a>.</p>
 
     <p>A <dfn>TriG-star document</dfn> defines an <a>RDF-star dataset</a>, composed of
       a single <a>default graph</a> and zero or more <a>named graphs</a>,
@@ -482,7 +482,14 @@ SELECT ?claimer WHERE {
 
     <p>TriG-star parsing uses the same updates described in <a href="#turtle-star-parsing" class="sectionRef"></a> as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
 
-    <p class="note">As with Turtle-star, the <a href="#grammar-production-embTriple">`embTriple`</a> and <a href="#grammar-production-annotation">`annotation`</a> yield <a>RDF-star triples</a> which are not directly added to `curGraph`.</p>
+    <p class="note">As with Turtle-star,
+      the <a href="#grammar-production-embTriple">`embTriple`</a>
+      and <a href="#grammar-production-annotation">`annotation`</a>
+      are used to set either the |curSubject| or |curObject|,
+      and do not directly add the associated <a>embedded triple</a> to |curGraph|.
+      Subsequent productions which use either |curSubject| or |curObject|
+      may result in adding triples |curGraph|.</p>
+
     <p>A conforming TriG-star parser MUST parse any
       valid <strong>TriG document</strong> and any
       valid <a>Turtle-star document</a> in addition

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -315,14 +315,14 @@ SELECT ?claimer WHERE {
     <li><a href="#n-quads-star" class="sectionRef"></a></li>
     <li><a href="#turtle-star" class="sectionRef"></a></li>
     <li><a href="#trig-star" class="sectionRef"></a></li>
+    <li><a href="#other-concrete-syntaxes" class="sectionRef"></a></li>
   </ul>
 
-  <p>Other specifications may define RDF-star concrete syntaxes.
-    In particular, syntaxes such as
-    RDF/XML [[RDF-SYNTAX-GRAMMAR]],
-    and JSON-LD [[JSON-LD]],
-    could be extended to support RDF-star.</p>
-
+  <p>
+    Changes for SPARQL-star are given in
+    <a href="#sparql-star-grammar" class="sectionRef"></a>
+    and the changes for the result set formats in
+    <a href="#query-result-formats" class="sectionRef"></a>.</p>
   <section id="n-triples-star">
     <h2>N-Triples-star</h2>
 
@@ -707,6 +707,16 @@ SELECT ?claimer WHERE {
           where |b| is the same blank node</li>
       </ol>
     </section>
+  </section>
+
+  <section id="other-concrete-syntaxes" class="informative">
+    <h2>Other Concrete Syntaxes</h2>
+
+    <p>While this document specifies a small number of concrete syntaxes,
+      nothing prevents other concrete syntaxes of RDF-star from being proposed.       In particular, syntaxes such as
+      RDF/XML [[RDF-SYNTAX-GRAMMAR]],
+      and JSON-LD [[JSON-LD]],
+      could be extended to support RDF-star.</p>
   </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -95,6 +95,8 @@
           <li>Test suites<ul>
             <li><a href="tests/turtle/eval/manifest.html">Turtle-star Evaluation</a></li>
             <li><a href="tests/turtle/syntax/manifest.html">Turtle-star Syntax</a></li>
+            <li><a href="tests/trig/eval/manifest.html">TriG-star Evaluation</a></li>
+            <li><a href="tests/trig/syntax/manifest.html">TriG-star Syntax</a></li>
             <li><a href="tests/nt/syntax/manifest.html">N-Triples-star Syntax</a></li>
             <li><a href="tests/semantics/manifest.html">Semantics</a></li>
             <li><a href="tests/sparql/syntax/manifest.html">SPARQL-star Syntax</a></li>

--- a/reports/Rakefile
+++ b/reports/Rakefile
@@ -15,6 +15,8 @@ TEST_PARTIALS = %w{
   semantics
   sparql/syntax
   sparql/eval
+  trig/syntax
+  trig/eval
   turtle/syntax
   turtle/eval
 }

--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -112,8326 +112,103 @@
   },
   "@id": "",
   "@type": [
-    "Software",
-    "doap:Project"
+    "doap:Project",
+    "Software"
+  ],
+  "name": "RDF-star",
+  "assertions": [
+    "eye-earl.ttl",
+    "ruby-sparql.ttl",
+    "ruby-turtle.ttl"
   ],
   "generatedBy": {
     "@id": "https://rubygems.org/gems/earl-report",
     "@type": [
-      "Software",
-      "doap:Project"
+      "doap:Project",
+      "Software"
     ],
+    "name": "earl-report",
+    "language": "Ruby",
     "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
+    "shortdesc": "Earl Report summary generator",
+    "release": {
+      "@id": "https://github.com/gkellogg/earl-report/tree/0.7.0",
+      "@type": "doap:Version",
+      "name": "earl-report-0.7.0",
+      "revision": "0.7.0",
+      "doap:created": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-03-25"
+      }
+    },
+    "homepage": "https://github.com/gkellogg/earl-report",
+    "license": "http://unlicense.org",
     "developer": [
       {
         "@id": "https://greggkellogg.net/foaf#me",
         "@type": [
-          "foaf:Person",
-          "Assertor"
+          "Assertor",
+          "foaf:Person"
         ],
-        "foaf:homepage": "https://greggkellogg.net/",
-        "foaf:name": "Gregg Kellogg"
+        "foaf:name": "Gregg Kellogg",
+        "foaf:homepage": "https://greggkellogg.net/"
       }
-    ],
-    "language": "Ruby",
-    "shortdesc": "Earl Report summary generator",
-    "name": "earl-report",
-    "homepage": "https://github.com/gkellogg/earl-report",
-    "release": {
-      "@id": "https://github.com/gkellogg/earl-report/tree/0.7.0",
-      "@type": "doap:Version",
-      "doap:created": {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2021-03-25"
-      },
-      "name": "earl-report-0.7.0",
-      "revision": "0.7.0"
-    },
-    "license": "http://unlicense.org"
+    ]
   },
-  "assertions": [
-    "ruby-turtle.ttl",
-    "ruby-sparql.ttl",
-    "eye-earl.ttl"
-  ],
   "entries": [
     {
-      "@id": "https://w3c.github.io/rdf-star/tests/semantics#manifest",
+      "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#manifest",
       "@type": [
-        "mf:Manifest",
-        "Report"
+        "Report",
+        "mf:Manifest"
       ],
+      "rdfs:label": "N-Triples-star Syntax Tests",
       "entries": [
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
           "@type": [
             "TestCriterion",
-            "mf:PositiveEntailmentTest",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl",
-          "rdfs:comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model.",
-          "mf:entailmentRegime": "simple",
-          "title": "all-identical-embedded-triples-are-the-same",
+          "title": "N-Triples-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt",
           "assertions": [
             {
-              "@id": "_:b253",
+              "@id": "_:b1171",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b254",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
               "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b170",
-              "@type": "Assertion",
               "result": {
-                "@id": "_:b171",
+                "@id": "_:b1172",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b195",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b196",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test005.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "rdfs:comment": "This test ensures that other entailments are not spurious.",
-          "mf:entailmentRegime": "simple",
-          "title": "embedded-triples-no-spurious",
-          "assertions": [
-            {
-              "@id": "_:b53",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b54",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b443",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b444",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b49",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b50",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
-          "mf:entailmentRegime": "simple",
-          "title": "bnodes-in-embedded-subject",
-          "assertions": [
-            {
-              "@id": "_:b2",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b3",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b804",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b398",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b619",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b620",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
-          "mf:entailmentRegime": "simple",
-          "title": "bnodes-in-embedded-object",
-          "assertions": [
-            {
-              "@id": "_:b897",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b703",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1002",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b202",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1119",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b101",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
-          "mf:entailmentRegime": "simple",
-          "title": "bnodes-in-embedded-subject-and-object",
-          "assertions": [
-            {
-              "@id": "_:b420",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b52",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b348",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b349",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b921",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b738",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "rdfs:comment": "The same bnode can not match different embedded terms.",
-          "mf:entailmentRegime": "simple",
-          "title": "bnodes-in-embedded-subject-and-object-fail",
-          "assertions": [
-            {
-              "@id": "_:b879",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b273",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b574",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b575",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1099",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1100",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
-          "rdfs:comment": "Identical embedded term can be replaced by the same fresh bnode multiple times.",
-          "mf:entailmentRegime": "simple",
-          "title": "same-bnode-same-embedded-term",
-          "assertions": [
-            {
-              "@id": "_:b59",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b60",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b410",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b411",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1059",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b808",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
-          "rdfs:comment": "Different bnodes can match identical embedded terms.",
-          "mf:entailmentRegime": "simple",
-          "title": "different-bnodes-same-embedded-term",
-          "assertions": [
-            {
-              "@id": "_:b1072",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b431",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b689",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b219",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b603",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b604",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
-          "mf:entailmentRegime": "simple",
-          "title": "constrained-bnodes-in-embedded-subject",
-          "assertions": [
-            {
-              "@id": "_:b495",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b496",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b475",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b476",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b462",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b463",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
-          "mf:entailmentRegime": "simple",
-          "title": "constrained-bnodes-in-embedded-object",
-          "assertions": [
-            {
-              "@id": "_:b486",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b189",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b503",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b42",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b704",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b705",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "rdfs:comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
-          "mf:entailmentRegime": "simple",
-          "title": "constrained-bnodes-in-embedded-fail",
-          "assertions": [
-            {
-              "@id": "_:b1094",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1017",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b556",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b557",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b601",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b92",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl",
-          "rdfs:comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
-          "mf:entailmentRegime": "simple",
-          "title": "constrained-bnodes-on-literal",
-          "assertions": [
-            {
-              "@id": "_:b1008",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b474",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1113",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b307",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b45",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b46",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "mf:result": {
-            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-            "@value": "false"
-          },
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl",
-          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
-          "mf:entailmentRegime": "RDF",
-          "title": "malformed-literal-control",
-          "assertions": [
-            {
-              "@id": "_:b910",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b252",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b729",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b730",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b708",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b709",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "mf:result": {
-            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-            "@value": "false"
-          },
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "rdfs:comment": "Malformed literals are allowed when embedded.",
-          "mf:entailmentRegime": "RDF",
-          "title": "malformed-literal",
-          "assertions": [
-            {
-              "@id": "_:b811",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b812",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b645",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b335",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b596",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b379",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "rdfs:comment": "Malformed literals are allowed when embedded.",
-          "mf:entailmentRegime": "RDF",
-          "title": "malformed-literal-accepted",
-          "assertions": [
-            {
-              "@id": "_:b567",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b568",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b740",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b483",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b697",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b698",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "rdfs:comment": "Embedded malformed literals do not lead to spurious entailment.",
-          "mf:entailmentRegime": "RDF",
-          "title": "malformed-literal-no-spurious",
-          "assertions": [
-            {
-              "@id": "_:b314",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b315",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b733",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b734",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b158",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b159",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "rdfs:comment": "Malformed literals can not be replaced by blank nodes.",
-          "mf:entailmentRegime": "RDF",
-          "title": "malformed-literal-bnode",
-          "assertions": [
-            {
-              "@id": "_:b666",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b667",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b887",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b888",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b999",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b450",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl",
-          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
-          "mf:entailmentRegime": "RDF",
-          "title": "opaque-literal-control",
-          "assertions": [
-            {
-              "@id": "_:b685",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b686",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b127",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b128",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b414",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b415",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl",
-          "rdfs:comment": "Embedded literals are opaque, even when their datatype is recognized.",
-          "mf:entailmentRegime": "RDF",
-          "title": "opaque-literal",
-          "assertions": [
-            {
-              "@id": "_:b448",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b449",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b368",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b369",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b82",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b83",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl",
-          "rdfs:comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
-          "mf:entailmentRegime": "RDF",
-          "title": "opaque-language-string-control",
-          "assertions": [
-            {
-              "@id": "_:b901",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b477",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b605",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b606",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b283",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b72",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl",
-          "rdfs:comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
-          "mf:entailmentRegime": "RDF",
-          "title": "opaque-language-string",
-          "assertions": [
-            {
-              "@id": "_:b117",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b118",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b397",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b166",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b830",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b831",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl",
-          "rdfs:comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
-          "mf:entailmentRegime": "RDFS-Plus",
-          "title": "opaque-iri-control",
-          "assertions": [
-            {
-              "@id": "_:b800",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b380",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1082",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b824",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b586",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b587",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/superman.ttl",
-          "rdfs:comment": "Embedded IRIs are opaque.",
-          "mf:entailmentRegime": "RDFS-Plus",
-          "title": "opaque-iri",
-          "assertions": [
-            {
-              "@id": "_:b359",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b360",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b277",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b278",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b570",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b571",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "rdfs:comment": "Embedded triples are not asserted.",
-          "mf:entailmentRegime": "simple",
-          "title": "embedded-not-asserted",
-          "assertions": [
-            {
-              "@id": "_:b762",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b130",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b23",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b24",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b537",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b532",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "rdfs:comment": "Annotated triples are asserted.",
-          "mf:entailmentRegime": "simple",
-          "title": "annotated-asserted",
-          "assertions": [
-            {
-              "@id": "_:b880",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b615",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b560",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b561",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1079",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b468",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "rdfs:comment": "Annotation are about the annotated triple.",
-          "mf:entailmentRegime": "simple",
-          "title": "annotation",
-          "assertions": [
-            {
-              "@id": "_:b533",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b534",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b95",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b96",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b727",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b728",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveEntailmentTest",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl",
-          "rdfs:comment": "Annotation is the same as separate assertions.",
-          "mf:entailmentRegime": "simple",
-          "title": "annotation-unfolded",
-          "assertions": [
-            {
-              "@id": "_:b911",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b912",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b111",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b112",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b792",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b790",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        }
-      ],
-      "rdfs:label": "RDF-star Semantics tests",
-      "rdfs:seeAlso": {
-        "@id": "https://w3c.github.io/rdf-star/tests/semantics/README"
-      }
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl",
-          "title": "Turtle-star - subject embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b1112",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b172",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b538",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b539",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b769",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b770",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl",
-          "title": "Turtle-star - object embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b1049",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b637",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b902",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b852",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b739",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b292",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl",
-          "title": "Turtle-star - blank node label",
-          "assertions": [
-            {
-              "@id": "_:b377",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b35",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b86",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b87",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b464",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b465",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl",
-          "title": "Turtle-star - blank node labels",
-          "assertions": [
-            {
-              "@id": "_:b1085",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b952",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1031",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b473",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b851",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b805",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl",
-          "title": "Turtle-star - Annotation form",
-          "assertions": [
-            {
-              "@id": "_:b535",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b536",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b989",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b289",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1105",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b711",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl",
-          "title": "Turtle-star - Annotation example",
-          "assertions": [
-            {
-              "@id": "_:b66",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b67",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b782",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b783",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1043",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b635",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl",
-          "title": "Turtle-star - Annotation - predicate and object lists",
-          "assertions": [
-            {
-              "@id": "_:b918",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b573",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b25",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b26",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b517",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b518",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl",
-          "title": "Turtle-star - Annotation - nested",
-          "assertions": [
-            {
-              "@id": "_:b775",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b731",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b926",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b505",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b856",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b372",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl",
-          "title": "Turtle-star - Annotation object list",
-          "assertions": [
-            {
-              "@id": "_:b402",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b403",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1106",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b933",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b437",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b438",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl",
-          "title": "Turtle-star - Annotation with embedding",
-          "assertions": [
-            {
-              "@id": "_:b756",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b38",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b76",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b77",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b941",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b942",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl",
-          "title": "Turtle-star - Annotation on triple with embedded subject",
-          "assertions": [
-            {
-              "@id": "_:b187",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b188",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1111",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b207",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1080",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1081",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl",
-          "title": "Turtle-star - Annotation on triple with embedded object",
-          "assertions": [
-            {
-              "@id": "_:b516",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b44",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b664",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b653",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b525",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b526",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        }
-      ],
-      "rdfs:label": "Turtle-star Evaluation Tests"
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq",
-          "title": "SPARQL-star - subject embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b696",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b668",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1065",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1038",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b931",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b378",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq",
-          "title": "SPARQL-star - object embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b527",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b528",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b669",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b670",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b427",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b428",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq",
-          "title": "SPARQL-star - subject embedded triple - vars",
-          "assertions": [
-            {
-              "@id": "_:b721",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b722",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b137",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b138",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b758",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b710",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq",
-          "title": "SPARQL-star - object embedded triple - vars",
-          "assertions": [
-            {
-              "@id": "_:b1068",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b859",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b312",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b313",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b997",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b998",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq",
-          "title": "SPARQL-star - Embedded triple in VALUES",
-          "assertions": [
-            {
-              "@id": "_:b1066",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b97",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b389",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b168",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b451",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b452",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq",
-          "title": "SPARQL-star - Embedded triple in CONSTRUCT",
-          "assertions": [
-            {
-              "@id": "_:b898",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b554",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
               "@id": "_:b957",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b401",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b265",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b266",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq",
-          "title": "SPARQL-star - Embedded triples in CONSTRUCT WHERE",
-          "assertions": [
-            {
-              "@id": "_:b661",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b662",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b777",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b778",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b846",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b847",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq",
-          "title": "SPARQL-star - embedded triple inside blankNodePropertyList",
-          "assertions": [
-            {
-              "@id": "_:b395",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b33",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b947",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b342",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b860",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b861",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq",
-          "title": "SPARQL-star - embedded triple inside collection",
-          "assertions": [
-            {
-              "@id": "_:b506",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b507",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1039",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b784",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b131",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b7",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq",
-          "title": "SPARQL-star - nested embedded triple, subject position",
-          "assertions": [
-            {
-              "@id": "_:b1019",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b827",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b78",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b79",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1084",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b948",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq",
-          "title": "SPARQL-star - nested embedded triple, object position",
-          "assertions": [
-            {
-              "@id": "_:b88",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b89",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b925",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b917",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b190",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b191",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq",
-          "title": "SPARQL-star - compound forms",
-          "assertions": [
-            {
-              "@id": "_:b816",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b331",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b837",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b786",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b723",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b724",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq",
-          "title": "SPARQL-star - blank node subject",
-          "assertions": [
-            {
-              "@id": "_:b613",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b614",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b135",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b136",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b498",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b499",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq",
-          "title": "SPARQL-star - blank node object",
-          "assertions": [
-            {
-              "@id": "_:b767",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b768",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b845",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b497",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b223",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b224",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq",
-          "title": "SPARQL-star - blank node",
-          "assertions": [
-            {
-              "@id": "_:b511",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b512",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b687",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b688",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b853",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b854",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq",
-          "title": "SPARQL-star - Annotation form",
-          "assertions": [
-            {
-              "@id": "_:b706",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b707",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1027",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1000",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b974",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b975",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq",
-          "title": "SPARQL-star - Annotation example",
-          "assertions": [
-            {
-              "@id": "_:b650",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b651",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1097",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b789",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b798",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b799",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq",
-          "title": "SPARQL-star - Annotation example",
-          "assertions": [
-            {
-              "@id": "_:b965",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b453",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1037",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1032",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b493",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b494",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq",
-          "title": "SPARQL-star - Annotation with embedding",
-          "assertions": [
-            {
-              "@id": "_:b1016",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b914",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b55",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b56",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b269",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b270",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq",
-          "title": "SPARQL-star - Annotation on triple with embedded object",
-          "assertions": [
-            {
-              "@id": "_:b943",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b850",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b712",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b64",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b175",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b176",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq",
-          "title": "SPARQL-star - Annotation with path",
-          "assertions": [
-            {
-              "@id": "_:b1007",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b598",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1022",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b167",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b84",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b85",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq",
-          "title": "SPARQL-star - Annotation with nested path",
-          "assertions": [
-            {
-              "@id": "_:b233",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b234",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b338",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b339",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b125",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b126",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq",
-          "title": "SPARQL-star - Annotation in CONSTRUCT ",
-          "assertions": [
-            {
-              "@id": "_:b1053",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b838",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b771",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b772",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b408",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b409",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq",
-          "title": "SPARQL-star - Annotation in CONSTRUCT WHERE",
-          "assertions": [
-            {
-              "@id": "_:b364",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b365",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1060",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b153",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b973",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b346",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq",
-          "title": "SPARQL-star - Expressions - Embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b520",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b521",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b796",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b797",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b27",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b28",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq",
-          "title": "SPARQL-star - Expressions - Embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b1029",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b630",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b754",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b597",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b855",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b821",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq",
-          "title": "SPARQL-star - Expressions - Functions",
-          "assertions": [
-            {
-              "@id": "_:b972",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b485",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1071",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b978",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b350",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b287",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq",
-          "title": "SPARQL-star - Expressions - TRIPLE",
-          "assertions": [
-            {
-              "@id": "_:b874",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b875",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b249",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b250",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b815",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b326",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq",
-          "title": "SPARQL-star - Expressions - Functions",
-          "assertions": [
-            {
-              "@id": "_:b725",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b726",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b509",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b510",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b755",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b658",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveSyntaxTest11"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq",
-          "title": "SPARQL-star - Expressions - BIND - CONSTRUCT",
-          "assertions": [
-            {
-              "@id": "_:b1011",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1012",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b876",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b877",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b36",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b37",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq",
-          "title": "SPARQL-star - bad - embedded triple as predicate",
-          "assertions": [
-            {
-              "@id": "_:b694",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b695",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b822",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b785",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b230",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b231",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq",
-          "title": "SPARQL-star - bad - embedded triple outside triple",
-          "assertions": [
-            {
-              "@id": "_:b1013",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1014",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b817",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b737",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b267",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b268",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq",
-          "title": "SPARQL-star - bad - collection list in embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b1009",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b939",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b958",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b30",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b396",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b310",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq",
-          "title": "SPARQL-star - bad - literal in subject position of embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b90",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b91",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b412",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b413",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b523",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b524",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq",
-          "title": "SPARQL-star - bad - blank node  as predicate in embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b200",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b201",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b636",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b513",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1096",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b757",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq",
-          "title": "SPARQL-star - bad - compound blank node expression",
-          "assertions": [
-            {
-              "@id": "_:b62",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b63",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b470",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b471",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1107",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b839",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq",
-          "title": "SPARQL-star - bad - incomplete embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b522",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b184",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b644",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b519",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b966",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b542",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq",
-          "title": "SPARQL-star - bad - quad embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b717",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b718",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b766",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b515",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b488",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b489",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq",
-          "title": "SPARQL-star - bad - variable in embedded triple in VALUES ",
-          "assertions": [
-            {
-              "@id": "_:b356",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b357",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b889",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b436",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b182",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b169",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq",
-          "title": "SPARQL-star - bad - blank node in embedded triple in VALUES ",
-          "assertions": [
-            {
-              "@id": "_:b1061",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b681",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b806",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b177",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b454",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b455",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq",
-          "title": "SPARQL-star - bad - empty annotation",
-          "assertions": [
-            {
-              "@id": "_:b868",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b869",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b979",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b550",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1050",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1051",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq",
-          "title": "SPARQL-star - bad - triples in annotation",
-          "assertions": [
-            {
-              "@id": "_:b565",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b318",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1003",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b229",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b197",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b198",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq",
-          "title": "SPARQL-star - bad - path - seq",
-          "assertions": [
-            {
-              "@id": "_:b1045",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b748",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b779",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b780",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1018",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b980",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq",
-          "title": "SPARQL-star - bad - path - alt",
-          "assertions": [
-            {
-              "@id": "_:b210",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b211",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b308",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b309",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b113",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b114",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq",
-          "title": "SPARQL-star - bad - path - p*",
-          "assertions": [
-            {
-              "@id": "_:b340",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b341",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b930",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b391",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b750",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b751",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq",
-          "title": "SPARQL-star - bad - path - p+",
-          "assertions": [
-            {
-              "@id": "_:b466",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b467",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b608",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b57",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b675",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b676",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq",
-          "title": "SPARQL-star - bad - path - p?",
-          "assertions": [
-            {
-              "@id": "_:b1109",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b873",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1030",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b829",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b74",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b75",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq",
-          "title": "SPARQL-star - bad - path in CONSTRUCT",
-          "assertions": [
-            {
-              "@id": "_:b920",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b203",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b344",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b345",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b742",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b351",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq",
-          "title": "SPARQL-star - bad - path in CONSTRUCT",
-          "assertions": [
-            {
-              "@id": "_:b1122",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b631",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b655",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b632",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b279",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b145",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru",
-          "title": "SPARQL-star - update",
-          "assertions": [
-            {
-              "@id": "_:b208",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b209",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b922",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b399",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1064",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b29",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru",
-          "title": "SPARQL-star - update",
-          "assertions": [
-            {
-              "@id": "_:b305",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b306",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b599",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b134",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b370",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b371",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru",
-          "title": "SPARQL-star - update",
-          "assertions": [
-            {
-              "@id": "_:b280",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b281",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b591",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b592",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b916",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b883",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru",
-          "title": "SPARQL-star - update with embedding",
-          "assertions": [
-            {
-              "@id": "_:b903",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b284",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b400",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b183",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b508",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b343",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru",
-          "title": "SPARQL-star - update with embedded object",
-          "assertions": [
-            {
-              "@id": "_:b1093",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1090",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1121",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b971",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b713",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b328",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru",
-          "title": "SPARQL-star - update with annotation template",
-          "assertions": [
-            {
-              "@id": "_:b1040",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b119",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b639",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b640",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b31",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b32",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru",
-          "title": "SPARQL-star - update with annotation, template and pattern",
-          "assertions": [
-            {
-              "@id": "_:b162",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b146",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1056",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1046",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b647",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b648",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-          "@type": [
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru",
-          "title": "SPARQL-star - update DATA with annotation",
-          "assertions": [
-            {
-              "@id": "_:b1075",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b987",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b659",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b660",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b915",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b222",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru",
-          "title": "SPARQL-star - update - bad syntax",
-          "assertions": [
-            {
-              "@id": "_:b919",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b251",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b884",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b885",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b848",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b849",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru",
-          "title": "SPARQL-star - update - bad syntax",
-          "assertions": [
-            {
-              "@id": "_:b423",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b424",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b17",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b18",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1092",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b367",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru",
-          "title": "SPARQL-star - update - bad syntax",
-          "assertions": [
-            {
-              "@id": "_:b1095",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b690",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b892",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b893",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1073",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b969",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru",
-          "title": "SPARQL-star - update - bad syntax",
-          "assertions": [
-            {
-              "@id": "_:b787",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b788",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1089",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b578",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b584",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b248",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        }
-      ],
-      "rdfs:label": "SPARQL-star Syntax Tests"
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl",
-          "title": "Turtle-star - subject embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b321",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b322",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b801",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b802",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b10",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b11",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl",
-          "title": "Turtle-star - object embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b274",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b275",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b682",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b320",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b383",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b384",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl",
-          "title": "Turtle-star - embedded triple inside blankNodePropertyList",
-          "assertions": [
-            {
-              "@id": "_:b579",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b580",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b679",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b680",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b932",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b116",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl",
-          "title": "Turtle-star - embedded triple inside collection",
-          "assertions": [
-            {
-              "@id": "_:b1103",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b214",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1116",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b622",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b456",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b457",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl",
-          "title": "Turtle-star - nested embedded triple, subject position",
-          "assertions": [
-            {
-              "@id": "_:b1102",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1055",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1028",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b555",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b882",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b430",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl",
-          "title": "Turtle-star - nested embedded triple, object position",
-          "assertions": [
-            {
-              "@id": "_:b818",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b819",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b760",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b761",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b602",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b543",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl",
-          "title": "Turtle-star - compound forms",
-          "assertions": [
-            {
-              "@id": "_:b1035",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1036",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b300",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b301",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b950",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b807",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl",
-          "title": "Turtle-star - blank node subject",
-          "assertions": [
-            {
-              "@id": "_:b392",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b393",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b741",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b154",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1125",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b334",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl",
-          "title": "Turtle-star - blank node object",
-          "assertions": [
-            {
-              "@id": "_:b1087",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b282",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b416",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b319",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b996",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b235",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl",
-          "title": "Turtle-star - blank node",
-          "assertions": [
-            {
-              "@id": "_:b1101",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b629",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b857",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b858",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b809",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b810",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl",
-          "title": "Turtle-star - bad - embedded triple as predicate",
-          "assertions": [
-            {
-              "@id": "_:b1021",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b935",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b385",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b386",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b142",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b143",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl",
-          "title": "Turtle-star - bad - embedded triple outside triple",
-          "assertions": [
-            {
-              "@id": "_:b938",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b419",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b446",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b447",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b530",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b531",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl",
-          "title": "Turtle-star - bad - collection list in embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b1015",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b445",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b683",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b373",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b863",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b93",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl",
-          "title": "Turtle-star - bad - literal in subject position of embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b992",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b993",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1114",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b961",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b193",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b194",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl",
-          "title": "Turtle-star - bad - blank node  as predicate in embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b481",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b482",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b791",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b553",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1006",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1005",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl",
-          "title": "Turtle-star - bad - compound blank node expression",
-          "assertions": [
-            {
-              "@id": "_:b1104",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b881",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b906",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b595",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b983",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b835",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl",
-          "title": "Turtle-star - bad - incomplete embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b105",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b106",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1091",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b700",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b514",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b501",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl",
-          "title": "Turtle-star - bad - over-long embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b1110",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b232",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b840",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b841",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1054",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b226",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl",
-          "title": "Turtle-star - Annotation form",
-          "assertions": [
-            {
-              "@id": "_:b347",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b107",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b375",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b376",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b905",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b844",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl",
-          "title": "Turtle-star - Annotation example",
-          "assertions": [
-            {
-              "@id": "_:b673",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b674",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b68",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b69",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b956",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b563",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl",
-          "title": "Turtle-star - bad - empty annotation",
-          "assertions": [
-            {
-              "@id": "_:b1118",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b480",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b963",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b865",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b297",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b298",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl",
-          "title": "Turtle-star - bad - triple as annotation",
-          "assertions": [
-            {
-              "@id": "_:b994",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b216",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": "https://josd.github.io/",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b1047",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b618",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b968",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b872",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": null
-            }
-          ]
-        }
-      ],
-      "rdfs:label": "Turtle-star Syntax Tests"
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj",
-          "testAction": {
-            "@id": "_:b276",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
-            }
-          },
-          "title": "SPARQL-star - all graph triples (JSON results)",
-          "assertions": [
-            {
-              "@id": "_:b752",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b5",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b548",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b549",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b593",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b594",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx",
-          "testAction": {
-            "@id": "_:b104",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
-            }
-          },
-          "title": "SPARQL-star - all graph triples (XML results)",
-          "assertions": [
-            {
-              "@id": "_:b585",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b39",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b102",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b103",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b715",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b716",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj",
-          "testAction": {
-            "@id": "_:b418",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.rq"
-            }
-          },
-          "title": "SPARQL-star - match constant embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b417",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b366",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1088",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b803",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b582",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b583",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj",
-          "testAction": {
-            "@id": "_:b311",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.rq"
-            }
-          },
-          "title": "SPARQL-star - match embedded triple, var subject",
-          "assertions": [
-            {
-              "@id": "_:b813",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b814",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b588",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b173",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b529",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b129",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj",
-          "testAction": {
-            "@id": "_:b0",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.rq"
-            }
-          },
-          "title": "SPARQL-star - match embedded triple, var predicate",
-          "assertions": [
-            {
-              "@id": "_:b1057",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1058",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b132",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b133",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b589",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b590",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj",
-          "testAction": {
-            "@id": "_:b122",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.rq"
-            }
-          },
-          "title": "SPARQL-star - match embedded triple, var object",
-          "assertions": [
-            {
-              "@id": "_:b120",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b121",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1023",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b832",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b934",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b220",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj",
-          "testAction": {
-            "@id": "_:b257",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.rq"
-            }
-          },
-          "title": "SPARQL-star - no match of embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b255",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b256",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1044",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1041",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b964",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b388",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj",
-          "testAction": {
-            "@id": "_:b178",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.rq"
-            }
-          },
-          "title": "SPARQL-star - Asserted and embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b421",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b422",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b491",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b492",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b490",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b260",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj",
-          "testAction": {
-            "@id": "_:b745",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.rq"
-            }
-          },
-          "title": "SPARQL-star -  Asserted and embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b743",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b744",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b953",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b954",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b928",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b16",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj",
-          "testAction": {
-            "@id": "_:b206",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.rq"
-            }
-          },
-          "title": "SPARQL-star - Pattern - Variable for embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b828",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b439",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1077",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b945",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b204",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b205",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj",
-          "testAction": {
-            "@id": "_:b181",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.rq"
-            }
-          },
-          "title": "SPARQL-star - Pattern - No match",
-          "assertions": [
-            {
-              "@id": "_:b1026",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b9",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b759",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b628",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b179",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b180",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj",
-          "testAction": {
-            "@id": "_:b70",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.rq"
-            }
-          },
-          "title": "SPARQL-star - Pattern - match variables in triple terms",
-          "assertions": [
-            {
-              "@id": "_:b362",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b363",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b352",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b353",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b641",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b642",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj",
-          "testAction": {
-            "@id": "_:b199",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.rq"
-            }
-          },
-          "title": "SPARQL-star - Pattern - Nesting 1",
-          "assertions": [
-            {
-              "@id": "_:b258",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b259",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b990",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b991",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b677",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b678",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj",
-          "testAction": {
-            "@id": "_:b469",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.rq"
-            }
-          },
-          "title": "SPARQL-star - Pattern - Nesting - 2",
-          "assertions": [
-            {
-              "@id": "_:b1001",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b361",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1070",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b842",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b684",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b387",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj",
-          "testAction": {
-            "@id": "_:b546",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.rq"
-            }
-          },
-          "title": "SPARQL-star - Pattern - Match and nesting",
-          "assertions": [
-            {
-              "@id": "_:b544",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b545",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b924",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b152",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b908",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b909",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj",
-          "testAction": {
-            "@id": "_:b100",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-5.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.rq"
-            }
-          },
-          "title": "SPARQL-star - Pattern - Same variable",
-          "assertions": [
-            {
-              "@id": "_:b746",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b691",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b299",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b40",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b98",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b99",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl",
-          "testAction": {
-            "@id": "_:b215",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.rq"
-            }
-          },
-          "title": "SPARQL-star - CONSTRUCT with constant template",
-          "assertions": [
-            {
-              "@id": "_:b236",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b237",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b406",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b407",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b432",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b433",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl",
-          "testAction": {
-            "@id": "_:b478",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.rq"
-            }
-          },
-          "title": "SPARQL-star - CONSTRUCT WHERE with constant template",
-          "assertions": [
-            {
-              "@id": "_:b607",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b228",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b638",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b374",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b735",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b736",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl",
-          "testAction": {
-            "@id": "_:b110",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.rq"
-            }
-          },
-          "title": "SPARQL-star - CONSTRUCT - about every triple",
-          "assertions": [
-            {
-              "@id": "_:b1108",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b1062",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b936",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b937",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b108",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b109",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl",
-          "testAction": {
-            "@id": "_:b34",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.rq"
-            }
-          },
-          "title": "SPARQL-star - CONSTRUCT with annotation syntax",
-          "assertions": [
-            {
-              "@id": "_:b692",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b693",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b626",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b627",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b749",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b296",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl",
-          "testAction": {
-            "@id": "_:b325",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.rq"
-            }
-          },
-          "title": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
-          "assertions": [
-            {
-              "@id": "_:b381",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b382",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b336",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b337",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b425",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b426",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj",
-          "testAction": {
-            "@id": "_:b19",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.rq"
-            }
-          },
-          "title": "SPARQL-star - GRAPH",
-          "assertions": [
-            {
-              "@id": "_:b156",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b157",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b458",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b459",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b540",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b541",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj",
-          "testAction": {
-            "@id": "_:b22",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.rq"
-            }
-          },
-          "title": "SPARQL-star - GRAPHs with blank node",
-          "assertions": [
-            {
-              "@id": "_:b20",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b21",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b793",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b502",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b611",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b612",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl",
-          "testAction": {
-            "@id": "_:b225",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.rq"
-            }
-          },
-          "title": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
-          "assertions": [
-            {
-              "@id": "_:b995",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b293",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b773",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b774",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b927",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b221",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj",
-          "testAction": {
-            "@id": "_:b58",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.rq"
-            }
-          },
-          "title": "SPARQL-star - Embedded triple - Functions",
-          "assertions": [
-            {
-              "@id": "_:b1042",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b870",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1115",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b15",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b404",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b405",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-          "@type": [
-            "mf:QueryEvaluationTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj",
-          "testAction": {
-            "@id": "_:b165",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.rq"
-            }
-          },
-          "title": "SPARQL-star - Embedded triple ORDER BY",
-          "assertions": [
-            {
-              "@id": "_:b1078",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b656",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b163",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b164",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b562",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b123",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-          "@type": [
-            "TestCriterion",
-            "mf:UpdateEvaluationTest",
-            "TestCase"
-          ],
-          "testResult": {
-            "@id": "_:b263",
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-1.trig"
-            }
-          },
-          "testAction": {
-            "@id": "_:b264",
-            "http://www.w3.org/2009/sparql/tests/test-update#request": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-1.ru"
-            },
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
-            }
-          },
-          "title": "SPARQL-star - Update",
-          "assertions": [
-            {
-              "@id": "_:b261",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b262",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b569",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b73",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b484",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b41",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-          "@type": [
-            "TestCriterion",
-            "mf:UpdateEvaluationTest",
-            "TestCase"
-          ],
-          "testResult": {
-            "@id": "_:b246",
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-2.trig"
-            }
-          },
-          "testAction": {
-            "@id": "_:b247",
-            "http://www.w3.org/2009/sparql/tests/test-update#request": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-2.ru"
-            },
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
-            }
-          },
-          "title": "SPARQL-star - Update - annotation",
-          "assertions": [
-            {
-              "@id": "_:b1124",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b43",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b244",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b245",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b671",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b649",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-          "@type": [
-            "TestCriterion",
-            "mf:UpdateEvaluationTest",
-            "TestCase"
-          ],
-          "testResult": {
-            "@id": "_:b71",
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-3.trig"
-            }
-          },
-          "testAction": {
-            "@id": "_:b6",
-            "http://www.w3.org/2009/sparql/tests/test-update#request": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-3.ru"
-            },
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
-            }
-          },
-          "title": "SPARQL-star - Update - data",
-          "assertions": [
-            {
-              "@id": "_:b864",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b241",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b354",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b355",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b890",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b227",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            }
-          ]
-        }
-      ],
-      "rdfs:label": "SPARQL-star Evaluation Tests"
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt",
-          "title": "N-Triples-star - subject embedded triple",
-          "assertions": [
-            {
-              "@id": "_:b160",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b161",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
-              "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b960",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b959",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b824",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b303",
+              "@id": "_:b744",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b304",
+                "@id": "_:b745",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8439,48 +216,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt",
           "title": "N-Triples-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt",
           "assertions": [
             {
-              "@id": "_:b886",
+              "@id": "_:b923",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b124",
+                "@id": "_:b924",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b442",
+              "@id": "_:b1141",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b302",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1082",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b946",
+              "@id": "_:b362",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b358",
+                "@id": "_:b363",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8488,48 +265,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt",
           "title": "N-Triples-star - subject and object embedded triples",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt",
           "assertions": [
             {
-              "@id": "_:b951",
+              "@id": "_:b713",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b940",
+                "@id": "_:b714",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b962",
+              "@id": "_:b1178",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b333",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b509",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b944",
+              "@id": "_:b338",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b904",
+                "@id": "_:b339",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8537,48 +314,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt",
           "title": "N-Triples-star - whitespace and terms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt",
           "assertions": [
             {
-              "@id": "_:b825",
+              "@id": "_:b1115",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b646",
+                "@id": "_:b296",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b624",
+              "@id": "_:b844",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b625",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b103",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b984",
+              "@id": "_:b1185",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b720",
+                "@id": "_:b50",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8586,48 +363,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt",
           "title": "N-Triples-star - Nested, no whitespace",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt",
           "assertions": [
             {
-              "@id": "_:b900",
+              "@id": "_:b1019",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b141",
+                "@id": "_:b1020",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b1020",
+              "@id": "_:b287",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b891",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b288",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b719",
+              "@id": "_:b558",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b663",
+                "@id": "_:b559",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8635,48 +412,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt",
           "title": "N-Triples-star - Blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt",
           "assertions": [
             {
-              "@id": "_:b621",
+              "@id": "_:b1319",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b94",
+                "@id": "_:b24",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b566",
+              "@id": "_:b327",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b564",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b328",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b1074",
+              "@id": "_:b146",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b504",
+                "@id": "_:b147",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8684,48 +461,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt",
           "title": "N-Triples-star - Blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt",
           "assertions": [
             {
-              "@id": "_:b1067",
+              "@id": "_:b952",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b155",
+                "@id": "_:b410",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b47",
+              "@id": "_:b462",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b48",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b463",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b654",
+              "@id": "_:b938",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b115",
+                "@id": "_:b406",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8733,48 +510,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt",
           "title": "N-Triples-star - Nested subject term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt",
           "assertions": [
             {
-              "@id": "_:b970",
+              "@id": "_:b1241",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b61",
+                "@id": "_:b371",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b13",
+              "@id": "_:b1080",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b14",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1081",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b623",
+              "@id": "_:b1000",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b576",
+                "@id": "_:b260",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8782,48 +559,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt",
           "title": "N-Triples-star - Nested object term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt",
           "assertions": [
             {
-              "@id": "_:b242",
+              "@id": "_:b1111",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b243",
+                "@id": "_:b1112",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b316",
+              "@id": "_:b305",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b317",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b306",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b1033",
+              "@id": "_:b1025",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b1034",
+                "@id": "_:b481",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8832,47 +609,47 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
           "@type": [
             "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt",
           "title": "N-Triples-star - Bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt",
           "assertions": [
             {
-              "@id": "_:b949",
+              "@id": "_:b1213",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b240",
+                "@id": "_:b1011",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b271",
+              "@id": "_:b1247",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b272",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1248",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b1010",
+              "@id": "_:b1174",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b472",
+                "@id": "_:b887",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8881,47 +658,47 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
           "@type": [
             "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt",
           "title": "N-Triples-star - Bad - embedded triple, literal subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt",
           "assertions": [
             {
-              "@id": "_:b843",
+              "@id": "_:b668",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b581",
+                "@id": "_:b277",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b440",
+              "@id": "_:b611",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b441",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b612",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b1063",
+              "@id": "_:b900",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b781",
+                "@id": "_:b901",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8930,47 +707,47 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
           "@type": [
             "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt",
           "title": "N-Triples-star - Bad - embedded triple, literal predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt",
           "assertions": [
             {
-              "@id": "_:b80",
+              "@id": "_:b620",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b81",
+                "@id": "_:b30",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b967",
+              "@id": "_:b442",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b732",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b252",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b294",
+              "@id": "_:b738",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b295",
+                "@id": "_:b739",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -8979,47 +756,47 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
           "@type": [
             "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt",
           "title": "N-Triples-star - Bad - embedded triple, blank node predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt",
           "assertions": [
             {
-              "@id": "_:b878",
+              "@id": "_:b144",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b657",
+                "@id": "_:b145",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b290",
+              "@id": "_:b1244",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b291",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b918",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b460",
+              "@id": "_:b482",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b461",
+                "@id": "_:b483",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9031,44 +808,44 @@
             "TestCriterion",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-1.ttl",
           "title": "N-Triples-star as Turtle-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-1.ttl",
           "assertions": [
             {
-              "@id": "_:b866",
+              "@id": "_:b799",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b867",
+                "@id": "_:b800",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b487",
+              "@id": "_:b1084",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b394",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1085",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b633",
+              "@id": "_:b546",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b634",
+                "@id": "_:b547",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9080,44 +857,44 @@
             "TestCriterion",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-2.ttl",
           "title": "N-Triples-star as Turtle-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-2.ttl",
           "assertions": [
             {
-              "@id": "_:b1117",
+              "@id": "_:b777",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b776",
+                "@id": "_:b60",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b894",
+              "@id": "_:b1056",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b895",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b990",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b823",
+              "@id": "_:b166",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b753",
+                "@id": "_:b167",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9129,44 +906,44 @@
             "TestCriterion",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-3.ttl",
           "title": "N-Triples-star as Turtle-star - subject and object embedded triples",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-3.ttl",
           "assertions": [
             {
-              "@id": "_:b1123",
+              "@id": "_:b1219",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b1083",
+                "@id": "_:b474",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b551",
+              "@id": "_:b1299",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b552",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b5",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b976",
+              "@id": "_:b888",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b747",
+                "@id": "_:b542",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9174,48 +951,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt",
           "title": "N-Triples-star as Turtle-star - whitespace and terms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt",
           "assertions": [
             {
-              "@id": "_:b329",
+              "@id": "_:b458",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b330",
+                "@id": "_:b307",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b185",
+              "@id": "_:b1205",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b186",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b618",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b672",
+              "@id": "_:b1256",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b144",
+                "@id": "_:b689",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9223,48 +1000,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt",
           "title": "N-Triples-star as Turtle-star - Nested, no whitespace",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt",
           "assertions": [
             {
-              "@id": "_:b139",
+              "@id": "_:b783",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b140",
+                "@id": "_:b49",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b1004",
+              "@id": "_:b1202",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b988",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b430",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b1048",
+              "@id": "_:b1194",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b600",
+                "@id": "_:b86",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9276,44 +1053,44 @@
             "TestCriterion",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-1.ttl",
           "title": "N-Triples-star as Turtle-star - Blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-1.ttl",
           "assertions": [
             {
-              "@id": "_:b1120",
+              "@id": "_:b972",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b699",
+                "@id": "_:b510",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b977",
+              "@id": "_:b1167",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b834",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b650",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b1069",
+              "@id": "_:b1134",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b923",
+                "@id": "_:b1010",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9325,44 +1102,44 @@
             "TestCriterion",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-2.ttl",
           "title": "N-Triples-star as Turtle-star - Blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-2.ttl",
           "assertions": [
             {
-              "@id": "_:b434",
+              "@id": "_:b1104",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b435",
+                "@id": "_:b1105",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b652",
+              "@id": "_:b1309",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b174",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b405",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b238",
+              "@id": "_:b1261",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b239",
+                "@id": "_:b1132",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9374,44 +1151,44 @@
             "TestCriterion",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-1.ttl",
           "title": "N-Triples-star as Turtle-star - Nested subject term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-1.ttl",
           "assertions": [
             {
-              "@id": "_:b285",
+              "@id": "_:b1200",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b286",
+                "@id": "_:b875",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b981",
+              "@id": "_:b603",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b982",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b604",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b763",
+              "@id": "_:b672",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b764",
+                "@id": "_:b673",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9423,44 +1200,44 @@
             "TestCriterion",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-2.ttl",
           "title": "N-Triples-star as Turtle-star - Nested object term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-2.ttl",
           "assertions": [
             {
-              "@id": "_:b907",
+              "@id": "_:b822",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b558",
+                "@id": "_:b823",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b871",
+              "@id": "_:b1154",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b500",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b557",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b323",
+              "@id": "_:b1311",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b324",
+                "@id": "_:b417",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9468,48 +1245,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-1.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-1.ttl",
           "assertions": [
             {
-              "@id": "_:b714",
+              "@id": "_:b64",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b192",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1",
               "subject": "https://josd.github.io/eye/",
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b862",
-              "@type": "Assertion",
               "result": {
                 "@id": "_:b65",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
+                "outcome": "earl:untested"
               },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1087",
+              "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1088",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b701",
+              "@id": "_:b1090",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b702",
+                "@id": "_:b499",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9517,48 +1294,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-2.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-2.ttl",
           "assertions": [
             {
-              "@id": "_:b1025",
+              "@id": "_:b1188",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b572",
+                "@id": "_:b933",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b985",
+              "@id": "_:b1300",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b986",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b827",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b929",
+              "@id": "_:b1158",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b899",
+                "@id": "_:b1159",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9566,48 +1343,48 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-3.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-3.ttl",
           "assertions": [
             {
-              "@id": "_:b609",
+              "@id": "_:b1237",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b610",
+                "@id": "_:b1170",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
             },
             {
-              "@id": "_:b149",
+              "@id": "_:b123",
               "@type": "Assertion",
-              "result": {
-                "@id": "_:b150",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3",
               "subject": "https://rubygems.org/gems/rdf-turtle",
               "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b124",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
               "mode": "earl:automatic"
             },
             {
-              "@id": "_:b643",
+              "@id": "_:b677",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b332",
+                "@id": "_:b678",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -9615,147 +1392,10034 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase"
           ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-4.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-4.ttl",
           "assertions": [
             {
-              "@id": "_:b820",
+              "@id": "_:b539",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b540",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b402",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b403",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b426",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b427",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "TriG-star Syntax Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig",
+          "assertions": [
+            {
+              "@id": "_:b209",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b210",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1233",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1234",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1130",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b489",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig",
+          "assertions": [
+            {
+              "@id": "_:b316",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b317",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b841",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b842",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b250",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b251",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - embedded triple inside blankNodePropertyList",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig",
+          "assertions": [
+            {
+              "@id": "_:b160",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b161",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1001",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b298",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b837",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b838",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - embedded triple inside collection",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig",
+          "assertions": [
+            {
+              "@id": "_:b752",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b753",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b814",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b398",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b951",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b852",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - nested embedded triple, subject position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig",
+          "assertions": [
+            {
+              "@id": "_:b39",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b40",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1100",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b471",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b198",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b199",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - nested embedded triple, object position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig",
+          "assertions": [
+            {
+              "@id": "_:b551",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b237",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b975",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b605",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b582",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b583",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - compound forms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig",
+          "assertions": [
+            {
+              "@id": "_:b356",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b357",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b592",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b593",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b946",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b651",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig",
+          "assertions": [
+            {
+              "@id": "_:b211",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b212",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1259",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1218",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b664",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+              "subject": "https://rubygems.org/gems/sparql",
               "result": {
                 "@id": "_:b665",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4",
-              "subject": "https://josd.github.io/eye/",
               "assertedBy": null
-            },
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig",
+          "assertions": [
             {
-              "@id": "_:b1024",
+              "@id": "_:b903",
               "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
+              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b765",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4",
-              "subject": "https://rubygems.org/gems/rdf-turtle",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b327",
-              "@type": "Assertion",
-              "result": {
-                "@id": "_:b8",
+                "@id": "_:b904",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b95",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b96",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1076",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b104",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - blank node",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig",
+          "assertions": [
+            {
+              "@id": "_:b20",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b21",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b965",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b831",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b902",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b148",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig",
+          "assertions": [
+            {
+              "@id": "_:b932",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b52",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1257",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1258",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b968",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b969",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - embedded triple outside triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig",
+          "assertions": [
+            {
+              "@id": "_:b272",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b273",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1301",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b416",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b961",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b962",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - collection list in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig",
+          "assertions": [
+            {
+              "@id": "_:b998",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b999",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b396",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b397",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1250",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b764",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - literal in subject position of embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig",
+          "assertions": [
+            {
+              "@id": "_:b685",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b686",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b633",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b634",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1015",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b869",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - blank node  as predicate in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig",
+          "assertions": [
+            {
+              "@id": "_:b794",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b679",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b711",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b498",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b970",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b877",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - compound blank node expression",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig",
+          "assertions": [
+            {
+              "@id": "_:b628",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b162",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b241",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b242",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b674",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b326",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - incomplete embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig",
+          "assertions": [
+            {
+              "@id": "_:b1235",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1086",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b386",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b387",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b233",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b234",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - over-long embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig",
+          "assertions": [
+            {
+              "@id": "_:b1291",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1157",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b991",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b687",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b955",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b956",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - Annotation form",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b647",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b244",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b407",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b408",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b879",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b880",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - Annotation example",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b1226",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1227",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b817",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b818",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1260",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1217",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - empty annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b365",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b366",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b743",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b520",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b927",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b928",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "TriG-star - bad - triple as annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b976",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b297",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b762",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b512",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b981",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b982",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
               "assertedBy": null
             }
           ]
         }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
       ],
-      "rdfs:label": "N-Triples-star Syntax Tests"
+      "rdfs:label": "Turtle-star Evaluation Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - subject embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b731",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b732",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b201",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b202",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1286",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1078",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - object embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b953",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b954",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b773",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b774",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b889",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b890",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - blank node label",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b770",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b681",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b523",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b524",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b522",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b178",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - blank node labels",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b959",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b682",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b930",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b51",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1074",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b758",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation form",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b268",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b12",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1211",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1212",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1201",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b702",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation example",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b943",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b404",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1307",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1047",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1139",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b768",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation - predicate and object lists",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl",
+          "assertions": [
+            {
+              "@id": "_:b99",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b83",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1180",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b206",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b966",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b128",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation - nested",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1155",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b1052",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1187",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1098",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1316",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1099",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation object list",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1295",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b914",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b360",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b361",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b691",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b170",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation with embedding",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b719",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b720",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b787",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b722",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1069",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1070",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation on triple with embedded subject",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1308",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b304",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b788",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b555",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b130",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b131",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+          ],
+          "title": "Turtle-star - Annotation on triple with embedded object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl",
+          "assertions": [
+            {
+              "@id": "_:b156",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b157",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1166",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b983",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b580",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b581",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "TriG-star Evaluation Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - subject embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig",
+          "assertions": [
+            {
+              "@id": "_:b281",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b282",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b370",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b367",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b803",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b804",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - object embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig",
+          "assertions": [
+            {
+              "@id": "_:b854",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b358",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b785",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b786",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b590",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b591",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - blank node label",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b58",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b59",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1195",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b295",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b825",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b688",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - blank node labels",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b1206",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1207",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1190",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b171",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1055",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b736",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation form",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b271",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b27",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b222",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b223",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b813",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b214",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation example",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b1198",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1062",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1189",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b671",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b381",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b382",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation - predicate and object lists",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig",
+          "assertions": [
+            {
+              "@id": "_:b1128",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1119",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b31",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b32",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b368",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b369",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation - nested",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig",
+          "assertions": [
+            {
+              "@id": "_:b256",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b257",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b925",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b926",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1199",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b589",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation object list",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig",
+          "assertions": [
+            {
+              "@id": "_:b1302",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b761",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b828",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b765",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1148",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b480",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation with embedding",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b1197",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b26",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b216",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b217",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b883",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b359",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation on triple with embedded subject",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b740",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b602",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b613",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b290",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b312",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b313",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval"
+          ],
+          "title": "TriG-star - Annotation on triple with embedded object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.trig",
+          "assertions": [
+            {
+              "@id": "_:b939",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b330",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b849",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b25",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b476",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b477",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "SPARQL-star Evaluation Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - all graph triples (JSON results)",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj",
+          "testAction": {
+            "@id": "_:b134",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b562",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b563",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1053",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b652",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b132",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b133",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - all graph triples (XML results)",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx",
+          "testAction": {
+            "@id": "_:b70",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b862",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b82",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b319",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b320",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b68",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b69",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - match constant embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj",
+          "testAction": {
+            "@id": "_:b488",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1151",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b811",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b487",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b374",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1059",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b284",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - match embedded triple, var subject",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj",
+          "testAction": {
+            "@id": "_:b205",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b977",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b394",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1102",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1103",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b203",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b204",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - match embedded triple, var predicate",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj",
+          "testAction": {
+            "@id": "_:b280",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1107",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1054",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b278",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b279",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b501",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b502",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - match embedded triple, var object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj",
+          "testAction": {
+            "@id": "_:b200",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b718",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b372",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1214",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b564",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b936",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b490",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - no match of embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj",
+          "testAction": {
+            "@id": "_:b15",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1232",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1210",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1005",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1006",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b721",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b497",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Asserted and embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj",
+          "testAction": {
+            "@id": "_:b646",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1222",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b283",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b644",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b645",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b754",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b552",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star -  Asserted and embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj",
+          "testAction": {
+            "@id": "_:b138",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b857",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b858",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b136",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b137",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b805",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b806",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Pattern - Variable for embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj",
+          "testAction": {
+            "@id": "_:b624",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b916",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b917",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1013",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b41",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b839",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b840",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Pattern - No match",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj",
+          "testAction": {
+            "@id": "_:b208",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1209",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b329",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1153",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b347",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1186",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b37",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Pattern - match variables in triple terms",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj",
+          "testAction": {
+            "@id": "_:b92",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b220",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b221",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1095",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1096",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b835",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b836",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Pattern - Nesting 1",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj",
+          "testAction": {
+            "@id": "_:b578",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b737",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b129",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b705",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b61",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b576",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b577",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Pattern - Nesting - 2",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj",
+          "testAction": {
+            "@id": "_:b311",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1163",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b224",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1246",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1108",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b309",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b310",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Pattern - Match and nesting",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj",
+          "testAction": {
+            "@id": "_:b183",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b596",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b597",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1320",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b579",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b239",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b240",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Pattern - Same variable",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj",
+          "testAction": {
+            "@id": "_:b264",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-5.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1230",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1231",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1135",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1064",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b263",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b63",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - CONSTRUCT with constant template",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl",
+          "testAction": {
+            "@id": "_:b457",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b780",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b614",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b456",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b79",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b793",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b238",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - CONSTRUCT WHERE with constant template",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl",
+          "testAction": {
+            "@id": "_:b486",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b484",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b485",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1281",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b798",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1193",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b876",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - CONSTRUCT - about every triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl",
+          "testAction": {
+            "@id": "_:b626",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1314",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b505",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1184",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b944",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1264",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b657",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - CONSTRUCT with annotation syntax",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl",
+          "testAction": {
+            "@id": "_:b54",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1298",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b979",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b733",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b734",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1032",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1033",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl",
+          "testAction": {
+            "@id": "_:b186",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b184",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b185",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1274",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b704",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1221",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b807",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - GRAPH",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj",
+          "testAction": {
+            "@id": "_:b245",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1317",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1228",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b845",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b846",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b565",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b38",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - GRAPHs with blank node",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj",
+          "testAction": {
+            "@id": "_:b228",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1192",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1057",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b226",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b227",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b439",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b440",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl",
+          "testAction": {
+            "@id": "_:b122",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b775",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b776",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b771",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b772",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b120",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b121",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Embedded triple - Functions",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj",
+          "testAction": {
+            "@id": "_:b194",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1002",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b197",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b192",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b193",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b399",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b57",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Embedded triple ORDER BY",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj",
+          "testAction": {
+            "@id": "_:b53",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.rq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b253",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b254",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b594",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b595",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b164",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b165",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+          "@type": [
+            "TestCriterion",
+            "mf:UpdateEvaluationTest",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Update",
+          "testResult": {
+            "@id": "_:b530",
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-1.trig"
+            }
+          },
+          "testAction": {
+            "@id": "_:b531",
+            "http://www.w3.org/2009/sparql/tests/test-update#request": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-1.ru"
+            },
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1277",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1215",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b528",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b529",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b929",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b71",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+          "@type": [
+            "TestCriterion",
+            "mf:UpdateEvaluationTest",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Update - annotation",
+          "testResult": {
+            "@id": "_:b433",
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-2.trig"
+            }
+          },
+          "testAction": {
+            "@id": "_:b434",
+            "http://www.w3.org/2009/sparql/tests/test-update#request": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-2.ru"
+            },
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b431",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b432",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b853",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b525",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1147",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1093",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+          "@type": [
+            "TestCriterion",
+            "mf:UpdateEvaluationTest",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Update - data",
+          "testResult": {
+            "@id": "_:b507",
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-3.trig"
+            }
+          },
+          "testAction": {
+            "@id": "_:b508",
+            "http://www.w3.org/2009/sparql/tests/test-update#request": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-3.ru"
+            },
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b746",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b747",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b931",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b322",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1253",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b72",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "SPARQL-star Syntax Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b638",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b639",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b179",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b180",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b0",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b350",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b351",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1133",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b778",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b948",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b515",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - subject embedded triple - vars",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq",
+          "assertions": [
+            {
+              "@id": "_:b726",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b727",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b571",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b572",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1022",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1012",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - object embedded triple - vars",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq",
+          "assertions": [
+            {
+              "@id": "_:b436",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b437",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b907",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b908",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b45",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b46",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Embedded triple in VALUES",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq",
+          "assertions": [
+            {
+              "@id": "_:b910",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b911",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b696",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b697",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b627",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b331",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Embedded triple in CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq",
+          "assertions": [
+            {
+              "@id": "_:b897",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b663",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b886",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b500",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b819",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b820",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Embedded triples in CONSTRUCT WHERE",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq",
+          "assertions": [
+            {
+              "@id": "_:b379",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b380",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1003",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b960",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1162",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b984",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - embedded triple inside blankNodePropertyList",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b1024",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b506",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b706",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b632",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b709",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b415",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - embedded triple inside collection",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b848",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b708",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b266",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b267",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b950",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b22",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - nested embedded triple, subject position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b905",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b906",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b781",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b782",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b980",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b942",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - nested embedded triple, object position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b881",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b882",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b152",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b153",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1196",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b76",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - compound forms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq",
+          "assertions": [
+            {
+              "@id": "_:b1117",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1118",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b629",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b630",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b269",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b270",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b920",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b127",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1068",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b964",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b568",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b569",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b195",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b196",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1026",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b11",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1249",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1176",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - blank node",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq",
+          "assertions": [
+            {
+              "@id": "_:b584",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b585",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1061",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1060",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1208",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1204",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation form",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b1173",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b894",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1278",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b503",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b265",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b189",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation example",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b34",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b35",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b469",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b470",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b388",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b141",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation example",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq",
+          "assertions": [
+            {
+              "@id": "_:b1073",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b140",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b680",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b373",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1268",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1269",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation with embedding",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq",
+          "assertions": [
+            {
+              "@id": "_:b1272",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b832",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1254",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1191",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b829",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b830",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation on triple with embedded object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq",
+          "assertions": [
+            {
+              "@id": "_:b833",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b834",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1265",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b971",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1271",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1216",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation with path",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq",
+          "assertions": [
+            {
+              "@id": "_:b809",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b810",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b892",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b893",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b354",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b355",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation with nested path",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq",
+          "assertions": [
+            {
+              "@id": "_:b641",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b642",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b218",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b219",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b885",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b532",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation in CONSTRUCT ",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq",
+          "assertions": [
+            {
+              "@id": "_:b1181",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b728",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b655",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b656",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1306",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b826",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Annotation in CONSTRUCT WHERE",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq",
+          "assertions": [
+            {
+              "@id": "_:b1296",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1164",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1229",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1063",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1045",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b548",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Expressions - Embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b491",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b492",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b669",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b670",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1150",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b808",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Expressions - Embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b258",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b259",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b285",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b17",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1121",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1122",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Expressions - Functions",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq",
+          "assertions": [
+            {
+              "@id": "_:b1039",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1040",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b375",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b376",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1285",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b676",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Expressions - TRIPLE",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq",
+          "assertions": [
+            {
+              "@id": "_:b570",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b513",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1091",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b443",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1326",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b921",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Expressions - Functions",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq",
+          "assertions": [
+            {
+              "@id": "_:b451",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b452",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1041",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b243",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1165",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1023",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - Expressions - BIND - CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq",
+          "assertions": [
+            {
+              "@id": "_:b700",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b701",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b422",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b423",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b274",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b275",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b87",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b88",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b947",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b723",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b878",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b843",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - embedded triple outside triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b1315",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b573",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1329",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1075",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b235",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b236",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - collection list in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq",
+          "assertions": [
+            {
+              "@id": "_:b622",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b623",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b994",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b995",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1146",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b693",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - literal in subject position of embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq",
+          "assertions": [
+            {
+              "@id": "_:b1004",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b996",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b533",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b521",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b815",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b816",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - blank node  as predicate in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq",
+          "assertions": [
+            {
+              "@id": "_:b493",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b494",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1312",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1058",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b609",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b610",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - compound blank node expression",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq",
+          "assertions": [
+            {
+              "@id": "_:b985",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b935",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b343",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b344",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b636",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b637",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - incomplete embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq",
+          "assertions": [
+            {
+              "@id": "_:b1156",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b534",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1037",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1038",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b446",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b447",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - quad embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq",
+          "assertions": [
+            {
+              "@id": "_:b1169",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b963",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b987",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b949",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b302",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b303",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - variable in embedded triple in VALUES ",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq",
+          "assertions": [
+            {
+              "@id": "_:b352",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b353",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1136",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b213",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1123",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b246",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - blank node in embedded triple in VALUES ",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq",
+          "assertions": [
+            {
+              "@id": "_:b517",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b518",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b454",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b455",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b631",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b19",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - empty annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq",
+          "assertions": [
+            {
+              "@id": "_:b187",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b188",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b574",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b575",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b748",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b749",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - triples in annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq",
+          "assertions": [
+            {
+              "@id": "_:b411",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b110",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b464",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b465",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b174",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b175",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - path - seq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq",
+          "assertions": [
+            {
+              "@id": "_:b472",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b473",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b115",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b116",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b729",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b730",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - path - alt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq",
+          "assertions": [
+            {
+              "@id": "_:b1282",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b909",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1160",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1161",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1267",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b114",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - path - p*",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq",
+          "assertions": [
+            {
+              "@id": "_:b445",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b151",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b97",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b98",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b435",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b111",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - path - p+",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq",
+          "assertions": [
+            {
+              "@id": "_:b13",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b14",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b724",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b635",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b149",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b150",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - path - p?",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq",
+          "assertions": [
+            {
+              "@id": "_:b73",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b74",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1072",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b735",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1220",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b23",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - path in CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq",
+          "assertions": [
+            {
+              "@id": "_:b586",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b587",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1328",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b441",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b937",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b389",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+          "@type": [
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - bad - path in CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq",
+          "assertions": [
+            {
+              "@id": "_:b390",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b391",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b873",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b874",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1131",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b395",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru",
+          "assertions": [
+            {
+              "@id": "_:b1125",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1126",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1065",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1066",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1048",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1049",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru",
+          "assertions": [
+            {
+              "@id": "_:b759",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b760",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b125",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b126",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1109",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1110",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru",
+          "assertions": [
+            {
+              "@id": "_:b84",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b85",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b710",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b556",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1263",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b958",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update with embedding",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru",
+          "assertions": [
+            {
+              "@id": "_:b43",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b44",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b108",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b109",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b345",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b334",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update with embedded object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru",
+          "assertions": [
+            {
+              "@id": "_:b566",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b567",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b797",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b16",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b80",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b81",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update with annotation template",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru",
+          "assertions": [
+            {
+              "@id": "_:b28",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b29",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b424",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b425",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1129",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b342",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update with annotation, template and pattern",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru",
+          "assertions": [
+            {
+              "@id": "_:b1050",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1051",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1294",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b997",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b248",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b249",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+          "@type": [
+            "TestCriterion",
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update DATA with annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru",
+          "assertions": [
+            {
+              "@id": "_:b850",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b851",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b640",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b286",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b988",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b173",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru",
+          "assertions": [
+            {
+              "@id": "_:b915",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b643",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b325",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b262",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b666",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b667",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru",
+          "assertions": [
+            {
+              "@id": "_:b1245",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b541",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b919",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b461",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1138",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1127",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru",
+          "assertions": [
+            {
+              "@id": "_:b142",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b143",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b294",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b100",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b898",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b364",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase"
+          ],
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru",
+          "assertions": [
+            {
+              "@id": "_:b77",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b78",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1255",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b884",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b466",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b383",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "Turtle-star Syntax Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b412",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b413",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1144",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1145",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b648",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b649",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b66",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b67",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b790",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b791",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b377",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b378",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - embedded triple inside blankNodePropertyList",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b716",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b717",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b190",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b191",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1140",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b215",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - embedded triple inside collection",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b864",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b865",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b400",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b401",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b154",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b155",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - nested embedded triple, subject position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1323",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b323",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b348",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b349",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1270",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b861",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - nested embedded triple, object position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1304",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b6",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b340",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b341",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b467",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b468",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - compound forms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl",
+          "assertions": [
+            {
+              "@id": "_:b694",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b695",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1083",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b741",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b912",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b913",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1287",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b1014",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b872",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b703",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b891",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b429",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b55",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b56",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b742",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b621",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1236",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b453",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - blank node",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl",
+          "assertions": [
+            {
+              "@id": "_:b945",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b135",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b3",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b4",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1313",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b308",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b7",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b8",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1182",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1183",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b560",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b561",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - embedded triple outside triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b812",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b301",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b616",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b617",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b93",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b94",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - collection list in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1273",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b615",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1042",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1043",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1242",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b519",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - literal in subject position of embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl",
+          "assertions": [
+            {
+              "@id": "_:b336",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b337",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b653",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b654",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1262",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b899",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - blank node  as predicate in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1321",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b1089",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1203",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b409",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1179",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b89",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - compound blank node expression",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl",
+          "assertions": [
+            {
+              "@id": "_:b922",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b847",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1149",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b444",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b600",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b601",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - incomplete embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl",
+          "assertions": [
+            {
+              "@id": "_:b821",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b763",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b625",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b255",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b158",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b159",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - over-long embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl",
+          "assertions": [
+            {
+              "@id": "_:b112",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b113",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b261",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b119",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1124",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b450",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - Annotation form",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b750",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b504",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1017",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1018",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b769",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b588",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "Turtle-star - Annotation example",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1029",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b172",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b47",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b48",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1225",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b293",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - empty annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b863",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b33",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1067",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b860",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b459",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b460",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+          "@type": [
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCase"
+          ],
+          "title": "Turtle-star - bad - triple as annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b675",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b438",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1289",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "result": {
+                "@id": "_:b1079",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1325",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1240",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/semantics#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-star/tests/semantics/README"
+      },
+      "rdfs:label": "RDF-star Semantics tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "all-identical-embedded-triples-are-the-same",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b867",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b868",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1027",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1028",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1071",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b428",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "embedded-triples-no-spurious",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test005.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "This test ensures that other entailments are not spurious.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b90",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b91",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1177",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b989",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b101",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b102",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "bnodes-in-embedded-subject",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b384",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b385",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1283",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1275",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b967",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b779",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "bnodes-in-embedded-object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b895",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b896",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1094",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b859",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b106",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b107",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "bnodes-in-embedded-subject-and-object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b420",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b421",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b934",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b856",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b661",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b662",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "bnodes-in-embedded-subject-and-object-fail",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "The same bnode can not match different embedded terms.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b511",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b10",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1030",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1031",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b105",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b62",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "same-bnode-same-embedded-term",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Identical embedded term can be replaced by the same fresh bnode multiple times.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1021",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b940",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b986",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b792",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1034",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b757",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "different-bnodes-same-embedded-term",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Different bnodes can match identical embedded terms.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b168",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b169",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b801",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b802",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b392",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b393",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "constrained-bnodes-in-embedded-subject",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b448",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b449",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1251",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1252",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b163",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b18",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "constrained-bnodes-in-embedded-object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1120",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b978",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b698",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b699",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1106",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1101",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "constrained-bnodes-in-embedded-fail",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b231",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b232",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1044",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b690",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b707",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b335",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "constrained-bnodes-on-literal",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b973",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b974",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b535",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b536",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1279",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b225",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "malformed-literal-control",
+          "mf:result": {
+            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+            "@value": "false"
+          },
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1324",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b712",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b795",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b796",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b553",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b554",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "malformed-literal",
+          "mf:result": {
+            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+            "@value": "false"
+          },
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Malformed literals are allowed when embedded.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b495",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b496",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b659",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b660",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1152",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b516",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "malformed-literal-accepted",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Malformed literals are allowed when embedded.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1016",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b545",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1327",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b324",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1223",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b751",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "malformed-literal-no-spurious",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Embedded malformed literals do not lead to spurious entailment.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1310",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b1290",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b299",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b300",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b598",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b599",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "malformed-literal-bnode",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Malformed literals can not be replaced by blank nodes.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1305",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "subject": "https://josd.github.io/eye/",
+              "result": {
+                "@id": "_:b1046",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1284",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b789",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1077",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b414",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "opaque-literal-control",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b346",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b247",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b766",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b767",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b941",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b475",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "opaque-literal",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Embedded literals are opaque, even when their datatype is recognized.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1168",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b715",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1175",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b658",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1035",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1036",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "opaque-language-string-control",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1276",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b289",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1116",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b321",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b418",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b419",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "title": "opaque-language-string",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b607",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b608",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b478",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b479",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1224",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b866",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDFS-Plus",
+          "title": "opaque-iri-control",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1280",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b42",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1238",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1239",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b784",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b139",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDFS-Plus",
+          "title": "opaque-iri",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Embedded IRIs are opaque.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/superman.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1142",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b1143",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b229",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b230",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b176",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b177",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+          "@type": [
+            "TestCriterion",
+            "mf:NegativeEntailmentTest",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "embedded-not-asserted",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Embedded triples are not asserted.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b1288",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b1137",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b1008",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b1009",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b755",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b756",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "annotated-asserted",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Annotated triples are asserted.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b314",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b315",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b606",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b36",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1318",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b1266",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "annotation",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Annotation are about the annotated triple.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b619",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b207",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b549",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b550",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1007",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b276",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "title": "annotation-unfolded",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "rdfs:comment": "Annotation is the same as separate assertions.",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "assertions": [
+            {
+              "@id": "_:b514",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "subject": "https://josd.github.io/eye/",
+              "assertedBy": "https://josd.github.io/",
+              "result": {
+                "@id": "_:b292",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            },
+            {
+              "@id": "_:b992",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "subject": "https://rubygems.org/gems/rdf-turtle",
+              "result": {
+                "@id": "_:b692",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1092",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "subject": "https://rubygems.org/gems/sparql",
+              "result": {
+                "@id": "_:b318",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        }
+      ]
     }
   ],
-  "name": "RDF-star",
-  "bibRef": "[[rdf-star]]",
   "testSubjects": [
     {
       "@id": "https://josd.github.io/eye/",
       "@type": [
+        "doap:Project",
         "Software",
-        "TestSubject",
-        "doap:Project"
+        "TestSubject"
       ],
+      "name": "EYE",
+      "language": "Prolog",
       "doapDesc": "Euler Yet another proof Engine",
       "developer": [
         {
           "@id": "https://josd.github.io/",
           "@type": [
-            "foaf:Person",
-            "Assertor"
+            "Assertor",
+            "foaf:Person"
           ],
+          "foaf:name": "Jos De Roo",
           "foaf:homepage": {
             "@id": "https://josd.github.io/",
             "@type": [
-              "foaf:Person",
-              "Assertor"
+              "Assertor",
+              "foaf:Person"
             ],
-            "foaf:homepage": "https://josd.github.io/",
-            "foaf:name": "Jos De Roo"
-          },
-          "foaf:name": "Jos De Roo"
+            "foaf:name": "Jos De Roo",
+            "foaf:homepage": "https://josd.github.io/"
+          }
         }
       ],
-      "language": "Prolog",
+      "homepage": "https://josd.github.io/eye/index.html",
       "release": {
-        "@id": "_:b4",
+        "@id": "_:b9",
         "revision": "EYE v21.0320.2311 josd"
-      },
-      "name": "EYE",
-      "homepage": "https://josd.github.io/eye/index.html"
+      }
     },
     {
       "@id": "https://rubygems.org/gems/rdf-turtle",
       "@type": [
+        "doap:Project",
         "Software",
-        "TestSubject",
-        "doap:Project"
+        "TestSubject"
       ],
+      "name": "Ruby RDF::Turtle",
+      "language": "Ruby",
       "doapDesc": "RDF::Turtle is an Turtle reader/writer for the RDF.rb library suite.",
       "developer": [
         {
           "@id": "https://greggkellogg.net/foaf#me",
           "@type": [
-            "foaf:Person",
-            "Assertor"
+            "Assertor",
+            "foaf:Person"
           ],
-          "foaf:homepage": "https://greggkellogg.net/",
-          "foaf:name": "Gregg Kellogg"
+          "foaf:name": "Gregg Kellogg",
+          "foaf:homepage": "https://greggkellogg.net/"
         }
       ],
-      "language": "Ruby",
+      "homepage": "https://ruby-rdf.github.com/rdf-turtle",
       "release": {
         "@id": "https://github.com/ruby-rdf/rdf-turtle/tree/3.1.3",
         "revision": "3.1.3"
-      },
-      "name": "Ruby RDF::Turtle",
-      "homepage": "https://ruby-rdf.github.com/rdf-turtle"
+      }
     },
     {
       "@id": "https://rubygems.org/gems/sparql",
       "@type": [
+        "doap:Project",
         "Software",
-        "TestSubject",
-        "doap:Project"
+        "TestSubject"
       ],
+      "name": "Ruby SPARQL",
+      "language": "Ruby",
       "doapDesc": "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite.",
       "developer": [
         {
           "@id": "https://greggkellogg.net/foaf#me",
           "@type": [
-            "foaf:Person",
-            "Assertor"
+            "Assertor",
+            "foaf:Person"
           ],
-          "foaf:homepage": "https://greggkellogg.net/",
-          "foaf:name": "Gregg Kellogg"
+          "foaf:name": "Gregg Kellogg",
+          "foaf:homepage": "https://greggkellogg.net/"
         }
       ],
-      "language": "Ruby",
+      "homepage": "https://github.com/ruby-rdf/sparql",
       "release": {
-        "@id": "_:b12",
+        "@id": "_:b2",
         "revision": "3.1.6"
-      },
-      "name": "Ruby SPARQL",
-      "homepage": "https://github.com/ruby-rdf/sparql"
+      }
     }
-  ]
+  ],
+  "bibRef": "[[rdf-star]]"
 }

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -7,84 +7,78 @@
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<> a earl:Software, doap:Project ;
-  earl:generatedBy <https://rubygems.org/gems/earl-report> ;
-  mf:report earl:ruby-turtle.ttl,
+<> a doap:Project, earl:Software ;
+  doap:name "RDF-star" ;
+  mf:report earl:eye-earl.ttl,
     earl:ruby-sparql.ttl,
-    earl:eye-earl.ttl ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#manifest>
+    earl:ruby-turtle.ttl ;
+  earl:generatedBy <https://rubygems.org/gems/earl-report> ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#manifest>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#manifest>
     <https://w3c.github.io/rdf-star/tests/turtle/eval#manifest>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#manifest>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#manifest>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#manifest>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#manifest>) ;
-  doap:name "RDF-star" ;
-  dc:bibliographicCitation "[[rdf-star]]" ;
+    <https://w3c.github.io/rdf-star/tests/semantics#manifest>) ;
   earl:testSubjects <https://josd.github.io/eye/>,
     <https://rubygems.org/gems/rdf-turtle>,
-    <https://rubygems.org/gems/sparql> .
+    <https://rubygems.org/gems/sparql> ;
+  dc:bibliographicCitation "[[rdf-star]]" .
 
 # Manifests
-<https://w3c.github.io/rdf-star/tests/semantics#manifest> a mf:Manifest, earl:Report ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same>
-    <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail>
-    <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term>
-    <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri>
-    <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotation>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded>) ;
-  rdfs:label "RDF-star Semantics tests" ;
-  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/semantics/README> .
+<https://w3c.github.io/rdf-star/tests/nt/syntax#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "N-Triples-star Syntax Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4>) .
 
-<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl> ;
-  rdfs:comment "Multiple occurences of the same embedded triples are undistinguishable in the abstract model." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "all-identical-embedded-triples-are-the-same" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - subject embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -92,35 +86,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test005.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  rdfs:comment "This test ensures that other entailments are not spurious." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "embedded-triples-no-spurious" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - object embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -128,35 +116,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "bnodes-in-embedded-subject" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - subject and object embedded triples" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -164,35 +146,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "bnodes-in-embedded-object" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - whitespace and terms" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -200,35 +176,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "bnodes-in-embedded-subject-and-object" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Nested, no whitespace" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -236,35 +206,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  rdfs:comment "The same bnode can not match different embedded terms." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "bnodes-in-embedded-subject-and-object-fail" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Blank node subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -272,35 +236,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
-  rdfs:comment "Identical embedded term can be replaced by the same fresh bnode multiple times." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "same-bnode-same-embedded-term" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Blank node object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -308,35 +266,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
-  rdfs:comment "Different bnodes can match identical embedded terms." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "different-bnodes-same-embedded-term" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Nested subject term" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -344,35 +296,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
-  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes" ;
-  mf:entailmentRegime "simple" ;
-  mf:name "constrained-bnodes-in-embedded-subject" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Nested object term" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -380,35 +326,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
-  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "constrained-bnodes-in-embedded-object" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Bad - embedded triple as predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -416,35 +356,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
-  rdfs:comment "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "constrained-bnodes-in-embedded-fail" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Bad - embedded triple, literal subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -452,35 +386,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl> ;
-  rdfs:comment "Literals in embedded triples and outside can be replaced by fresh bnodes." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "constrained-bnodes-on-literal" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Bad - embedded triple, literal predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -488,35 +416,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl> ;
-  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "malformed-literal-control" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star - Bad - embedded triple, blank node predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -524,71 +446,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  rdfs:comment "Malformed literals are allowed when embedded." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "malformed-literal" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - subject embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:failed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  rdfs:comment "Malformed literals are allowed when embedded." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "malformed-literal-accepted" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -596,106 +476,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  rdfs:comment "Embedded malformed literals do not lead to spurious entailment." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "malformed-literal-no-spurious" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - object embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:failed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  rdfs:comment "Malformed literals can not be replaced by blank nodes." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "malformed-literal-bnode" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl> ;
-  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "opaque-literal-control" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -703,71 +506,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl> ;
-  rdfs:comment "Embedded literals are opaque, even when their datatype is recognized." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "opaque-literal" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - subject and object embedded triples" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-3.ttl> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:failed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl> ;
-  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "opaque-language-string-control" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -775,71 +536,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl> ;
-  rdfs:comment "Embedded literals (including language strings) are opaque, even when their datatype is recognized." ;
-  mf:entailmentRegime "RDF" ;
-  mf:name "opaque-language-string" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - whitespace and terms" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:failed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl> ;
-  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously." ;
-  mf:entailmentRegime "RDFS-Plus" ;
-  mf:name "opaque-iri-control" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -847,35 +566,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/superman.ttl> ;
-  rdfs:comment "Embedded IRIs are opaque." ;
-  mf:entailmentRegime "RDFS-Plus" ;
-  mf:name "opaque-iri" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Nested, no whitespace" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -883,35 +596,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  rdfs:comment "Embedded triples are not asserted." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "embedded-not-asserted" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Blank node subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -919,35 +626,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
-  rdfs:comment "Annotated triples are asserted." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "annotated-asserted" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Blank node object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -955,35 +656,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#annotation> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
-  rdfs:comment "Annotation are about the annotated triple." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "annotation" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Nested subject term" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -991,35 +686,29 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> a earl:TestCriterion, mf:PositiveEntailmentTest, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:recognizedDatatypes () ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
-  mf:unrecognizedDatatypes () ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl> ;
-  rdfs:comment "Annotation is the same as separate assertions." ;
-  mf:entailmentRegime "simple" ;
-  mf:name "annotation-unfolded" ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Nested object term" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -1027,7 +716,791 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#manifest> a mf:Manifest, earl:Report ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple as predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-1.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-2.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-3.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
+  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-4.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "TriG-star Syntax Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2>) .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - subject embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - object embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - embedded triple inside blankNodePropertyList" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - embedded triple inside collection" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - nested embedded triple, subject position" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - nested embedded triple, object position" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - compound forms" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - blank node subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - blank node object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - blank node" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - embedded triple as predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - embedded triple outside triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - collection list in embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - literal in subject position of embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - blank node  as predicate in embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - compound blank node expression" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - incomplete embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - over-long embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - Annotation form" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+  mf:name "TriG-star - Annotation example" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - empty annotation" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase ;
+  mf:name "TriG-star - bad - triple as annotation" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "Turtle-star Evaluation Tests" ;
   mf:entries (<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1>
     <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2>
     <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1>
@@ -1039,13 +1512,12 @@
     <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5>
     <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1>
     <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3>) ;
-  rdfs:label "Turtle-star Evaluation Tests" .
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3>) .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - subject embedded triple" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl> ;
-  mf:name "Turtle-star - subject embedded triple" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
@@ -1074,10 +1546,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - object embedded triple" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl> ;
-  mf:name "Turtle-star - object embedded triple" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
@@ -1106,10 +1578,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - blank node label" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl> ;
-  mf:name "Turtle-star - blank node label" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
@@ -1138,10 +1610,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - blank node labels" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl> ;
-  mf:name "Turtle-star - blank node labels" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
@@ -1170,10 +1642,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation form" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl> ;
-  mf:name "Turtle-star - Annotation form" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
@@ -1202,10 +1674,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation example" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl> ;
-  mf:name "Turtle-star - Annotation example" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
@@ -1234,10 +1706,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation - predicate and object lists" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl> ;
-  mf:name "Turtle-star - Annotation - predicate and object lists" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
@@ -1266,10 +1738,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation - nested" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl> ;
-  mf:name "Turtle-star - Annotation - nested" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
@@ -1298,10 +1770,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation object list" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl> ;
-  mf:name "Turtle-star - Annotation object list" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
@@ -1330,10 +1802,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation with embedding" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl> ;
-  mf:name "Turtle-star - Annotation with embedding" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
@@ -1362,10 +1834,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation on triple with embedded subject" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl> ;
-  mf:name "Turtle-star - Annotation on triple with embedded subject" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
@@ -1394,10 +1866,10 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
+  mf:name "Turtle-star - Annotation on triple with embedded object" ;
   mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt> ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl> ;
-  mf:name "Turtle-star - Annotation on triple with embedded object" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
@@ -1426,7 +1898,1314 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest> a mf:Manifest, earl:Report ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "TriG-star Evaluation Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3>) .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - subject embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - object embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - blank node label" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - blank node labels" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation form" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation example" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation - predicate and object lists" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation - nested" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation object list" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation with embedding" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation on triple with embedded subject" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval> ;
+  mf:name "TriG-star - Annotation on triple with embedded object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.trig> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "SPARQL-star Evaluation Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3>) .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - all graph triples (JSON results)" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj> ;
+  mf:action _:b134 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - all graph triples (XML results)" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx> ;
+  mf:action _:b70 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - match constant embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj> ;
+  mf:action _:b488 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - match embedded triple, var subject" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj> ;
+  mf:action _:b205 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - match embedded triple, var predicate" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj> ;
+  mf:action _:b280 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - match embedded triple, var object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj> ;
+  mf:action _:b200 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - no match of embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj> ;
+  mf:action _:b15 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Asserted and embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj> ;
+  mf:action _:b646 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star -  Asserted and embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj> ;
+  mf:action _:b138 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Pattern - Variable for embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj> ;
+  mf:action _:b624 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Pattern - No match" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj> ;
+  mf:action _:b208 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Pattern - match variables in triple terms" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj> ;
+  mf:action _:b92 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Pattern - Nesting 1" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj> ;
+  mf:action _:b578 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Pattern - Nesting - 2" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj> ;
+  mf:action _:b311 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Pattern - Match and nesting" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj> ;
+  mf:action _:b183 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Pattern - Same variable" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj> ;
+  mf:action _:b264 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - CONSTRUCT with constant template" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl> ;
+  mf:action _:b457 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - CONSTRUCT WHERE with constant template" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl> ;
+  mf:action _:b486 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - CONSTRUCT - about every triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl> ;
+  mf:action _:b626 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - CONSTRUCT with annotation syntax" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl> ;
+  mf:action _:b54 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - CONSTRUCT WHERE with annotation syntax" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl> ;
+  mf:action _:b186 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - GRAPH" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj> ;
+  mf:action _:b245 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - GRAPHs with blank node" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj> ;
+  mf:action _:b228 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Embedded triple - BIND - CONSTRUCT" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl> ;
+  mf:action _:b122 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Embedded triple - Functions" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj> ;
+  mf:action _:b194 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:name "SPARQL-star - Embedded triple ORDER BY" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj> ;
+  mf:action _:b53 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
+  mf:name "SPARQL-star - Update" ;
+  mf:result _:b530 ;
+  mf:action _:b531 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
+  mf:name "SPARQL-star - Update - annotation" ;
+  mf:result _:b433 ;
+  mf:action _:b434 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
+  mf:name "SPARQL-star - Update - data" ;
+  mf:result _:b507 ;
+  mf:action _:b508 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "SPARQL-star Syntax Tests" ;
   mf:entries (<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3>
@@ -1487,12 +3266,11 @@
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4>) ;
-  rdfs:label "SPARQL-star Syntax Tests" .
+    <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4>) .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - subject embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> ;
@@ -1520,9 +3298,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - object embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> ;
@@ -1550,9 +3328,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - subject embedded triple - vars" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> ;
@@ -1580,9 +3358,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - object embedded triple - vars" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> ;
@@ -1610,9 +3388,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Embedded triple in VALUES" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> ;
@@ -1640,9 +3418,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Embedded triple in CONSTRUCT" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> ;
@@ -1670,9 +3448,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Embedded triples in CONSTRUCT WHERE" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> ;
@@ -1700,9 +3478,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - embedded triple inside blankNodePropertyList" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> ;
@@ -1730,9 +3508,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - embedded triple inside collection" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> ;
@@ -1760,9 +3538,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - nested embedded triple, subject position" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> ;
@@ -1790,9 +3568,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - nested embedded triple, object position" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> ;
@@ -1820,9 +3598,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - compound forms" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> ;
@@ -1850,9 +3628,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - blank node subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> ;
@@ -1880,9 +3658,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - blank node object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> ;
@@ -1910,9 +3688,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - blank node" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> ;
@@ -1940,9 +3718,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Annotation form" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> ;
@@ -1970,9 +3748,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - Annotation example" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq> ;
-  mf:name "SPARQL-star - Annotation example" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> ;
@@ -2000,9 +3778,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - Annotation example" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq> ;
-  mf:name "SPARQL-star - Annotation example" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> ;
@@ -2030,9 +3808,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Annotation with embedding" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> ;
@@ -2060,9 +3838,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Annotation on triple with embedded object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> ;
@@ -2090,9 +3868,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Annotation with path" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> ;
@@ -2120,9 +3898,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Annotation with nested path" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> ;
@@ -2150,9 +3928,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Annotation in CONSTRUCT " ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> ;
@@ -2180,9 +3958,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Annotation in CONSTRUCT WHERE" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> ;
@@ -2210,9 +3988,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - Expressions - Embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq> ;
-  mf:name "SPARQL-star - Expressions - Embedded triple" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> ;
@@ -2240,9 +4018,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - Expressions - Embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq> ;
-  mf:name "SPARQL-star - Expressions - Embedded triple" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> ;
@@ -2270,9 +4048,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - Expressions - Functions" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq> ;
-  mf:name "SPARQL-star - Expressions - Functions" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> ;
@@ -2300,9 +4078,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Expressions - TRIPLE" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> ;
@@ -2330,9 +4108,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Expressions - Functions" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> ;
@@ -2360,9 +4138,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> a earl:TestCriterion, earl:TestCase, mf:PositiveSyntaxTest11 ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - Expressions - BIND - CONSTRUCT" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> ;
@@ -2391,8 +4169,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq> ;
   mf:name "SPARQL-star - bad - embedded triple as predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> ;
@@ -2421,8 +4199,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq> ;
   mf:name "SPARQL-star - bad - embedded triple outside triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> ;
@@ -2451,8 +4229,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq> ;
   mf:name "SPARQL-star - bad - collection list in embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> ;
@@ -2481,8 +4259,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq> ;
   mf:name "SPARQL-star - bad - literal in subject position of embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> ;
@@ -2511,8 +4289,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq> ;
   mf:name "SPARQL-star - bad - blank node  as predicate in embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> ;
@@ -2541,8 +4319,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq> ;
   mf:name "SPARQL-star - bad - compound blank node expression" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> ;
@@ -2571,8 +4349,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq> ;
   mf:name "SPARQL-star - bad - incomplete embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> ;
@@ -2601,8 +4379,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq> ;
   mf:name "SPARQL-star - bad - quad embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> ;
@@ -2631,8 +4409,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq> ;
   mf:name "SPARQL-star - bad - variable in embedded triple in VALUES " ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> ;
@@ -2661,8 +4439,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq> ;
   mf:name "SPARQL-star - bad - blank node in embedded triple in VALUES " ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> ;
@@ -2691,8 +4469,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq> ;
   mf:name "SPARQL-star - bad - empty annotation" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> ;
@@ -2721,8 +4499,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq> ;
   mf:name "SPARQL-star - bad - triples in annotation" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> ;
@@ -2751,8 +4529,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq> ;
   mf:name "SPARQL-star - bad - path - seq" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> ;
@@ -2781,8 +4559,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq> ;
   mf:name "SPARQL-star - bad - path - alt" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> ;
@@ -2811,8 +4589,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq> ;
   mf:name "SPARQL-star - bad - path - p*" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> ;
@@ -2841,8 +4619,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq> ;
   mf:name "SPARQL-star - bad - path - p+" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> ;
@@ -2871,8 +4649,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq> ;
   mf:name "SPARQL-star - bad - path - p?" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> ;
@@ -2901,8 +4679,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq> ;
   mf:name "SPARQL-star - bad - path in CONSTRUCT" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> ;
@@ -2931,8 +4709,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq> ;
   mf:name "SPARQL-star - bad - path in CONSTRUCT" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> ;
@@ -2960,9 +4738,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - update" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru> ;
-  mf:name "SPARQL-star - update" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> ;
@@ -2990,9 +4768,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - update" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru> ;
-  mf:name "SPARQL-star - update" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> ;
@@ -3020,9 +4798,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+  mf:name "SPARQL-star - update" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru> ;
-  mf:name "SPARQL-star - update" ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> ;
@@ -3050,9 +4828,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - update with embedding" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> ;
@@ -3080,9 +4858,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - update with embedded object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> ;
@@ -3110,9 +4888,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - update with annotation template" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> ;
@@ -3140,9 +4918,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - update with annotation, template and pattern" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> ;
@@ -3170,9 +4948,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> a mf:PositiveUpdateSyntaxTest11, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru> ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
   mf:name "SPARQL-star - update DATA with annotation" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> ;
@@ -3201,8 +4979,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> ;
@@ -3231,8 +5009,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> ;
@@ -3261,8 +5039,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> ;
@@ -3291,8 +5069,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> ;
@@ -3320,7 +5098,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest> a mf:Manifest, earl:Report ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "Turtle-star Syntax Tests" ;
   mf:entries (<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1>
@@ -3342,12 +5121,11 @@
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2>) ;
-  rdfs:label "Turtle-star Syntax Tests" .
+    <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2>) .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl> ;
   mf:name "Turtle-star - subject embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> ;
@@ -3377,8 +5155,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl> ;
   mf:name "Turtle-star - object embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> ;
@@ -3408,8 +5186,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl> ;
   mf:name "Turtle-star - embedded triple inside blankNodePropertyList" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> ;
@@ -3439,8 +5217,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl> ;
   mf:name "Turtle-star - embedded triple inside collection" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> ;
@@ -3470,8 +5248,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl> ;
   mf:name "Turtle-star - nested embedded triple, subject position" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> ;
@@ -3501,8 +5279,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl> ;
   mf:name "Turtle-star - nested embedded triple, object position" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> ;
@@ -3532,8 +5310,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl> ;
   mf:name "Turtle-star - compound forms" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> ;
@@ -3563,8 +5341,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl> ;
   mf:name "Turtle-star - blank node subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> ;
@@ -3594,8 +5372,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl> ;
   mf:name "Turtle-star - blank node object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> ;
@@ -3625,8 +5403,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl> ;
   mf:name "Turtle-star - blank node" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> ;
@@ -3655,9 +5433,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - embedded triple as predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> ;
@@ -3686,9 +5464,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - embedded triple outside triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> ;
@@ -3717,9 +5495,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - collection list in embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> ;
@@ -3748,9 +5526,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - literal in subject position of embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> ;
@@ -3779,9 +5557,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - blank node  as predicate in embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> ;
@@ -3810,9 +5588,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - compound blank node expression" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> ;
@@ -3841,9 +5619,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - incomplete embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> ;
@@ -3872,9 +5650,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - over-long embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> ;
@@ -3904,8 +5682,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl> ;
   mf:name "Turtle-star - Annotation form" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> ;
@@ -3935,8 +5713,8 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl> ;
   mf:name "Turtle-star - Annotation example" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> ;
@@ -3965,9 +5743,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - empty annotation" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> ;
@@ -3996,9 +5774,9 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase ;
   mf:name "Turtle-star - bad - triple as annotation" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> ;
@@ -4027,53 +5805,58 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#manifest> a mf:Manifest, earl:Report ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3>) ;
-  rdfs:label "SPARQL-star Evaluation Tests" .
+<https://w3c.github.io/rdf-star/tests/semantics#manifest> a earl:Report, mf:Manifest ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/semantics/README> ;
+  rdfs:label "RDF-star Semantics tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same>
+    <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail>
+    <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term>
+    <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri>
+    <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotation>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded>) .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj> ;
-  mf:action _:b276 ;
-  mf:name "SPARQL-star - all graph triples (JSON results)" ;
+<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "all-identical-embedded-triples-are-the-same" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Multiple occurences of the same embedded triples are undistinguishable in the abstract model." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4081,30 +5864,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx> ;
-  mf:action _:b104 ;
-  mf:name "SPARQL-star - all graph triples (XML results)" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "embedded-triples-no-spurious" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test005.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "This test ensures that other entailments are not spurious." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4112,30 +5900,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj> ;
-  mf:action _:b418 ;
-  mf:name "SPARQL-star - match constant embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "bnodes-in-embedded-subject" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4143,30 +5936,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj> ;
-  mf:action _:b311 ;
-  mf:name "SPARQL-star - match embedded triple, var subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "bnodes-in-embedded-object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4174,30 +5972,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj> ;
-  mf:action _:b0 ;
-  mf:name "SPARQL-star - match embedded triple, var predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "bnodes-in-embedded-subject-and-object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4205,30 +6008,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj> ;
-  mf:action _:b122 ;
-  mf:name "SPARQL-star - match embedded triple, var object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "bnodes-in-embedded-subject-and-object-fail" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "The same bnode can not match different embedded terms." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4236,30 +6044,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj> ;
-  mf:action _:b257 ;
-  mf:name "SPARQL-star - no match of embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "same-bnode-same-embedded-term" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Identical embedded term can be replaced by the same fresh bnode multiple times." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4267,30 +6080,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj> ;
-  mf:action _:b178 ;
-  mf:name "SPARQL-star - Asserted and embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "different-bnodes-same-embedded-term" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Different bnodes can match identical embedded terms." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4298,30 +6116,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj> ;
-  mf:action _:b745 ;
-  mf:name "SPARQL-star -  Asserted and embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "constrained-bnodes-in-embedded-subject" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4329,30 +6152,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj> ;
-  mf:action _:b206 ;
-  mf:name "SPARQL-star - Pattern - Variable for embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "constrained-bnodes-in-embedded-object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4360,30 +6188,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj> ;
-  mf:action _:b181 ;
-  mf:name "SPARQL-star - Pattern - No match" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "constrained-bnodes-in-embedded-fail" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4391,30 +6224,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj> ;
-  mf:action _:b70 ;
-  mf:name "SPARQL-star - Pattern - match variables in triple terms" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "constrained-bnodes-on-literal" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Literals in embedded triples and outside can be replaced by fresh bnodes." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4422,30 +6260,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj> ;
-  mf:action _:b199 ;
-  mf:name "SPARQL-star - Pattern - Nesting 1" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "malformed-literal-control" ;
+  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously." ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4453,30 +6296,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj> ;
-  mf:action _:b469 ;
-  mf:name "SPARQL-star - Pattern - Nesting - 2" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "malformed-literal" ;
+  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Malformed literals are allowed when embedded." ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:failed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4484,30 +6332,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj> ;
-  mf:action _:b546 ;
-  mf:name "SPARQL-star - Pattern - Match and nesting" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "malformed-literal-accepted" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Malformed literals are allowed when embedded." ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4515,30 +6368,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj> ;
-  mf:action _:b100 ;
-  mf:name "SPARQL-star - Pattern - Same variable" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "malformed-literal-no-spurious" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Embedded malformed literals do not lead to spurious entailment." ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:failed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4546,22 +6404,26 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl> ;
-  mf:action _:b215 ;
-  mf:name "SPARQL-star - CONSTRUCT with constant template" ;
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "malformed-literal-bnode" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Malformed literals can not be replaced by blank nodes." ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4569,7 +6431,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4577,30 +6439,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl> ;
-  mf:action _:b478 ;
-  mf:name "SPARQL-star - CONSTRUCT WHERE with constant template" ;
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "opaque-literal-control" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously." ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4608,30 +6475,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl> ;
-  mf:action _:b110 ;
-  mf:name "SPARQL-star - CONSTRUCT - about every triple" ;
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "opaque-literal" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Embedded literals are opaque, even when their datatype is recognized." ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:failed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4639,30 +6511,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl> ;
-  mf:action _:b34 ;
-  mf:name "SPARQL-star - CONSTRUCT with annotation syntax" ;
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "opaque-language-string-control" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4670,30 +6547,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl> ;
-  mf:action _:b325 ;
-  mf:name "SPARQL-star - CONSTRUCT WHERE with annotation syntax" ;
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:name "opaque-language-string" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Embedded literals (including language strings) are opaque, even when their datatype is recognized." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:failed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4701,30 +6583,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj> ;
-  mf:action _:b19 ;
-  mf:name "SPARQL-star - GRAPH" ;
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDFS-Plus" ;
+  mf:name "opaque-iri-control" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4732,30 +6619,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj> ;
-  mf:action _:b22 ;
-  mf:name "SPARQL-star - GRAPHs with blank node" ;
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "RDFS-Plus" ;
+  mf:name "opaque-iri" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Embedded IRIs are opaque." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/superman.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4763,30 +6655,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl> ;
-  mf:action _:b225 ;
-  mf:name "SPARQL-star - Embedded triple - BIND - CONSTRUCT" ;
+<https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "embedded-not-asserted" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Embedded triples are not asserted." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4794,30 +6691,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj> ;
-  mf:action _:b58 ;
-  mf:name "SPARQL-star - Embedded triple - Functions" ;
+<https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "annotated-asserted" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Annotated triples are asserted." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4825,30 +6727,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj> ;
-  mf:action _:b165 ;
-  mf:name "SPARQL-star - Embedded triple ORDER BY" ;
+<https://w3c.github.io/rdf-star/tests/semantics#annotation> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "annotation" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Annotation are about the annotated triple." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4856,30 +6763,35 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
-  mf:result _:b263 ;
-  mf:action _:b264 ;
-  mf:name "SPARQL-star - Update" ;
+<https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> a mf:PositiveEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:name "annotation-unfolded" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  rdfs:comment "Annotation is the same as separate assertions." ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
     earl:subject <https://rubygems.org/gems/rdf-turtle> ;
     earl:result [
       a earl:TestResult ;
@@ -4887,129 +6799,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
-  mf:result _:b246 ;
-  mf:action _:b247 ;
-  mf:name "SPARQL-star - Update - annotation" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
-  mf:result _:b71 ;
-  mf:action _:b6 ;
-  mf:name "SPARQL-star - Update - data" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#manifest> a mf:Manifest, earl:Report ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4>) ;
-  rdfs:label "N-Triples-star Syntax Tests" .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt> ;
-  mf:name "N-Triples-star - subject embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -5017,791 +6807,41 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt> ;
-  mf:name "N-Triples-star - object embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt> ;
-  mf:name "N-Triples-star - subject and object embedded triples" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt> ;
-  mf:name "N-Triples-star - whitespace and terms" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt> ;
-  mf:name "N-Triples-star - Nested, no whitespace" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt> ;
-  mf:name "N-Triples-star - Blank node subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt> ;
-  mf:name "N-Triples-star - Blank node object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt> ;
-  mf:name "N-Triples-star - Nested subject term" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt> ;
-  mf:name "N-Triples-star - Nested object term" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt> ;
-  mf:name "N-Triples-star - Bad - embedded triple as predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt> ;
-  mf:name "N-Triples-star - Bad - embedded triple, literal subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt> ;
-  mf:name "N-Triples-star - Bad - embedded triple, literal predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt> ;
-  mf:name "N-Triples-star - Bad - embedded triple, blank node predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-1.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - subject embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-2.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - object embedded triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-syntax-3.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - subject and object embedded triples" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt> ;
-  mf:name "N-Triples-star as Turtle-star - whitespace and terms" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt> ;
-  mf:name "N-Triples-star as Turtle-star - Nested, no whitespace" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-1.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Blank node subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bnode-2.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Blank node object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-1.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Nested subject term" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-nested-2.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Nested object term" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-nested-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-1.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple as predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-2.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-3.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/nt-ttl-star-bad-syntax-4.ttl> ;
-  mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-turtle> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#nt-ttl-star-bad-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://josd.github.io/eye/> a earl:Software, earl:TestSubject, doap:Project ;
+<https://josd.github.io/eye/> a doap:Project, earl:Software, earl:TestSubject ;
+  doap:name "EYE" ;
+  doap:programming-language "Prolog" ;
   doap:description "Euler Yet another proof Engine"@en ;
   doap:developer <https://josd.github.io/> ;
-  doap:programming-language "Prolog" ;
-  doap:release [doap:revision "EYE v21.0320.2311 josd"] ;
-  doap:name "EYE" ;
-  doap:homepage <https://josd.github.io/eye/index.html> .
+  doap:homepage <https://josd.github.io/eye/index.html> ;
+  doap:release [doap:revision "EYE v21.0320.2311 josd"] .
 
-<https://josd.github.io/> a foaf:Person, earl:Assertor ;
-  foaf:homepage <https://josd.github.io/> ;
-  foaf:name "Jos De Roo" .
+<https://josd.github.io/> a earl:Assertor, foaf:Person ;
+  foaf:name "Jos De Roo" ;
+  foaf:homepage <https://josd.github.io/> .
 
-<https://rubygems.org/gems/rdf-turtle> a earl:Software, earl:TestSubject, doap:Project ;
+<https://rubygems.org/gems/rdf-turtle> a doap:Project, earl:Software, earl:TestSubject ;
+  doap:name "Ruby RDF::Turtle" ;
+  doap:programming-language "Ruby" ;
   doap:description "RDF::Turtle is an Turtle reader/writer for the RDF.rb library suite."@en ;
   doap:developer <https://greggkellogg.net/foaf#me> ;
+  doap:homepage <https://ruby-rdf.github.com/rdf-turtle> ;
+  doap:release [doap:revision "3.1.3"] .
+
+<https://greggkellogg.net/foaf#me> a earl:Assertor, foaf:Person ;
+  foaf:name "Gregg Kellogg" ;
+  foaf:homepage <https://greggkellogg.net/> .
+
+<https://rubygems.org/gems/sparql> a doap:Project, earl:Software, earl:TestSubject ;
+  doap:name "Ruby SPARQL" ;
   doap:programming-language "Ruby" ;
-  doap:release [doap:revision "3.1.3"] ;
-  doap:name "Ruby RDF::Turtle" ;
-  doap:homepage <https://ruby-rdf.github.com/rdf-turtle> .
-
-<https://greggkellogg.net/foaf#me> a foaf:Person, earl:Assertor ;
-  foaf:homepage <https://greggkellogg.net/> ;
-  foaf:name "Gregg Kellogg" .
-
-<https://rubygems.org/gems/sparql> a earl:Software, earl:TestSubject, doap:Project ;
   doap:description "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite."@en ;
   doap:developer <https://greggkellogg.net/foaf#me> ;
-  doap:programming-language "Ruby" ;
-  doap:release [doap:revision "3.1.6"] ;
-  doap:name "Ruby SPARQL" ;
-  doap:homepage <https://github.com/ruby-rdf/sparql> .
+  doap:homepage <https://github.com/ruby-rdf/sparql> ;
+  doap:release [doap:revision "3.1.6"] .
 
-<https://greggkellogg.net/foaf#me> a foaf:Person, earl:Assertor ;
-  foaf:homepage <https://greggkellogg.net/> ;
-  foaf:name "Gregg Kellogg" .
+<https://greggkellogg.net/foaf#me> a earl:Assertor, foaf:Person ;
+  foaf:name "Gregg Kellogg" ;
+  foaf:homepage <https://greggkellogg.net/> .
 
 
 # Report Generation Software

--- a/reports/index.html
+++ b/reports/index.html
@@ -5,9 +5,9 @@
 <link href='earl.ttl' rel='alternate' type='text/turtle' />
 <link href='earl.jsonld' rel='alternate' type='application/ld+json' />
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
-<link href='ruby-turtle.ttl' rel='related' />
-<link href='ruby-sparql.ttl' rel='related' />
 <link href='eye-earl.ttl' rel='related' />
+<link href='ruby-sparql.ttl' rel='related' />
+<link href='ruby-turtle.ttl' rel='related' />
 <title>
 RDF-star Processor Conformance
 </title>
@@ -92,8 +92,8 @@ RDF-star Processor Conformance
 EARL results from the RDF-star Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2021-03-26' property='dc:issued'>
-26 March 2021
+<time class='dt-published' datetime='2021-03-31' property='dc:issued'>
+31 March 2021
 </time>
 </h2>
 <dl>
@@ -208,12 +208,24 @@ SPARQL-star Syntax Tests
 </li>
 <li class='tocline'>
 <span class='secno'>3.5</span>
+<a class='tocxref' href='#TriG-star-Evaluation-Tests'>
+TriG-star Evaluation Tests
+</a>
+</li>
+<li class='tocline'>
+<span class='secno'>3.6</span>
+<a class='tocxref' href='#TriG-star-Syntax-Tests'>
+TriG-star Syntax Tests
+</a>
+</li>
+<li class='tocline'>
+<span class='secno'>3.7</span>
 <a class='tocxref' href='#Turtle-star-Evaluation-Tests'>
 Turtle-star Evaluation Tests
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>3.6</span>
+<span class='secno'>3.8</span>
 <a class='tocxref' href='#Turtle-star-Syntax-Tests'>
 Turtle-star Syntax Tests
 </a>
@@ -1572,9 +1584,215 @@ Percentage passed out of 61 Tests
 </tr>
 </table>
 </section>
-<section id='Turtle-star-Evaluation-Tests'>
+<section id='TriG-star-Evaluation-Tests'>
 <h2>
 <span class='secno'>3.5</span>
+<span>TriG-star Evaluation Tests</span>
+</h2>
+<table class='report'>
+<tr>
+<th>
+Test
+</th>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1'>Test trig-star-1: TriG-star - subject embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2'>Test trig-star-2: TriG-star - object embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1'>Test trig-star-bnode-1: TriG-star - blank node label</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2'>Test trig-star-bnode-2: TriG-star - blank node labels</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1'>Test trig-star-annotation-1: TriG-star - Annotation form</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2'>Test trig-star-annotation-2: TriG-star - Annotation example</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3'>Test trig-star-annotation-3: TriG-star - Annotation - predicate and object lists</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4'>Test trig-star-annotation-4: TriG-star - Annotation - nested</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5'>Test trig-star-annotation-5: TriG-star - Annotation object list</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1'>Test trig-star-embed-annotation-1: TriG-star - Annotation with embedding</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2'>Test trig-star-embed-annotation-2: TriG-star - Annotation on triple with embedded subject</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3'>Test trig-star-embed-annotation-3: TriG-star - Annotation on triple with embedded object</a>
+</td>
+</tr>
+<tr class='summary'>
+<td>
+Percentage passed out of 12 Tests
+</td>
+</tr>
+</table>
+</section>
+<section id='TriG-star-Syntax-Tests'>
+<h2>
+<span class='secno'>3.6</span>
+<span>TriG-star Syntax Tests</span>
+</h2>
+<table class='report'>
+<tr>
+<th>
+Test
+</th>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1'>Test trig-star-1: TriG-star - subject embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2'>Test trig-star-2: TriG-star - object embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1'>Test trig-star-inside-1: TriG-star - embedded triple inside blankNodePropertyList</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2'>Test trig-star-inside-2: TriG-star - embedded triple inside collection</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1'>Test trig-star-nested-1: TriG-star - nested embedded triple, subject position</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2'>Test trig-star-nested-2: TriG-star - nested embedded triple, object position</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1'>Test trig-star-compound-1: TriG-star - compound forms</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1'>Test trig-star-bnode-1: TriG-star - blank node subject</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2'>Test trig-star-bnode-2: TriG-star - blank node object</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3'>Test trig-star-bnode-3: TriG-star - blank node</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1'>Test trig-star-bad-1: TriG-star - bad - embedded triple as predicate</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2'>Test trig-star-bad-2: TriG-star - bad - embedded triple outside triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3'>Test trig-star-bad-3: TriG-star - bad - collection list in embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4'>Test trig-star-bad-4: TriG-star - bad - literal in subject position of embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5'>Test trig-star-bad-5: TriG-star - bad - blank node  as predicate in embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6'>Test trig-star-bad-6: TriG-star - bad - compound blank node expression</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7'>Test trig-star-bad-7: TriG-star - bad - incomplete embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8'>Test trig-star-bad-8: TriG-star - bad - over-long embedded triple</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1'>Test trig-star-ann-1: TriG-star - Annotation form</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2'>Test trig-star-ann-2: TriG-star - Annotation example</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1'>Test trig-star-bad-ann-1: TriG-star - bad - empty annotation</a>
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2'>Test trig-star-bad-ann-2: TriG-star - bad - triple as annotation</a>
+</td>
+</tr>
+<tr class='summary'>
+<td>
+Percentage passed out of 22 Tests
+</td>
+</tr>
+</table>
+</section>
+<section id='Turtle-star-Evaluation-Tests'>
+<h2>
+<span class='secno'>3.7</span>
 <span>Turtle-star Evaluation Tests</span>
 </h2>
 <table class='report'>
@@ -1744,7 +1962,7 @@ Percentage passed out of 12 Tests
 </section>
 <section id='Turtle-star-Syntax-Tests'>
 <h2>
-<span class='secno'>3.6</span>
+<span class='secno'>3.8</span>
 <span>Turtle-star Syntax Tests</span>
 </h2>
 <table class='report'>
@@ -2058,7 +2276,7 @@ https://josd.github.io/eye/index.html
 <a href='https://josd.github.io/'>
 <span property='foaf:name'>Jos De Roo</span>
 </a>
-<a href-@id='https://josd.github.io/' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://josd.github.io/' href-foaf:name='Jos De Roo' property='foaf:homepage'>
+<a href-@id='https://josd.github.io/' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://josd.github.io/' href-foaf:name='Jos De Roo' property='foaf:homepage'>
 https://josd.github.io/
 </a>
 </div>
@@ -2234,17 +2452,17 @@ Individual test results used to construct this report are available here:
 </p>
 <ul>
 <li>
-<a class='source' href='ruby-turtle.ttl'>ruby-turtle.ttl</a>
+<a class='source' href='eye-earl.ttl'>eye-earl.ttl</a>
 </li>
 <li>
 <a class='source' href='ruby-sparql.ttl'>ruby-sparql.ttl</a>
 </li>
 <li>
-<a class='source' href='eye-earl.ttl'>eye-earl.ttl</a>
+<a class='source' href='ruby-turtle.ttl'>ruby-turtle.ttl</a>
 </li>
 </ul>
 </section>
-<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='https://rubygems.org/gems/earl-report' typeof='Software doap:Project'>
+<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='https://rubygems.org/gems/earl-report' typeof='doap:Project Software'>
 <h2>
 <span class='secno'>C.</span>
 Report Generation Software

--- a/tests/index.html
+++ b/tests/index.html
@@ -42,6 +42,8 @@
       <li><a href="semantics/">Semantics tests</a>,</li>
       <li><a href="sparql/syntax/">SPARQL Syntax tests</a>,</li>
       <li><a href="sparql/eval/">SPARQL Evaluation tests</a>,</li>
+      <li><a href="trig/syntax/">TriG Syntax tests</a>,</li>
+      <li><a href="trig/eval/">TriG Evaluation tests</a>,</li>
       <li><a href="turtle/syntax/">Turtle Syntax tests</a>,</li>
       <li><a href="turtle/eval/">Turtle Evaluation tests</a>,</li>
     </ul>

--- a/tests/make-jsonld-manifests.rb
+++ b/tests/make-jsonld-manifests.rb
@@ -13,6 +13,8 @@ local_ctx = JSON.parse(File.read("#{man_dir}/manifest-context.jsonld"))
   semantics
   sparql/syntax
   sparql/eval
+  trig/syntax
+  trig/eval
   turtle/syntax
   turtle/eval
 }.each do |path|

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -9,6 +9,8 @@
       "semantics/manifest.jsonld",
       "sparql/eval/manifest.jsonld",
       "sparql/syntax/manifest.jsonld",
+      "trig/eval/manifest.jsonld",
+      "trig/syntax/manifest.jsonld",
       "turtle/eval/manifest.jsonld",
       "turtle/syntax/manifest.jsonld"
    ]

--- a/tests/manifest.ttl
+++ b/tests/manifest.ttl
@@ -17,6 +17,8 @@ trs:manifest  rdf:type mf:Manifest ;
       <semantics/manifest.ttl>
       <sparql/eval/manifest.ttl>
       <sparql/syntax/manifest.ttl>
+      <trig/eval/manifest.ttl>
+      <trig/syntax/manifest.ttl>
       <turtle/eval/manifest.ttl>
       <turtle/syntax/manifest.ttl>
     ) .

--- a/tests/nt/syntax/manifest.jsonld
+++ b/tests/nt/syntax/manifest.jsonld
@@ -60,11 +60,14 @@
         "NotClassified": "test:NotClassified",
         "Rejected": "test:Rejected",
         "Obsoleted": "test:Obsoleted",
-        "Withdrawn": "test:RejectedWithdrawn"
+        "Withdrawn": "test:Withdrawn"
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
+    "statusOf": {
+      "@reverse": "test:approval"
+    }
   },
   "@id": "trs:manifest",
   "@type": "Manifest",
@@ -73,158 +76,158 @@
     {
       "@id": "trs:ntriples-star-1",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - subject embedded triple",
-      "action": "ntriples-star-syntax-1.nt"
+      "action": "ntriples-star-syntax-1.nt",
+      "name": "N-Triples-star - subject embedded triple"
     },
     {
       "@id": "trs:ntriples-star-2",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - object embedded triple",
-      "action": "ntriples-star-syntax-2.nt"
+      "action": "ntriples-star-syntax-2.nt",
+      "name": "N-Triples-star - object embedded triple"
     },
     {
       "@id": "trs:ntriples-star-3",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - subject and object embedded triples",
-      "action": "ntriples-star-syntax-3.nt"
+      "action": "ntriples-star-syntax-3.nt",
+      "name": "N-Triples-star - subject and object embedded triples"
     },
     {
       "@id": "trs:ntriples-star-4",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - whitespace and terms",
-      "action": "ntriples-star-syntax-4.nt"
+      "action": "ntriples-star-syntax-4.nt",
+      "name": "N-Triples-star - whitespace and terms"
     },
     {
       "@id": "trs:ntriples-star-5",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - Nested, no whitespace",
-      "action": "ntriples-star-syntax-5.nt"
+      "action": "ntriples-star-syntax-5.nt",
+      "name": "N-Triples-star - Nested, no whitespace"
     },
     {
       "@id": "trs:ntriples-star-bnode-1",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - Blank node subject",
-      "action": "ntriples-star-bnode-1.nt"
+      "action": "ntriples-star-bnode-1.nt",
+      "name": "N-Triples-star - Blank node subject"
     },
     {
       "@id": "trs:ntriples-star-bnode-2",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - Blank node object",
-      "action": "ntriples-star-bnode-2.nt"
+      "action": "ntriples-star-bnode-2.nt",
+      "name": "N-Triples-star - Blank node object"
     },
     {
       "@id": "trs:ntriples-star-nested-1",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - Nested subject term",
-      "action": "ntriples-star-nested-1.nt"
+      "action": "ntriples-star-nested-1.nt",
+      "name": "N-Triples-star - Nested subject term"
     },
     {
       "@id": "trs:ntriples-star-nested-2",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star - Nested object term",
-      "action": "ntriples-star-nested-2.nt"
+      "action": "ntriples-star-nested-2.nt",
+      "name": "N-Triples-star - Nested object term"
     },
     {
       "@id": "trs:ntriples-star-bad-1",
       "@type": "rdft:TestNTriplesNegativeSyntax",
-      "name": "N-Triples-star - Bad - embedded triple as predicate",
-      "action": "ntriples-star-bad-syntax-1.nt"
+      "action": "ntriples-star-bad-syntax-1.nt",
+      "name": "N-Triples-star - Bad - embedded triple as predicate"
     },
     {
       "@id": "trs:ntriples-star-bad-2",
       "@type": "rdft:TestNTriplesNegativeSyntax",
-      "name": "N-Triples-star - Bad - embedded triple, literal subject",
-      "action": "ntriples-star-bad-syntax-2.nt"
+      "action": "ntriples-star-bad-syntax-2.nt",
+      "name": "N-Triples-star - Bad - embedded triple, literal subject"
     },
     {
       "@id": "trs:ntriples-star-bad-3",
       "@type": "rdft:TestNTriplesNegativeSyntax",
-      "name": "N-Triples-star - Bad - embedded triple, literal predicate",
-      "action": "ntriples-star-bad-syntax-3.nt"
+      "action": "ntriples-star-bad-syntax-3.nt",
+      "name": "N-Triples-star - Bad - embedded triple, literal predicate"
     },
     {
       "@id": "trs:ntriples-star-bad-4",
       "@type": "rdft:TestNTriplesNegativeSyntax",
-      "name": "N-Triples-star - Bad - embedded triple, blank node predicate",
-      "action": "ntriples-star-bad-syntax-4.nt"
+      "action": "ntriples-star-bad-syntax-4.nt",
+      "name": "N-Triples-star - Bad - embedded triple, blank node predicate"
     },
     {
       "@id": "trs:nt-ttl-star-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - subject embedded triple",
-      "action": "nt-ttl-star-syntax-1.ttl"
+      "action": "nt-ttl-star-syntax-1.ttl",
+      "name": "N-Triples-star as Turtle-star - subject embedded triple"
     },
     {
       "@id": "trs:nt-ttl-star-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - object embedded triple",
-      "action": "nt-ttl-star-syntax-2.ttl"
+      "action": "nt-ttl-star-syntax-2.ttl",
+      "name": "N-Triples-star as Turtle-star - object embedded triple"
     },
     {
       "@id": "trs:nt-ttl-star-3",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - subject and object embedded triples",
-      "action": "nt-ttl-star-syntax-3.ttl"
+      "action": "nt-ttl-star-syntax-3.ttl",
+      "name": "N-Triples-star as Turtle-star - subject and object embedded triples"
     },
     {
       "@id": "trs:nt-ttl-star-4",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - whitespace and terms",
-      "action": "ntriples-star-syntax-4.nt"
+      "action": "ntriples-star-syntax-4.nt",
+      "name": "N-Triples-star as Turtle-star - whitespace and terms"
     },
     {
       "@id": "trs:nt-ttl-star-5",
       "@type": "rdft:TestNTriplesPositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - Nested, no whitespace",
-      "action": "ntriples-star-syntax-5.nt"
+      "action": "ntriples-star-syntax-5.nt",
+      "name": "N-Triples-star as Turtle-star - Nested, no whitespace"
     },
     {
       "@id": "trs:nt-ttl-star-bnode-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - Blank node subject",
-      "action": "nt-ttl-star-bnode-1.ttl"
+      "action": "nt-ttl-star-bnode-1.ttl",
+      "name": "N-Triples-star as Turtle-star - Blank node subject"
     },
     {
       "@id": "trs:nt-ttl-star-bnode-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - Blank node object",
-      "action": "nt-ttl-star-bnode-2.ttl"
+      "action": "nt-ttl-star-bnode-2.ttl",
+      "name": "N-Triples-star as Turtle-star - Blank node object"
     },
     {
       "@id": "trs:nt-ttl-star-nested-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - Nested subject term",
-      "action": "nt-ttl-star-nested-1.ttl"
+      "action": "nt-ttl-star-nested-1.ttl",
+      "name": "N-Triples-star as Turtle-star - Nested subject term"
     },
     {
       "@id": "trs:nt-ttl-star-nested-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "N-Triples-star as Turtle-star - Nested object term",
-      "action": "nt-ttl-star-nested-2.ttl"
+      "action": "nt-ttl-star-nested-2.ttl",
+      "name": "N-Triples-star as Turtle-star - Nested object term"
     },
     {
       "@id": "trs:nt-ttl-star-bad-1",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "N-Triples-star as Turtle-star - Bad - embedded triple as predicate",
-      "action": "nt-ttl-star-bad-syntax-1.ttl"
+      "action": "nt-ttl-star-bad-syntax-1.ttl",
+      "name": "N-Triples-star as Turtle-star - Bad - embedded triple as predicate"
     },
     {
       "@id": "trs:nt-ttl-star-bad-2",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject",
-      "action": "nt-ttl-star-bad-syntax-2.ttl"
+      "action": "nt-ttl-star-bad-syntax-2.ttl",
+      "name": "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject"
     },
     {
       "@id": "trs:nt-ttl-star-bad-3",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate",
-      "action": "nt-ttl-star-bad-syntax-3.ttl"
+      "action": "nt-ttl-star-bad-syntax-3.ttl",
+      "name": "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate"
     },
     {
       "@id": "trs:nt-ttl-star-bad-4",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate",
-      "action": "nt-ttl-star-bad-syntax-4.ttl"
+      "action": "nt-ttl-star-bad-syntax-4.ttl",
+      "name": "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate"
     }
   ]
 }

--- a/tests/semantics/manifest.jsonld
+++ b/tests/semantics/manifest.jsonld
@@ -72,33 +72,17 @@
   "@id": "trs:manifest",
   "@included": [
     {
-      "@id": "trs:triple-in-object",
-      "@type": "PositiveEntailmentTest",
-      "comment": "Embedded triples can appear in object position (withdrawn, as it belongs to concrete syntax test-suites).",
-      "entailmentRegime": "simple",
-      "unrecognizedDatatypes": [
-
-      ],
-      "result": "test000o.ttl",
-      "name": "triple-in-object",
-      "approval": "Withdrawn",
-      "action": "test000o.ttl",
-      "recognizedDatatypes": [
-
-      ]
-    },
-    {
       "@id": "trs:malformed-literal-bnode-3",
       "@type": "NegativeEntailmentTest",
-      "comment": "Identical malformed literals can not be replaced with the same blank node (withdrawn as the current semantics does not enforce this).",
       "entailmentRegime": "RDF",
+      "approval": "Withdrawn",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "malformed-literal-3r.ttl",
-      "name": "malformed-literal-bnode-3",
-      "approval": "Withdrawn",
       "action": "malformed-literal-3a.ttl",
+      "comment": "Identical malformed literals can not be replaced with the same blank node (withdrawn as the current semantics does not enforce this).",
+      "name": "malformed-literal-bnode-3",
+      "result": "malformed-literal-3r.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -106,31 +90,47 @@
     {
       "@id": "trs:malformed-literal-bnode",
       "@type": "PositiveEntailmentTest",
-      "comment": "Malformed literals can be replaced by blank nodes (withdrawn as the current semantics does not enforce this).",
       "entailmentRegime": "RDF",
+      "approval": "Withdrawn",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002or.ttl",
-      "name": "malformed-literal-bnode",
-      "approval": "Withdrawn",
       "action": "malformed-literal.ttl",
+      "comment": "Malformed literals can be replaced by blank nodes (withdrawn as the current semantics does not enforce this).",
+      "name": "malformed-literal-bnode",
+      "result": "test002or.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
     },
     {
-      "@id": "trs:triple-in-subject",
+      "@id": "trs:triple-in-object",
       "@type": "PositiveEntailmentTest",
-      "comment": "Embedded triples can appear in subject position (withdrawn, as it belongs to concrete syntax test-suites).",
       "entailmentRegime": "simple",
+      "approval": "Withdrawn",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test000s.ttl",
-      "name": "triple-in-subject",
+      "action": "test000o.ttl",
+      "comment": "Embedded triples can appear in object position (withdrawn, as it belongs to concrete syntax test-suites).",
+      "name": "triple-in-object",
+      "result": "test000o.ttl",
+      "recognizedDatatypes": [
+
+      ]
+    },
+    {
+      "@id": "trs:triple-in-subject",
+      "@type": "PositiveEntailmentTest",
+      "entailmentRegime": "simple",
       "approval": "Withdrawn",
+      "unrecognizedDatatypes": [
+
+      ],
       "action": "test000s.ttl",
+      "comment": "Embedded triples can appear in subject position (withdrawn, as it belongs to concrete syntax test-suites).",
+      "name": "triple-in-subject",
+      "result": "test000s.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -138,34 +138,36 @@
     {
       "@id": "trs:malformed-literal-bnode-2",
       "@type": "PositiveEntailmentTest",
-      "comment": "Identical malformed literals can be replaced with the same blank node  (withdrawn as the current semantics does not enforce this).",
       "entailmentRegime": "RDF",
+      "approval": "Withdrawn",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "malformed-literal-2r.ttl",
-      "name": "malformed-literal-bnode-2",
-      "approval": "Withdrawn",
       "action": "malformed-literal-2a.ttl",
+      "comment": "Identical malformed literals can be replaced with the same blank node  (withdrawn as the current semantics does not enforce this).",
+      "name": "malformed-literal-bnode-2",
+      "result": "malformed-literal-2r.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
     }
   ],
   "@type": "Manifest",
+  "label": "RDF-star Semantics tests",
+  "seeAlso": "README",
   "entries": [
     {
       "@id": "trs:all-identical-embedded-triples-are-the-same",
       "@type": "PositiveEntailmentTest",
-      "comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test001r.ttl",
-      "name": "all-identical-embedded-triples-are-the-same",
-      "approval": "Proposed",
       "action": "test001a.ttl",
+      "comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model.",
+      "name": "all-identical-embedded-triples-are-the-same",
+      "result": "test001r.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -173,15 +175,15 @@
     {
       "@id": "trs:embedded-triples-no-spurious",
       "@type": "NegativeEntailmentTest",
-      "comment": "This test ensures that other entailments are not spurious.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test005.ttl",
-      "name": "embedded-triples-no-spurious",
-      "approval": "Proposed",
       "action": "test002a.ttl",
+      "comment": "This test ensures that other entailments are not spurious.",
+      "name": "embedded-triples-no-spurious",
+      "result": "test005.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -189,15 +191,15 @@
     {
       "@id": "trs:bnodes-in-embedded-subject",
       "@type": "PositiveEntailmentTest",
-      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002sr.ttl",
-      "name": "bnodes-in-embedded-subject",
-      "approval": "Proposed",
       "action": "test002a.ttl",
+      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "name": "bnodes-in-embedded-subject",
+      "result": "test002sr.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -205,15 +207,15 @@
     {
       "@id": "trs:bnodes-in-embedded-object",
       "@type": "PositiveEntailmentTest",
-      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002or.ttl",
-      "name": "bnodes-in-embedded-object",
-      "approval": "Proposed",
       "action": "test002a.ttl",
+      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "name": "bnodes-in-embedded-object",
+      "result": "test002or.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -221,15 +223,15 @@
     {
       "@id": "trs:bnodes-in-embedded-subject-and-object",
       "@type": "PositiveEntailmentTest",
-      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002sor.ttl",
-      "name": "bnodes-in-embedded-subject-and-object",
-      "approval": "Proposed",
       "action": "test002a.ttl",
+      "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "name": "bnodes-in-embedded-subject-and-object",
+      "result": "test002sor.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -237,15 +239,15 @@
     {
       "@id": "trs:bnodes-in-embedded-subject-and-object-fail",
       "@type": "NegativeEntailmentTest",
-      "comment": "The same bnode can not match different embedded terms.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002sbr.ttl",
-      "name": "bnodes-in-embedded-subject-and-object-fail",
-      "approval": "Proposed",
       "action": "test002a.ttl",
+      "comment": "The same bnode can not match different embedded terms.",
+      "name": "bnodes-in-embedded-subject-and-object-fail",
+      "result": "test002sbr.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -253,15 +255,15 @@
     {
       "@id": "trs:same-bnode-same-embedded-term",
       "@type": "PositiveEntailmentTest",
-      "comment": "Identical embedded term can be replaced by the same fresh bnode multiple times.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002sbr.ttl",
-      "name": "same-bnode-same-embedded-term",
-      "approval": "Proposed",
       "action": "test003a.ttl",
+      "comment": "Identical embedded term can be replaced by the same fresh bnode multiple times.",
+      "name": "same-bnode-same-embedded-term",
+      "result": "test002sbr.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -269,15 +271,15 @@
     {
       "@id": "trs:different-bnodes-same-embedded-term",
       "@type": "PositiveEntailmentTest",
-      "comment": "Different bnodes can match identical embedded terms.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002sor.ttl",
-      "name": "different-bnodes-same-embedded-term",
-      "approval": "Proposed",
       "action": "test003a.ttl",
+      "comment": "Different bnodes can match identical embedded terms.",
+      "name": "different-bnodes-same-embedded-term",
+      "result": "test002sor.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -285,15 +287,15 @@
     {
       "@id": "trs:constrained-bnodes-in-embedded-subject",
       "@type": "PositiveEntailmentTest",
-      "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test004sr.ttl",
-      "name": "constrained-bnodes-in-embedded-subject",
-      "approval": "Proposed",
       "action": "test004a.ttl",
+      "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
+      "name": "constrained-bnodes-in-embedded-subject",
+      "result": "test004sr.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -301,15 +303,15 @@
     {
       "@id": "trs:constrained-bnodes-in-embedded-object",
       "@type": "PositiveEntailmentTest",
-      "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test004or.ttl",
-      "name": "constrained-bnodes-in-embedded-object",
-      "approval": "Proposed",
       "action": "test004a.ttl",
+      "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
+      "name": "constrained-bnodes-in-embedded-object",
+      "result": "test004or.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -317,15 +319,15 @@
     {
       "@id": "trs:constrained-bnodes-in-embedded-fail",
       "@type": "NegativeEntailmentTest",
-      "comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test004fr.ttl",
-      "name": "constrained-bnodes-in-embedded-fail",
-      "approval": "Proposed",
       "action": "test004a.ttl",
+      "comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
+      "name": "constrained-bnodes-in-embedded-fail",
+      "result": "test004fr.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -333,15 +335,15 @@
     {
       "@id": "trs:constrained-bnodes-on-literal",
       "@type": "PositiveEntailmentTest",
-      "comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test006r.ttl",
-      "name": "constrained-bnodes-on-literal",
-      "approval": "Proposed",
       "action": "test006a.ttl",
+      "comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
+      "name": "constrained-bnodes-on-literal",
+      "result": "test006r.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -349,15 +351,15 @@
     {
       "@id": "trs:malformed-literal-control",
       "@type": "PositiveEntailmentTest",
-      "comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "mf:result": false,
-      "name": "malformed-literal-control",
-      "approval": "Proposed",
       "action": "malformed-literal-control.ttl",
+      "comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
+      "name": "malformed-literal-control",
+      "mf:result": false,
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -365,15 +367,15 @@
     {
       "@id": "trs:malformed-literal",
       "@type": "NegativeEntailmentTest",
-      "comment": "Malformed literals are allowed when embedded.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "mf:result": false,
-      "name": "malformed-literal",
-      "approval": "Proposed",
       "action": "malformed-literal.ttl",
+      "comment": "Malformed literals are allowed when embedded.",
+      "name": "malformed-literal",
+      "mf:result": false,
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -381,15 +383,15 @@
     {
       "@id": "trs:malformed-literal-accepted",
       "@type": "PositiveEntailmentTest",
-      "comment": "Malformed literals are allowed when embedded.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "malformed-literal.ttl",
-      "name": "malformed-literal-accepted",
-      "approval": "Proposed",
       "action": "malformed-literal.ttl",
+      "comment": "Malformed literals are allowed when embedded.",
+      "name": "malformed-literal-accepted",
+      "result": "malformed-literal.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -397,15 +399,15 @@
     {
       "@id": "trs:malformed-literal-no-spurious",
       "@type": "NegativeEntailmentTest",
-      "comment": "Embedded malformed literals do not lead to spurious entailment.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "malformed-literal-other.ttl",
-      "name": "malformed-literal-no-spurious",
-      "approval": "Proposed",
       "action": "malformed-literal.ttl",
+      "comment": "Embedded malformed literals do not lead to spurious entailment.",
+      "name": "malformed-literal-no-spurious",
+      "result": "malformed-literal-other.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -413,15 +415,15 @@
     {
       "@id": "trs:malformed-literal-bnode-neg",
       "@type": "NegativeEntailmentTest",
-      "comment": "Malformed literals can not be replaced by blank nodes.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002or.ttl",
-      "name": "malformed-literal-bnode",
-      "approval": "Proposed",
       "action": "malformed-literal.ttl",
+      "comment": "Malformed literals can not be replaced by blank nodes.",
+      "name": "malformed-literal-bnode",
+      "result": "test002or.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -429,15 +431,15 @@
     {
       "@id": "trs:opaque-literal-control",
       "@type": "PositiveEntailmentTest",
-      "comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "canonical-literal-control.ttl",
-      "name": "opaque-literal-control",
-      "approval": "Proposed",
       "action": "non-canonical-literal-control.ttl",
+      "comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
+      "name": "opaque-literal-control",
+      "result": "canonical-literal-control.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -445,15 +447,15 @@
     {
       "@id": "trs:opaque-literal",
       "@type": "NegativeEntailmentTest",
-      "comment": "Embedded literals are opaque, even when their datatype is recognized.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "canonical-literal.ttl",
-      "name": "opaque-literal",
-      "approval": "Proposed",
       "action": "non-canonical-literal.ttl",
+      "comment": "Embedded literals are opaque, even when their datatype is recognized.",
+      "name": "opaque-literal",
+      "result": "canonical-literal.ttl",
       "recognizedDatatypes": [
         "xsd:integer"
       ]
@@ -461,15 +463,15 @@
     {
       "@id": "trs:opaque-language-string-control",
       "@type": "PositiveEntailmentTest",
-      "comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "upercase-language-string-control.ttl",
-      "name": "opaque-language-string-control",
-      "approval": "Proposed",
       "action": "lowercase-language-string-control.ttl",
+      "comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
+      "name": "opaque-language-string-control",
+      "result": "upercase-language-string-control.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -477,15 +479,15 @@
     {
       "@id": "trs:opaque-language-string",
       "@type": "NegativeEntailmentTest",
-      "comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
       "entailmentRegime": "RDF",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "upercase-language-string.ttl",
-      "name": "opaque-language-string",
-      "approval": "Proposed",
       "action": "lowercase-language-string.ttl",
+      "comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
+      "name": "opaque-language-string",
+      "result": "upercase-language-string.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -493,15 +495,15 @@
     {
       "@id": "trs:opaque-iri-control",
       "@type": "PositiveEntailmentTest",
-      "comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
       "entailmentRegime": "RDFS-Plus",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "control-sameas-r.ttl",
-      "name": "opaque-iri-control",
-      "approval": "Proposed",
       "action": "control-sameas-a.ttl",
+      "comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
+      "name": "opaque-iri-control",
+      "result": "control-sameas-r.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -509,15 +511,15 @@
     {
       "@id": "trs:opaque-iri",
       "@type": "NegativeEntailmentTest",
-      "comment": "Embedded IRIs are opaque.",
       "entailmentRegime": "RDFS-Plus",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "superman_undesired_entailment.ttl",
-      "name": "opaque-iri",
-      "approval": "Proposed",
       "action": "superman.ttl",
+      "comment": "Embedded IRIs are opaque.",
+      "name": "opaque-iri",
+      "result": "superman_undesired_entailment.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -525,15 +527,15 @@
     {
       "@id": "trs:embedded-not-asserted",
       "@type": "NegativeEntailmentTest",
-      "comment": "Embedded triples are not asserted.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test002pgr.ttl",
-      "name": "embedded-not-asserted",
-      "approval": "Proposed",
       "action": "test002a.ttl",
+      "comment": "Embedded triples are not asserted.",
+      "name": "embedded-not-asserted",
+      "result": "test002pgr.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -541,15 +543,15 @@
     {
       "@id": "trs:annotated-asserted",
       "@type": "PositiveEntailmentTest",
-      "comment": "Annotated triples are asserted.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test007r1.ttl",
-      "name": "annotated-asserted",
-      "approval": "Proposed",
       "action": "test007a.ttl",
+      "comment": "Annotated triples are asserted.",
+      "name": "annotated-asserted",
+      "result": "test007r1.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -557,15 +559,15 @@
     {
       "@id": "trs:annotation",
       "@type": "PositiveEntailmentTest",
-      "comment": "Annotation are about the annotated triple.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test007r2.ttl",
-      "name": "annotation",
-      "approval": "Proposed",
       "action": "test007a.ttl",
+      "comment": "Annotation are about the annotated triple.",
+      "name": "annotation",
+      "result": "test007r2.ttl",
       "recognizedDatatypes": [
 
       ]
@@ -573,20 +575,18 @@
     {
       "@id": "trs:annotation-unfolded",
       "@type": "PositiveEntailmentTest",
-      "comment": "Annotation is the same as separate assertions.",
       "entailmentRegime": "simple",
+      "approval": "Proposed",
       "unrecognizedDatatypes": [
 
       ],
-      "result": "test007a.ttl",
-      "name": "annotation-unfolded",
-      "approval": "Proposed",
       "action": "test007a2.ttl",
+      "comment": "Annotation is the same as separate assertions.",
+      "name": "annotation-unfolded",
+      "result": "test007a.ttl",
       "recognizedDatatypes": [
 
       ]
     }
-  ],
-  "label": "RDF-star Semantics tests",
-  "seeAlso": "README"
+  ]
 }

--- a/tests/semantics/manifest.jsonld
+++ b/tests/semantics/manifest.jsonld
@@ -72,84 +72,84 @@
   "@id": "trs:manifest",
   "@included": [
     {
-      "@id": "trs:malformed-literal-bnode-3",
-      "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Withdrawn",
-      "unrecognizedDatatypes": [
-
-      ],
-      "action": "malformed-literal-3a.ttl",
-      "comment": "Identical malformed literals can not be replaced with the same blank node (withdrawn as the current semantics does not enforce this).",
-      "name": "malformed-literal-bnode-3",
-      "result": "malformed-literal-3r.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ]
-    },
-    {
-      "@id": "trs:malformed-literal-bnode",
-      "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Withdrawn",
-      "unrecognizedDatatypes": [
-
-      ],
-      "action": "malformed-literal.ttl",
-      "comment": "Malformed literals can be replaced by blank nodes (withdrawn as the current semantics does not enforce this).",
-      "name": "malformed-literal-bnode",
-      "result": "test002or.ttl",
-      "recognizedDatatypes": [
-        "xsd:integer"
-      ]
-    },
-    {
-      "@id": "trs:triple-in-object",
-      "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Withdrawn",
-      "unrecognizedDatatypes": [
-
-      ],
-      "action": "test000o.ttl",
-      "comment": "Embedded triples can appear in object position (withdrawn, as it belongs to concrete syntax test-suites).",
-      "name": "triple-in-object",
-      "result": "test000o.ttl",
-      "recognizedDatatypes": [
-
-      ]
-    },
-    {
       "@id": "trs:triple-in-subject",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Withdrawn",
+      "action": "test000s.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test000s.ttl",
       "comment": "Embedded triples can appear in subject position (withdrawn, as it belongs to concrete syntax test-suites).",
+      "approval": "Withdrawn",
       "name": "triple-in-subject",
-      "result": "test000s.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test000s.ttl"
+    },
+    {
+      "@id": "trs:malformed-literal-bnode-3",
+      "@type": "NegativeEntailmentTest",
+      "action": "malformed-literal-3a.ttl",
+      "unrecognizedDatatypes": [
+
+      ],
+      "comment": "Identical malformed literals can not be replaced with the same blank node (withdrawn as the current semantics does not enforce this).",
+      "approval": "Withdrawn",
+      "name": "malformed-literal-bnode-3",
+      "entailmentRegime": "RDF",
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ],
+      "result": "malformed-literal-3r.ttl"
     },
     {
       "@id": "trs:malformed-literal-bnode-2",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Withdrawn",
+      "action": "malformed-literal-2a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "malformed-literal-2a.ttl",
       "comment": "Identical malformed literals can be replaced with the same blank node  (withdrawn as the current semantics does not enforce this).",
+      "approval": "Withdrawn",
       "name": "malformed-literal-bnode-2",
-      "result": "malformed-literal-2r.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "result": "malformed-literal-2r.ttl"
+    },
+    {
+      "@id": "trs:triple-in-object",
+      "@type": "PositiveEntailmentTest",
+      "action": "test000o.ttl",
+      "unrecognizedDatatypes": [
+
+      ],
+      "comment": "Embedded triples can appear in object position (withdrawn, as it belongs to concrete syntax test-suites).",
+      "approval": "Withdrawn",
+      "name": "triple-in-object",
+      "entailmentRegime": "simple",
+      "recognizedDatatypes": [
+
+      ],
+      "result": "test000o.ttl"
+    },
+    {
+      "@id": "trs:malformed-literal-bnode",
+      "@type": "PositiveEntailmentTest",
+      "action": "malformed-literal.ttl",
+      "unrecognizedDatatypes": [
+
+      ],
+      "comment": "Malformed literals can be replaced by blank nodes (withdrawn as the current semantics does not enforce this).",
+      "approval": "Withdrawn",
+      "name": "malformed-literal-bnode",
+      "entailmentRegime": "RDF",
+      "recognizedDatatypes": [
+        "xsd:integer"
+      ],
+      "result": "test002or.ttl"
     }
   ],
   "@type": "Manifest",
@@ -159,434 +159,434 @@
     {
       "@id": "trs:all-identical-embedded-triples-are-the-same",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test001a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test001a.ttl",
       "comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model.",
+      "approval": "Proposed",
       "name": "all-identical-embedded-triples-are-the-same",
-      "result": "test001r.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test001r.ttl"
     },
     {
       "@id": "trs:embedded-triples-no-spurious",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test002a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test002a.ttl",
       "comment": "This test ensures that other entailments are not spurious.",
+      "approval": "Proposed",
       "name": "embedded-triples-no-spurious",
-      "result": "test005.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test005.ttl"
     },
     {
       "@id": "trs:bnodes-in-embedded-subject",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test002a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test002a.ttl",
       "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-subject",
-      "result": "test002sr.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test002sr.ttl"
     },
     {
       "@id": "trs:bnodes-in-embedded-object",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test002a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test002a.ttl",
       "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-object",
-      "result": "test002or.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test002or.ttl"
     },
     {
       "@id": "trs:bnodes-in-embedded-subject-and-object",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test002a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test002a.ttl",
       "comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-subject-and-object",
-      "result": "test002sor.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test002sor.ttl"
     },
     {
       "@id": "trs:bnodes-in-embedded-subject-and-object-fail",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test002a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test002a.ttl",
       "comment": "The same bnode can not match different embedded terms.",
+      "approval": "Proposed",
       "name": "bnodes-in-embedded-subject-and-object-fail",
-      "result": "test002sbr.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test002sbr.ttl"
     },
     {
       "@id": "trs:same-bnode-same-embedded-term",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test003a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test003a.ttl",
       "comment": "Identical embedded term can be replaced by the same fresh bnode multiple times.",
+      "approval": "Proposed",
       "name": "same-bnode-same-embedded-term",
-      "result": "test002sbr.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test002sbr.ttl"
     },
     {
       "@id": "trs:different-bnodes-same-embedded-term",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test003a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test003a.ttl",
       "comment": "Different bnodes can match identical embedded terms.",
+      "approval": "Proposed",
       "name": "different-bnodes-same-embedded-term",
-      "result": "test002sor.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test002sor.ttl"
     },
     {
       "@id": "trs:constrained-bnodes-in-embedded-subject",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test004a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test004a.ttl",
       "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
+      "approval": "Proposed",
       "name": "constrained-bnodes-in-embedded-subject",
-      "result": "test004sr.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test004sr.ttl"
     },
     {
       "@id": "trs:constrained-bnodes-in-embedded-object",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test004a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test004a.ttl",
       "comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
+      "approval": "Proposed",
       "name": "constrained-bnodes-in-embedded-object",
-      "result": "test004or.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test004or.ttl"
     },
     {
       "@id": "trs:constrained-bnodes-in-embedded-fail",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test004a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test004a.ttl",
       "comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
+      "approval": "Proposed",
       "name": "constrained-bnodes-in-embedded-fail",
-      "result": "test004fr.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test004fr.ttl"
     },
     {
       "@id": "trs:constrained-bnodes-on-literal",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test006a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test006a.ttl",
       "comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
+      "approval": "Proposed",
       "name": "constrained-bnodes-on-literal",
-      "result": "test006r.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test006r.ttl"
     },
     {
       "@id": "trs:malformed-literal-control",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "malformed-literal-control.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "malformed-literal-control.ttl",
       "comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
+      "approval": "Proposed",
       "name": "malformed-literal-control",
-      "mf:result": false,
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "mf:result": false
     },
     {
       "@id": "trs:malformed-literal",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "malformed-literal.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "malformed-literal.ttl",
       "comment": "Malformed literals are allowed when embedded.",
+      "approval": "Proposed",
       "name": "malformed-literal",
-      "mf:result": false,
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "mf:result": false
     },
     {
       "@id": "trs:malformed-literal-accepted",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "malformed-literal.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "malformed-literal.ttl",
       "comment": "Malformed literals are allowed when embedded.",
+      "approval": "Proposed",
       "name": "malformed-literal-accepted",
-      "result": "malformed-literal.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "result": "malformed-literal.ttl"
     },
     {
       "@id": "trs:malformed-literal-no-spurious",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "malformed-literal.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "malformed-literal.ttl",
       "comment": "Embedded malformed literals do not lead to spurious entailment.",
+      "approval": "Proposed",
       "name": "malformed-literal-no-spurious",
-      "result": "malformed-literal-other.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "result": "malformed-literal-other.ttl"
     },
     {
       "@id": "trs:malformed-literal-bnode-neg",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "malformed-literal.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "malformed-literal.ttl",
       "comment": "Malformed literals can not be replaced by blank nodes.",
+      "approval": "Proposed",
       "name": "malformed-literal-bnode",
-      "result": "test002or.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "result": "test002or.ttl"
     },
     {
       "@id": "trs:opaque-literal-control",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "non-canonical-literal-control.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "non-canonical-literal-control.ttl",
       "comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
+      "approval": "Proposed",
       "name": "opaque-literal-control",
-      "result": "canonical-literal-control.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "result": "canonical-literal-control.ttl"
     },
     {
       "@id": "trs:opaque-literal",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "non-canonical-literal.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "non-canonical-literal.ttl",
       "comment": "Embedded literals are opaque, even when their datatype is recognized.",
+      "approval": "Proposed",
       "name": "opaque-literal",
-      "result": "canonical-literal.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
         "xsd:integer"
-      ]
+      ],
+      "result": "canonical-literal.ttl"
     },
     {
       "@id": "trs:opaque-language-string-control",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "lowercase-language-string-control.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "lowercase-language-string-control.ttl",
       "comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
+      "approval": "Proposed",
       "name": "opaque-language-string-control",
-      "result": "upercase-language-string-control.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "upercase-language-string-control.ttl"
     },
     {
       "@id": "trs:opaque-language-string",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "RDF",
-      "approval": "Proposed",
+      "action": "lowercase-language-string.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "lowercase-language-string.ttl",
       "comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
+      "approval": "Proposed",
       "name": "opaque-language-string",
-      "result": "upercase-language-string.ttl",
+      "entailmentRegime": "RDF",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "upercase-language-string.ttl"
     },
     {
       "@id": "trs:opaque-iri-control",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "RDFS-Plus",
-      "approval": "Proposed",
+      "action": "control-sameas-a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "control-sameas-a.ttl",
       "comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
+      "approval": "Proposed",
       "name": "opaque-iri-control",
-      "result": "control-sameas-r.ttl",
+      "entailmentRegime": "RDFS-Plus",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "control-sameas-r.ttl"
     },
     {
       "@id": "trs:opaque-iri",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "RDFS-Plus",
-      "approval": "Proposed",
+      "action": "superman.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "superman.ttl",
       "comment": "Embedded IRIs are opaque.",
+      "approval": "Proposed",
       "name": "opaque-iri",
-      "result": "superman_undesired_entailment.ttl",
+      "entailmentRegime": "RDFS-Plus",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "superman_undesired_entailment.ttl"
     },
     {
       "@id": "trs:embedded-not-asserted",
       "@type": "NegativeEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test002a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test002a.ttl",
       "comment": "Embedded triples are not asserted.",
+      "approval": "Proposed",
       "name": "embedded-not-asserted",
-      "result": "test002pgr.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test002pgr.ttl"
     },
     {
       "@id": "trs:annotated-asserted",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test007a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test007a.ttl",
       "comment": "Annotated triples are asserted.",
+      "approval": "Proposed",
       "name": "annotated-asserted",
-      "result": "test007r1.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test007r1.ttl"
     },
     {
       "@id": "trs:annotation",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test007a.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test007a.ttl",
       "comment": "Annotation are about the annotated triple.",
+      "approval": "Proposed",
       "name": "annotation",
-      "result": "test007r2.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test007r2.ttl"
     },
     {
       "@id": "trs:annotation-unfolded",
       "@type": "PositiveEntailmentTest",
-      "entailmentRegime": "simple",
-      "approval": "Proposed",
+      "action": "test007a2.ttl",
       "unrecognizedDatatypes": [
 
       ],
-      "action": "test007a2.ttl",
       "comment": "Annotation is the same as separate assertions.",
+      "approval": "Proposed",
       "name": "annotation-unfolded",
-      "result": "test007a.ttl",
+      "entailmentRegime": "simple",
       "recognizedDatatypes": [
 
-      ]
+      ],
+      "result": "test007a.ttl"
     }
   ]
 }

--- a/tests/sparql/eval/manifest.jsonld
+++ b/tests/sparql/eval/manifest.jsonld
@@ -60,11 +60,14 @@
         "NotClassified": "test:NotClassified",
         "Rejected": "test:Rejected",
         "Obsoleted": "test:Obsoleted",
-        "Withdrawn": "test:RejectedWithdrawn"
+        "Withdrawn": "test:Withdrawn"
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
+    "statusOf": {
+      "@reverse": "test:approval"
+    }
   },
   "@id": "trs:manifest",
   "@type": "Manifest",
@@ -73,297 +76,297 @@
     {
       "@id": "trs:sparql-star-results-1j",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-results-1.srj",
-      "name": "SPARQL-star - all graph triples (JSON results)",
       "action": {
-        "qt:data": "data-0.ttl",
-        "qt:query": "sparql-star-results-1.rq"
-      }
+        "qt:query": "sparql-star-results-1.rq",
+        "qt:data": "data-0.ttl"
+      },
+      "name": "SPARQL-star - all graph triples (JSON results)",
+      "result": "sparql-star-results-1.srj"
     },
     {
       "@id": "trs:sparql-star-results-1x",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-results-1.srx",
-      "name": "SPARQL-star - all graph triples (XML results)",
       "action": {
-        "qt:data": "data-0.ttl",
-        "qt:query": "sparql-star-results-1.rq"
-      }
+        "qt:query": "sparql-star-results-1.rq",
+        "qt:data": "data-0.ttl"
+      },
+      "name": "SPARQL-star - all graph triples (XML results)",
+      "result": "sparql-star-results-1.srx"
     },
     {
       "@id": "trs:sparql-star-basic-2",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-basic-2.srj",
-      "name": "SPARQL-star - match constant embedded triple",
       "action": {
-        "qt:data": "data-1.ttl",
-        "qt:query": "sparql-star-basic-2.rq"
-      }
+        "qt:query": "sparql-star-basic-2.rq",
+        "qt:data": "data-1.ttl"
+      },
+      "name": "SPARQL-star - match constant embedded triple",
+      "result": "sparql-star-basic-2.srj"
     },
     {
       "@id": "trs:sparql-star-basic-3",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-basic-3.srj",
-      "name": "SPARQL-star - match embedded triple, var subject",
       "action": {
-        "qt:data": "data-1.ttl",
-        "qt:query": "sparql-star-basic-3.rq"
-      }
+        "qt:query": "sparql-star-basic-3.rq",
+        "qt:data": "data-1.ttl"
+      },
+      "name": "SPARQL-star - match embedded triple, var subject",
+      "result": "sparql-star-basic-3.srj"
     },
     {
       "@id": "trs:sparql-star-basic-4",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-basic-4.srj",
-      "name": "SPARQL-star - match embedded triple, var predicate",
       "action": {
-        "qt:data": "data-1.ttl",
-        "qt:query": "sparql-star-basic-4.rq"
-      }
+        "qt:query": "sparql-star-basic-4.rq",
+        "qt:data": "data-1.ttl"
+      },
+      "name": "SPARQL-star - match embedded triple, var predicate",
+      "result": "sparql-star-basic-4.srj"
     },
     {
       "@id": "trs:sparql-star-basic-5",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-basic-5.srj",
-      "name": "SPARQL-star - match embedded triple, var object",
       "action": {
-        "qt:data": "data-1.ttl",
-        "qt:query": "sparql-star-basic-5.rq"
-      }
+        "qt:query": "sparql-star-basic-5.rq",
+        "qt:data": "data-1.ttl"
+      },
+      "name": "SPARQL-star - match embedded triple, var object",
+      "result": "sparql-star-basic-5.srj"
     },
     {
       "@id": "trs:sparql-star-basic-6",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-basic-6.srj",
-      "name": "SPARQL-star - no match of embedded triple",
       "action": {
-        "qt:data": "data-1.ttl",
-        "qt:query": "sparql-star-basic-6.rq"
-      }
+        "qt:query": "sparql-star-basic-6.rq",
+        "qt:data": "data-1.ttl"
+      },
+      "name": "SPARQL-star - no match of embedded triple",
+      "result": "sparql-star-basic-6.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-1",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-01.srj",
-      "name": "SPARQL-star - Asserted and embedded triple",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-01.rq"
-      }
+        "qt:query": "sparql-star-pattern-01.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star - Asserted and embedded triple",
+      "result": "sparql-star-pattern-01.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-2",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-02.srj",
-      "name": "SPARQL-star -  Asserted and embedded triple",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-02.rq"
-      }
+        "qt:query": "sparql-star-pattern-02.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star -  Asserted and embedded triple",
+      "result": "sparql-star-pattern-02.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-3",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-03.srj",
-      "name": "SPARQL-star - Pattern - Variable for embedded triple",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-03.rq"
-      }
+        "qt:query": "sparql-star-pattern-03.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star - Pattern - Variable for embedded triple",
+      "result": "sparql-star-pattern-03.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-4",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-04.srj",
-      "name": "SPARQL-star - Pattern - No match",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-04.rq"
-      }
+        "qt:query": "sparql-star-pattern-04.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star - Pattern - No match",
+      "result": "sparql-star-pattern-04.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-5",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-05.srj",
-      "name": "SPARQL-star - Pattern - match variables in triple terms",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-05.rq"
-      }
+        "qt:query": "sparql-star-pattern-05.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star - Pattern - match variables in triple terms",
+      "result": "sparql-star-pattern-05.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-6",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-06.srj",
-      "name": "SPARQL-star - Pattern - Nesting 1",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-06.rq"
-      }
+        "qt:query": "sparql-star-pattern-06.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star - Pattern - Nesting 1",
+      "result": "sparql-star-pattern-06.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-7",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-07.srj",
-      "name": "SPARQL-star - Pattern - Nesting - 2",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-07.rq"
-      }
+        "qt:query": "sparql-star-pattern-07.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star - Pattern - Nesting - 2",
+      "result": "sparql-star-pattern-07.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-8",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-08.srj",
-      "name": "SPARQL-star - Pattern - Match and nesting",
       "action": {
-        "qt:data": "data-2.ttl",
-        "qt:query": "sparql-star-pattern-08.rq"
-      }
+        "qt:query": "sparql-star-pattern-08.rq",
+        "qt:data": "data-2.ttl"
+      },
+      "name": "SPARQL-star - Pattern - Match and nesting",
+      "result": "sparql-star-pattern-08.srj"
     },
     {
       "@id": "trs:sparql-star-pattern-9",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-pattern-09.srj",
-      "name": "SPARQL-star - Pattern - Same variable",
       "action": {
-        "qt:data": "data-5.ttl",
-        "qt:query": "sparql-star-pattern-09.rq"
-      }
+        "qt:query": "sparql-star-pattern-09.rq",
+        "qt:data": "data-5.ttl"
+      },
+      "name": "SPARQL-star - Pattern - Same variable",
+      "result": "sparql-star-pattern-09.srj"
     },
     {
       "@id": "trs:sparql-star-construct-1",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-construct-1.ttl",
-      "name": "SPARQL-star - CONSTRUCT with constant template",
       "action": {
-        "qt:data": "data-3.ttl",
-        "qt:query": "sparql-star-construct-1.rq"
-      }
+        "qt:query": "sparql-star-construct-1.rq",
+        "qt:data": "data-3.ttl"
+      },
+      "name": "SPARQL-star - CONSTRUCT with constant template",
+      "result": "sparql-star-construct-1.ttl"
     },
     {
       "@id": "trs:sparql-star-construct-2",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-construct-2.ttl",
-      "name": "SPARQL-star - CONSTRUCT WHERE with constant template",
       "action": {
-        "qt:data": "data-3.ttl",
-        "qt:query": "sparql-star-construct-2.rq"
-      }
+        "qt:query": "sparql-star-construct-2.rq",
+        "qt:data": "data-3.ttl"
+      },
+      "name": "SPARQL-star - CONSTRUCT WHERE with constant template",
+      "result": "sparql-star-construct-2.ttl"
     },
     {
       "@id": "trs:sparql-star-construct-3",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-construct-3.ttl",
-      "name": "SPARQL-star - CONSTRUCT - about every triple",
       "action": {
-        "qt:data": "data-3.ttl",
-        "qt:query": "sparql-star-construct-3.rq"
-      }
+        "qt:query": "sparql-star-construct-3.rq",
+        "qt:data": "data-3.ttl"
+      },
+      "name": "SPARQL-star - CONSTRUCT - about every triple",
+      "result": "sparql-star-construct-3.ttl"
     },
     {
       "@id": "trs:sparql-star-construct-4",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-construct-4.ttl",
-      "name": "SPARQL-star - CONSTRUCT with annotation syntax",
       "action": {
-        "qt:data": "data-3.ttl",
-        "qt:query": "sparql-star-construct-4.rq"
-      }
+        "qt:query": "sparql-star-construct-4.rq",
+        "qt:data": "data-3.ttl"
+      },
+      "name": "SPARQL-star - CONSTRUCT with annotation syntax",
+      "result": "sparql-star-construct-4.ttl"
     },
     {
       "@id": "trs:sparql-star-construct-5",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-construct-5.ttl",
-      "name": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
       "action": {
-        "qt:data": "data-3.ttl",
-        "qt:query": "sparql-star-construct-5.rq"
-      }
+        "qt:query": "sparql-star-construct-5.rq",
+        "qt:data": "data-3.ttl"
+      },
+      "name": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
+      "result": "sparql-star-construct-5.ttl"
     },
     {
       "@id": "trs:sparql-star-graphs-1",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-graphs-1.srj",
-      "name": "SPARQL-star - GRAPH",
       "action": {
-        "qt:data": "data-4.trig",
-        "qt:query": "sparql-star-graphs-1.rq"
-      }
+        "qt:query": "sparql-star-graphs-1.rq",
+        "qt:data": "data-4.trig"
+      },
+      "name": "SPARQL-star - GRAPH",
+      "result": "sparql-star-graphs-1.srj"
     },
     {
       "@id": "trs:sparql-star-graphs-2",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-graphs-2.srj",
-      "name": "SPARQL-star - GRAPHs with blank node",
       "action": {
-        "qt:data": "data-4.trig",
-        "qt:query": "sparql-star-graphs-2.rq"
-      }
+        "qt:query": "sparql-star-graphs-2.rq",
+        "qt:data": "data-4.trig"
+      },
+      "name": "SPARQL-star - GRAPHs with blank node",
+      "result": "sparql-star-graphs-2.srj"
     },
     {
       "@id": "trs:sparql-star-expr-1",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-expr-01.ttl",
-      "name": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
       "action": {
-        "qt:data": "data-4.trig",
-        "qt:query": "sparql-star-expr-01.rq"
-      }
+        "qt:query": "sparql-star-expr-01.rq",
+        "qt:data": "data-4.trig"
+      },
+      "name": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
+      "result": "sparql-star-expr-01.ttl"
     },
     {
       "@id": "trs:sparql-star-expr-2",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-expr-02.srj",
-      "name": "SPARQL-star - Embedded triple - Functions",
       "action": {
-        "qt:data": "empty.nq",
-        "qt:query": "sparql-star-expr-02.rq"
-      }
+        "qt:query": "sparql-star-expr-02.rq",
+        "qt:data": "empty.nq"
+      },
+      "name": "SPARQL-star - Embedded triple - Functions",
+      "result": "sparql-star-expr-02.srj"
     },
     {
       "@id": "trs:sparql-star-order-1",
       "@type": "QueryEvaluationTest",
-      "result": "sparql-star-order-1.srj",
-      "name": "SPARQL-star - Embedded triple ORDER BY",
       "action": {
-        "qt:data": "data-7.ttl",
-        "qt:query": "sparql-star-order-1.rq"
-      }
+        "qt:query": "sparql-star-order-1.rq",
+        "qt:data": "data-7.ttl"
+      },
+      "name": "SPARQL-star - Embedded triple ORDER BY",
+      "result": "sparql-star-order-1.srj"
     },
     {
       "@id": "trs:sparql-star-update-1",
       "@type": "UpdateEvaluationTest",
-      "result": {
-        "ut:data": "update-result-1.trig"
-      },
-      "name": "SPARQL-star - Update",
       "action": {
         "ut:request": "sparql-star-update-1.ru",
         "ut:data": "data-6.trig"
+      },
+      "name": "SPARQL-star - Update",
+      "result": {
+        "ut:data": "update-result-1.trig"
       }
     },
     {
       "@id": "trs:sparql-star-update-2",
       "@type": "UpdateEvaluationTest",
-      "result": {
-        "ut:data": "update-result-2.trig"
-      },
-      "name": "SPARQL-star - Update - annotation",
       "action": {
         "ut:request": "sparql-star-update-2.ru",
         "ut:data": "data-6.trig"
+      },
+      "name": "SPARQL-star - Update - annotation",
+      "result": {
+        "ut:data": "update-result-2.trig"
       }
     },
     {
       "@id": "trs:sparql-star-update-3",
       "@type": "UpdateEvaluationTest",
-      "result": {
-        "ut:data": "update-result-3.trig"
-      },
-      "name": "SPARQL-star - Update - data",
       "action": {
         "ut:request": "sparql-star-update-3.ru",
         "ut:data": "empty.nq"
+      },
+      "name": "SPARQL-star - Update - data",
+      "result": {
+        "ut:data": "update-result-3.trig"
       }
     }
   ]

--- a/tests/sparql/syntax/manifest.jsonld
+++ b/tests/sparql/syntax/manifest.jsonld
@@ -60,11 +60,14 @@
         "NotClassified": "test:NotClassified",
         "Rejected": "test:Rejected",
         "Obsoleted": "test:Obsoleted",
-        "Withdrawn": "test:RejectedWithdrawn"
+        "Withdrawn": "test:Withdrawn"
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
+    "statusOf": {
+      "@reverse": "test:approval"
+    }
   },
   "@id": "trs:manifest",
   "@type": "Manifest",
@@ -73,368 +76,368 @@
     {
       "@id": "trs:sparql-star-1",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - subject embedded triple",
-      "action": "sparql-star-syntax-basic-01.rq"
+      "action": "sparql-star-syntax-basic-01.rq",
+      "name": "SPARQL-star - subject embedded triple"
     },
     {
       "@id": "trs:sparql-star-2",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - object embedded triple",
-      "action": "sparql-star-syntax-basic-02.rq"
+      "action": "sparql-star-syntax-basic-02.rq",
+      "name": "SPARQL-star - object embedded triple"
     },
     {
       "@id": "trs:sparql-star-3",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - subject embedded triple - vars",
-      "action": "sparql-star-syntax-basic-03.rq"
+      "action": "sparql-star-syntax-basic-03.rq",
+      "name": "SPARQL-star - subject embedded triple - vars"
     },
     {
       "@id": "trs:sparql-star-4",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - object embedded triple - vars",
-      "action": "sparql-star-syntax-basic-04.rq"
+      "action": "sparql-star-syntax-basic-04.rq",
+      "name": "SPARQL-star - object embedded triple - vars"
     },
     {
       "@id": "trs:sparql-star-5",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Embedded triple in VALUES",
-      "action": "sparql-star-syntax-basic-05.rq"
+      "action": "sparql-star-syntax-basic-05.rq",
+      "name": "SPARQL-star - Embedded triple in VALUES"
     },
     {
       "@id": "trs:sparql-star-6",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Embedded triple in CONSTRUCT",
-      "action": "sparql-star-syntax-basic-06.rq"
+      "action": "sparql-star-syntax-basic-06.rq",
+      "name": "SPARQL-star - Embedded triple in CONSTRUCT"
     },
     {
       "@id": "trs:sparql-star-7",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Embedded triples in CONSTRUCT WHERE",
-      "action": "sparql-star-syntax-basic-07.rq"
+      "action": "sparql-star-syntax-basic-07.rq",
+      "name": "SPARQL-star - Embedded triples in CONSTRUCT WHERE"
     },
     {
       "@id": "trs:sparql-star-inside-1",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - embedded triple inside blankNodePropertyList",
-      "action": "sparql-star-syntax-inside-01.rq"
+      "action": "sparql-star-syntax-inside-01.rq",
+      "name": "SPARQL-star - embedded triple inside blankNodePropertyList"
     },
     {
       "@id": "trs:sparql-star-inside-2",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - embedded triple inside collection",
-      "action": "sparql-star-syntax-inside-02.rq"
+      "action": "sparql-star-syntax-inside-02.rq",
+      "name": "SPARQL-star - embedded triple inside collection"
     },
     {
       "@id": "trs:sparql-star-nested-1",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - nested embedded triple, subject position",
-      "action": "sparql-star-syntax-nested-01.rq"
+      "action": "sparql-star-syntax-nested-01.rq",
+      "name": "SPARQL-star - nested embedded triple, subject position"
     },
     {
       "@id": "trs:sparql-star-nested-2",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - nested embedded triple, object position",
-      "action": "sparql-star-syntax-nested-02.rq"
+      "action": "sparql-star-syntax-nested-02.rq",
+      "name": "SPARQL-star - nested embedded triple, object position"
     },
     {
       "@id": "trs:sparql-star-compound-1",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - compound forms",
-      "action": "sparql-star-syntax-compound.rq"
+      "action": "sparql-star-syntax-compound.rq",
+      "name": "SPARQL-star - compound forms"
     },
     {
       "@id": "trs:sparql-star-bnode-1",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - blank node subject",
-      "action": "sparql-star-syntax-bnode-01.rq"
+      "action": "sparql-star-syntax-bnode-01.rq",
+      "name": "SPARQL-star - blank node subject"
     },
     {
       "@id": "trs:sparql-star-bnode-2",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - blank node object",
-      "action": "sparql-star-syntax-bnode-02.rq"
+      "action": "sparql-star-syntax-bnode-02.rq",
+      "name": "SPARQL-star - blank node object"
     },
     {
       "@id": "trs:sparql-star-bnode-3",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - blank node",
-      "action": "sparql-star-syntax-bnode-03.rq"
+      "action": "sparql-star-syntax-bnode-03.rq",
+      "name": "SPARQL-star - blank node"
     },
     {
       "@id": "trs:sparql-star-ann-01",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation form",
-      "action": "sparql-star-annotation-01.rq"
+      "action": "sparql-star-annotation-01.rq",
+      "name": "SPARQL-star - Annotation form"
     },
     {
       "@id": "trs:sparql-star-ann-02",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation example",
-      "action": "sparql-star-annotation-02.rq"
+      "action": "sparql-star-annotation-02.rq",
+      "name": "SPARQL-star - Annotation example"
     },
     {
       "@id": "trs:sparql-star-ann-03",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation example",
-      "action": "sparql-star-annotation-03.rq"
+      "action": "sparql-star-annotation-03.rq",
+      "name": "SPARQL-star - Annotation example"
     },
     {
       "@id": "trs:sparql-star-ann-04",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation with embedding",
-      "action": "sparql-star-annotation-04.rq"
+      "action": "sparql-star-annotation-04.rq",
+      "name": "SPARQL-star - Annotation with embedding"
     },
     {
       "@id": "trs:sparql-star-ann-05",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation on triple with embedded object",
-      "action": "sparql-star-annotation-05.rq"
+      "action": "sparql-star-annotation-05.rq",
+      "name": "SPARQL-star - Annotation on triple with embedded object"
     },
     {
       "@id": "trs:sparql-star-ann-06",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation with path",
-      "action": "sparql-star-annotation-06.rq"
+      "action": "sparql-star-annotation-06.rq",
+      "name": "SPARQL-star - Annotation with path"
     },
     {
       "@id": "trs:sparql-star-ann-07",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation with nested path",
-      "action": "sparql-star-annotation-07.rq"
+      "action": "sparql-star-annotation-07.rq",
+      "name": "SPARQL-star - Annotation with nested path"
     },
     {
       "@id": "trs:sparql-star-ann-08",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation in CONSTRUCT ",
-      "action": "sparql-star-annotation-08.rq"
+      "action": "sparql-star-annotation-08.rq",
+      "name": "SPARQL-star - Annotation in CONSTRUCT "
     },
     {
       "@id": "trs:sparql-star-ann-09",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Annotation in CONSTRUCT WHERE",
-      "action": "sparql-star-annotation-09.rq"
+      "action": "sparql-star-annotation-09.rq",
+      "name": "SPARQL-star - Annotation in CONSTRUCT WHERE"
     },
     {
       "@id": "trs:sparql-star-expr-1",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Expressions - Embedded triple",
-      "action": "sparql-star-syntax-expr-01.rq"
+      "action": "sparql-star-syntax-expr-01.rq",
+      "name": "SPARQL-star - Expressions - Embedded triple"
     },
     {
       "@id": "trs:sparql-star-expr-2",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Expressions - Embedded triple",
-      "action": "sparql-star-syntax-expr-02.rq"
+      "action": "sparql-star-syntax-expr-02.rq",
+      "name": "SPARQL-star - Expressions - Embedded triple"
     },
     {
       "@id": "trs:sparql-star-expr-3",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Expressions - Functions",
-      "action": "sparql-star-syntax-expr-03.rq"
+      "action": "sparql-star-syntax-expr-03.rq",
+      "name": "SPARQL-star - Expressions - Functions"
     },
     {
       "@id": "trs:sparql-star-expr-4",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Expressions - TRIPLE",
-      "action": "sparql-star-syntax-expr-04.rq"
+      "action": "sparql-star-syntax-expr-04.rq",
+      "name": "SPARQL-star - Expressions - TRIPLE"
     },
     {
       "@id": "trs:sparql-star-expr-5",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Expressions - Functions",
-      "action": "sparql-star-syntax-expr-05.rq"
+      "action": "sparql-star-syntax-expr-05.rq",
+      "name": "SPARQL-star - Expressions - Functions"
     },
     {
       "@id": "trs:sparql-star-expr-6",
       "@type": "PositiveSyntaxTest11",
-      "name": "SPARQL-star - Expressions - BIND - CONSTRUCT",
-      "action": "sparql-star-syntax-expr-06.rq"
+      "action": "sparql-star-syntax-expr-06.rq",
+      "name": "SPARQL-star - Expressions - BIND - CONSTRUCT"
     },
     {
       "@id": "trs:sparql-star-bad-1",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - embedded triple as predicate",
-      "action": "sparql-star-syntax-bad-01.rq"
+      "action": "sparql-star-syntax-bad-01.rq",
+      "name": "SPARQL-star - bad - embedded triple as predicate"
     },
     {
       "@id": "trs:sparql-star-bad-2",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - embedded triple outside triple",
-      "action": "sparql-star-syntax-bad-02.rq"
+      "action": "sparql-star-syntax-bad-02.rq",
+      "name": "SPARQL-star - bad - embedded triple outside triple"
     },
     {
       "@id": "trs:sparql-star-bad-3",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - collection list in embedded triple",
-      "action": "sparql-star-syntax-bad-03.rq"
+      "action": "sparql-star-syntax-bad-03.rq",
+      "name": "SPARQL-star - bad - collection list in embedded triple"
     },
     {
       "@id": "trs:sparql-star-bad-4",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - literal in subject position of embedded triple",
-      "action": "sparql-star-syntax-bad-04.rq"
+      "action": "sparql-star-syntax-bad-04.rq",
+      "name": "SPARQL-star - bad - literal in subject position of embedded triple"
     },
     {
       "@id": "trs:sparql-star-bad-5",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - blank node  as predicate in embedded triple",
-      "action": "sparql-star-syntax-bad-05.rq"
+      "action": "sparql-star-syntax-bad-05.rq",
+      "name": "SPARQL-star - bad - blank node  as predicate in embedded triple"
     },
     {
       "@id": "trs:sparql-star-bad-6",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - compound blank node expression",
-      "action": "sparql-star-syntax-bad-06.rq"
+      "action": "sparql-star-syntax-bad-06.rq",
+      "name": "SPARQL-star - bad - compound blank node expression"
     },
     {
       "@id": "trs:sparql-star-bad-7",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - incomplete embedded triple",
-      "action": "sparql-star-syntax-bad-07.rq"
+      "action": "sparql-star-syntax-bad-07.rq",
+      "name": "SPARQL-star - bad - incomplete embedded triple"
     },
     {
       "@id": "trs:sparql-star-bad-8",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - quad embedded triple",
-      "action": "sparql-star-syntax-bad-08.rq"
+      "action": "sparql-star-syntax-bad-08.rq",
+      "name": "SPARQL-star - bad - quad embedded triple"
     },
     {
       "@id": "trs:sparql-star-bad-9",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - variable in embedded triple in VALUES ",
-      "action": "sparql-star-syntax-bad-09.rq"
+      "action": "sparql-star-syntax-bad-09.rq",
+      "name": "SPARQL-star - bad - variable in embedded triple in VALUES "
     },
     {
       "@id": "trs:sparql-star-bad-10",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - blank node in embedded triple in VALUES ",
-      "action": "sparql-star-syntax-bad-10.rq"
+      "action": "sparql-star-syntax-bad-10.rq",
+      "name": "SPARQL-star - bad - blank node in embedded triple in VALUES "
     },
     {
       "@id": "trs:sparql-star-bad-ann-1",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - empty annotation",
-      "action": "sparql-star-syntax-bad-ann-1.rq"
+      "action": "sparql-star-syntax-bad-ann-1.rq",
+      "name": "SPARQL-star - bad - empty annotation"
     },
     {
       "@id": "trs:sparql-star-bad-ann-2",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - triples in annotation",
-      "action": "sparql-star-syntax-bad-ann-2.rq"
+      "action": "sparql-star-syntax-bad-ann-2.rq",
+      "name": "SPARQL-star - bad - triples in annotation"
     },
     {
       "@id": "trs:sparql-star-bad-ann-path-1",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - path - seq",
-      "action": "sparql-star-syntax-bad-ann-path-1.rq"
+      "action": "sparql-star-syntax-bad-ann-path-1.rq",
+      "name": "SPARQL-star - bad - path - seq"
     },
     {
       "@id": "trs:sparql-star-bad-ann-path-2",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - path - alt",
-      "action": "sparql-star-syntax-bad-ann-path-2.rq"
+      "action": "sparql-star-syntax-bad-ann-path-2.rq",
+      "name": "SPARQL-star - bad - path - alt"
     },
     {
       "@id": "trs:sparql-star-bad-ann-path-3",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - path - p*",
-      "action": "sparql-star-syntax-bad-ann-path-3.rq"
+      "action": "sparql-star-syntax-bad-ann-path-3.rq",
+      "name": "SPARQL-star - bad - path - p*"
     },
     {
       "@id": "trs:sparql-star-bad-ann-path-4",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - path - p+",
-      "action": "sparql-star-syntax-bad-ann-path-4.rq"
+      "action": "sparql-star-syntax-bad-ann-path-4.rq",
+      "name": "SPARQL-star - bad - path - p+"
     },
     {
       "@id": "trs:sparql-star-bad-ann-path-5",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - path - p?",
-      "action": "sparql-star-syntax-bad-ann-path-5.rq"
+      "action": "sparql-star-syntax-bad-ann-path-5.rq",
+      "name": "SPARQL-star - bad - path - p?"
     },
     {
       "@id": "trs:sparql-star-bad-ann-path-6",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - path in CONSTRUCT",
-      "action": "sparql-star-syntax-bad-ann-path-6.rq"
+      "action": "sparql-star-syntax-bad-ann-path-6.rq",
+      "name": "SPARQL-star - bad - path in CONSTRUCT"
     },
     {
       "@id": "trs:sparql-star-bad-ann-path-7",
       "@type": "NegativeSyntaxTest11",
-      "name": "SPARQL-star - bad - path in CONSTRUCT",
-      "action": "sparql-star-syntax-bad-ann-path-7.rq"
+      "action": "sparql-star-syntax-bad-ann-path-7.rq",
+      "name": "SPARQL-star - bad - path in CONSTRUCT"
     },
     {
       "@id": "trs:sparql-star-update-1",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update",
-      "action": "sparql-star-syntax-update-1.ru"
+      "action": "sparql-star-syntax-update-1.ru",
+      "name": "SPARQL-star - update"
     },
     {
       "@id": "trs:sparql-star-update-2",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update",
-      "action": "sparql-star-syntax-update-2.ru"
+      "action": "sparql-star-syntax-update-2.ru",
+      "name": "SPARQL-star - update"
     },
     {
       "@id": "trs:sparql-star-update-3",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update",
-      "action": "sparql-star-syntax-update-3.ru"
+      "action": "sparql-star-syntax-update-3.ru",
+      "name": "SPARQL-star - update"
     },
     {
       "@id": "trs:sparql-star-update-4",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update with embedding",
-      "action": "sparql-star-syntax-update-4.ru"
+      "action": "sparql-star-syntax-update-4.ru",
+      "name": "SPARQL-star - update with embedding"
     },
     {
       "@id": "trs:sparql-star-update-5",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update with embedded object",
-      "action": "sparql-star-syntax-update-5.ru"
+      "action": "sparql-star-syntax-update-5.ru",
+      "name": "SPARQL-star - update with embedded object"
     },
     {
       "@id": "trs:sparql-star-update-6",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update with annotation template",
-      "action": "sparql-star-syntax-update-6.ru"
+      "action": "sparql-star-syntax-update-6.ru",
+      "name": "SPARQL-star - update with annotation template"
     },
     {
       "@id": "trs:sparql-star-update-7",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update with annotation, template and pattern",
-      "action": "sparql-star-syntax-update-7.ru"
+      "action": "sparql-star-syntax-update-7.ru",
+      "name": "SPARQL-star - update with annotation, template and pattern"
     },
     {
       "@id": "trs:sparql-star-update-8",
       "@type": "PositiveUpdateSyntaxTest11",
-      "name": "SPARQL-star - update DATA with annotation",
-      "action": "sparql-star-syntax-update-8.ru"
+      "action": "sparql-star-syntax-update-8.ru",
+      "name": "SPARQL-star - update DATA with annotation"
     },
     {
       "@id": "trs:sparql-star-bad-update-1",
       "@type": "NegativeUpdateSyntaxTest11",
-      "name": "SPARQL-star - update - bad syntax",
-      "action": "sparql-star-syntax-bad-update-1.ru"
+      "action": "sparql-star-syntax-bad-update-1.ru",
+      "name": "SPARQL-star - update - bad syntax"
     },
     {
       "@id": "trs:sparql-star-bad-update-2",
       "@type": "NegativeUpdateSyntaxTest11",
-      "name": "SPARQL-star - update - bad syntax",
-      "action": "sparql-star-syntax-bad-update-2.ru"
+      "action": "sparql-star-syntax-bad-update-2.ru",
+      "name": "SPARQL-star - update - bad syntax"
     },
     {
       "@id": "trs:sparql-star-bad-update-3",
       "@type": "NegativeUpdateSyntaxTest11",
-      "name": "SPARQL-star - update - bad syntax",
-      "action": "sparql-star-syntax-bad-update-3.ru"
+      "action": "sparql-star-syntax-bad-update-3.ru",
+      "name": "SPARQL-star - update - bad syntax"
     },
     {
       "@id": "trs:sparql-star-bad-update-4",
       "@type": "NegativeUpdateSyntaxTest11",
-      "name": "SPARQL-star - update - bad syntax",
-      "action": "sparql-star-syntax-bad-update-4.ru"
+      "action": "sparql-star-syntax-bad-update-4.ru",
+      "name": "SPARQL-star - update - bad syntax"
     }
   ]
 }

--- a/tests/trig/eval/index.html
+++ b/tests/trig/eval/index.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<style>
+    .included a, .entries a {
+        text-decoration: none;
+    }
+
+    .included a:hover, .entries a:hover {
+        text-decoration: underline;
+    }
+
+    .entries .rejected {
+        text-decoration: line-through red;
+    }
+
+    .entries .approved::after {
+        content: "✓";
+    }
+
+    .entry h2 a {
+        text-decoration: none;
+    }
+
+    .approved tr.status td {
+        color: darkGreen;
+    }
+
+    .proposed tr.status td {
+        color: orange;
+    }
+
+    .rejected tr.status td {
+        color: red;
+    }
+
+    tr.recognized td, tr.unrecognized td {
+        font-family: monospace;
+    }
+
+    pre {
+        border: thin solid black;
+        background-color: lightYellow;
+        padding: .6em 1em;
+        max-height: 25em;
+        overflow-y: scroll;
+    }
+
+    .TestTurtleNegativeSyntax pre,
+    .NegativeSyntaxTest11 pre,
+    .NegativeUpdateSyntaxTest11 pre,
+    .NegativeEntailmentTest pre.result {
+        background-color: lightPink;
+    }
+</style>
+<title>manifest</title>
+<h1>manifest</h1>
+<p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
+<ul class="entries">
+<li class="proposed"><a href="#turtle-star-1">Turtle-star - subject embedded triple</a>
+<li class="proposed"><a href="#turtle-star-2">Turtle-star - object embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bnode-1">Turtle-star - blank node label</a>
+<li class="proposed"><a href="#turtle-star-bnode-2">Turtle-star - blank node labels</a>
+<li class="proposed"><a href="#turtle-star-annotation-1">Turtle-star - Annotation form</a>
+<li class="proposed"><a href="#turtle-star-annotation-2">Turtle-star - Annotation example</a>
+<li class="proposed"><a href="#turtle-star-annotation-3">Turtle-star - Annotation - predicate and object lists</a>
+<li class="proposed"><a href="#turtle-star-annotation-4">Turtle-star - Annotation - nested</a>
+<li class="proposed"><a href="#turtle-star-annotation-5">Turtle-star - Annotation object list</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-1">Turtle-star - Annotation with embedding</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-2">Turtle-star - Annotation on triple with embedded subject</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-3">Turtle-star - Annotation on triple with embedded object</a>
+</ul>
+<section id="turtle-star-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - subject embedded triple <a href="#turtle-star-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-01.ttl">turtle-star-eval-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;:s :p :o&gt;&gt; :q :z .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-01.nt">turtle-star-eval-01.nt</a></code></div>
+<pre class="result">
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - object embedded triple <a href="#turtle-star-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-02.ttl">turtle-star-eval-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:a :q &lt;&lt;:s :p :o&gt;&gt; .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-02.nt">turtle-star-eval-02.nt</a></code></div>
+<pre class="result">
+&lt;http://example/a&gt; &lt;http://example/q&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; .
+</pre>
+</section><section id="turtle-star-bnode-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - blank node label <a href="#turtle-star-bnode-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-bnode-1.ttl">turtle-star-eval-bnode-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+_:b :p :o .
+&lt;&lt;_:b :p :o&gt;&gt; :q :z .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-bnode-1.nt">turtle-star-eval-bnode-1.nt</a></code></div>
+<pre class="result">
+_:b9 &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; _:b9 &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-bnode-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - blank node labels <a href="#turtle-star-bnode-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-bnode-2.ttl">turtle-star-eval-bnode-2.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+_:a :p1 _:a .
+&lt;&lt;_:a :p1 _:a &gt;&gt; :q &lt;&lt;_:a :p2 :o&gt;&gt; .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-bnode-2.nt">turtle-star-eval-bnode-2.nt</a></code></div>
+<pre class="result">
+_:label1 &lt;http://example/p1&gt; _:label1 .
+&lt;&lt; _:label1 &lt;http://example/p1&gt; _:label1 &gt;&gt; &lt;http://example/q&gt; &lt;&lt; _:label1 &lt;http://example/p2&gt; &lt;http://example/o&gt; &gt;&gt; .
+</pre>
+</section><section id="turtle-star-annotation-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation form <a href="#turtle-star-annotation-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-1.ttl">turtle-star-eval-annotation-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-1.nt">turtle-star-eval-annotation-1.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-annotation-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation example <a href="#turtle-star-annotation-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-2.ttl">turtle-star-eval-annotation-2.ttl</a></code></div>
+<pre>
+PREFIX :       &lt;http://example/&gt;
+PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
+
+:s :p :o {| :source [ :graph &lt;http://host1/&gt; ;
+                      :date "2020-01-20"^^xsd:date
+                    ] ;
+            :source [ :graph &lt;http://host2/&gt; ;
+                      :date "2020-12-31"^^xsd:date
+                    ]
+          |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-2.nt">turtle-star-eval-annotation-2.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+_:b1 &lt;http://example/graph&gt; &lt;http://host1/&gt; .
+_:b1 &lt;http://example/date&gt; "2020-01-20"^^&lt;http://www.w3.org/2001/XMLSchema#date&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/source&gt; _:b1 .
+_:b2 &lt;http://example/graph&gt; &lt;http://host2/&gt; .
+_:b2 &lt;http://example/date&gt; "2020-12-31"^^&lt;http://www.w3.org/2001/XMLSchema#date&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/source&gt; _:b2 .
+</pre>
+</section><section id="turtle-star-annotation-3" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation - predicate and object lists <a href="#turtle-star-annotation-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-3.ttl">turtle-star-eval-annotation-3.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :a :b |};
+    :p2 :o2 {| :a2 :b2 |},
+        :o3 {| :a3 :b3 |}.
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-3.nt">turtle-star-eval-annotation-3.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
+&lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt; &gt;&gt; &lt;http://example/a2&gt; &lt;http://example/b2&gt; .
+&lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o3&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o3&gt; &gt;&gt; &lt;http://example/a3&gt; &lt;http://example/b3&gt; .
+</pre>
+</section><section id="turtle-star-annotation-4" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation - nested <a href="#turtle-star-annotation-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-4.ttl">turtle-star-eval-annotation-4.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :a :b {| :a2 :b2 |} |}.
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-4.nt">turtle-star-eval-annotation-4.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
+&lt;&lt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; &gt;&gt; &lt;http://example/a2&gt; &lt;http://example/b2&gt; .
+</pre>
+</section><section id="turtle-star-annotation-5" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation object list <a href="#turtle-star-annotation-5">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-5.ttl">turtle-star-eval-annotation-5.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o1, :o2 {| :a :b |} .
+
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-5.nt">turtle-star-eval-annotation-5.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o1&gt; .
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation with embedding <a href="#turtle-star-embed-annotation-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-1.ttl">turtle-star-eval-embed-annotation-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :r &lt;&lt;:s1 :p1 :o1&gt;&gt; |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-1.nt">turtle-star-eval-embed-annotation-1.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt;&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation on triple with embedded subject <a href="#turtle-star-embed-annotation-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-2.ttl">turtle-star-eval-embed-annotation-2.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;:s1 :p1 :o1&gt;&gt; :p :o {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-2.nt">turtle-star-eval-embed-annotation-2.nt</a></code></div>
+<pre class="result">
+&lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt;&lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-3" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation on triple with embedded object <a href="#turtle-star-embed-annotation-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-3.ttl">turtle-star-eval-embed-annotation-3.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p &lt;&lt;:s2 :p2 :o2&gt;&gt; {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-3.nt">turtle-star-eval-embed-annotation-3.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;&lt;&lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt;&gt;&gt; .
+&lt;&lt;&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;&lt;&lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt;&gt;&gt;&gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
+</pre>
+</section>

--- a/tests/trig/eval/manifest.html
+++ b/tests/trig/eval/manifest.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<style>
+    .included a, .entries a {
+        text-decoration: none;
+    }
+
+    .included a:hover, .entries a:hover {
+        text-decoration: underline;
+    }
+
+    .entries .rejected {
+        text-decoration: line-through red;
+    }
+
+    .entries .approved::after {
+        content: "✓";
+    }
+
+    .entry h2 a {
+        text-decoration: none;
+    }
+
+    .approved tr.status td {
+        color: darkGreen;
+    }
+
+    .proposed tr.status td {
+        color: orange;
+    }
+
+    .rejected tr.status td {
+        color: red;
+    }
+
+    tr.recognized td, tr.unrecognized td {
+        font-family: monospace;
+    }
+
+    pre {
+        border: thin solid black;
+        background-color: lightYellow;
+        padding: .6em 1em;
+        max-height: 25em;
+        overflow-y: scroll;
+    }
+
+    .TestTurtleNegativeSyntax pre,
+    .NegativeSyntaxTest11 pre,
+    .NegativeUpdateSyntaxTest11 pre,
+    .NegativeEntailmentTest pre.result {
+        background-color: lightPink;
+    }
+</style>
+<title>manifest</title>
+<h1>manifest</h1>
+<p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
+<ul class="entries">
+<li class="proposed"><a href="#turtle-star-1">Turtle-star - subject embedded triple</a>
+<li class="proposed"><a href="#turtle-star-2">Turtle-star - object embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bnode-1">Turtle-star - blank node label</a>
+<li class="proposed"><a href="#turtle-star-bnode-2">Turtle-star - blank node labels</a>
+<li class="proposed"><a href="#turtle-star-annotation-1">Turtle-star - Annotation form</a>
+<li class="proposed"><a href="#turtle-star-annotation-2">Turtle-star - Annotation example</a>
+<li class="proposed"><a href="#turtle-star-annotation-3">Turtle-star - Annotation - predicate and object lists</a>
+<li class="proposed"><a href="#turtle-star-annotation-4">Turtle-star - Annotation - nested</a>
+<li class="proposed"><a href="#turtle-star-annotation-5">Turtle-star - Annotation object list</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-1">Turtle-star - Annotation with embedding</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-2">Turtle-star - Annotation on triple with embedded subject</a>
+<li class="proposed"><a href="#turtle-star-embed-annotation-3">Turtle-star - Annotation on triple with embedded object</a>
+</ul>
+<section id="turtle-star-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - subject embedded triple <a href="#turtle-star-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-01.ttl">turtle-star-eval-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;:s :p :o&gt;&gt; :q :z .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-01.nt">turtle-star-eval-01.nt</a></code></div>
+<pre class="result">
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - object embedded triple <a href="#turtle-star-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-02.ttl">turtle-star-eval-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:a :q &lt;&lt;:s :p :o&gt;&gt; .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-02.nt">turtle-star-eval-02.nt</a></code></div>
+<pre class="result">
+&lt;http://example/a&gt; &lt;http://example/q&gt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; .
+</pre>
+</section><section id="turtle-star-bnode-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - blank node label <a href="#turtle-star-bnode-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-bnode-1.ttl">turtle-star-eval-bnode-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+_:b :p :o .
+&lt;&lt;_:b :p :o&gt;&gt; :q :z .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-bnode-1.nt">turtle-star-eval-bnode-1.nt</a></code></div>
+<pre class="result">
+_:b9 &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; _:b9 &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/q&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-bnode-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - blank node labels <a href="#turtle-star-bnode-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-bnode-2.ttl">turtle-star-eval-bnode-2.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+_:a :p1 _:a .
+&lt;&lt;_:a :p1 _:a &gt;&gt; :q &lt;&lt;_:a :p2 :o&gt;&gt; .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-bnode-2.nt">turtle-star-eval-bnode-2.nt</a></code></div>
+<pre class="result">
+_:label1 &lt;http://example/p1&gt; _:label1 .
+&lt;&lt; _:label1 &lt;http://example/p1&gt; _:label1 &gt;&gt; &lt;http://example/q&gt; &lt;&lt; _:label1 &lt;http://example/p2&gt; &lt;http://example/o&gt; &gt;&gt; .
+</pre>
+</section><section id="turtle-star-annotation-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation form <a href="#turtle-star-annotation-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-1.ttl">turtle-star-eval-annotation-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-1.nt">turtle-star-eval-annotation-1.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-annotation-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation example <a href="#turtle-star-annotation-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-2.ttl">turtle-star-eval-annotation-2.ttl</a></code></div>
+<pre>
+PREFIX :       &lt;http://example/&gt;
+PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
+
+:s :p :o {| :source [ :graph &lt;http://host1/&gt; ;
+                      :date "2020-01-20"^^xsd:date
+                    ] ;
+            :source [ :graph &lt;http://host2/&gt; ;
+                      :date "2020-12-31"^^xsd:date
+                    ]
+          |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-2.nt">turtle-star-eval-annotation-2.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+_:b1 &lt;http://example/graph&gt; &lt;http://host1/&gt; .
+_:b1 &lt;http://example/date&gt; "2020-01-20"^^&lt;http://www.w3.org/2001/XMLSchema#date&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/source&gt; _:b1 .
+_:b2 &lt;http://example/graph&gt; &lt;http://host2/&gt; .
+_:b2 &lt;http://example/date&gt; "2020-12-31"^^&lt;http://www.w3.org/2001/XMLSchema#date&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/source&gt; _:b2 .
+</pre>
+</section><section id="turtle-star-annotation-3" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation - predicate and object lists <a href="#turtle-star-annotation-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-3.ttl">turtle-star-eval-annotation-3.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :a :b |};
+    :p2 :o2 {| :a2 :b2 |},
+        :o3 {| :a3 :b3 |}.
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-3.nt">turtle-star-eval-annotation-3.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
+&lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt; &gt;&gt; &lt;http://example/a2&gt; &lt;http://example/b2&gt; .
+&lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o3&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p2&gt; &lt;http://example/o3&gt; &gt;&gt; &lt;http://example/a3&gt; &lt;http://example/b3&gt; .
+</pre>
+</section><section id="turtle-star-annotation-4" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation - nested <a href="#turtle-star-annotation-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-4.ttl">turtle-star-eval-annotation-4.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :a :b {| :a2 :b2 |} |}.
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-4.nt">turtle-star-eval-annotation-4.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
+&lt;&lt; &lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; &gt;&gt; &lt;http://example/a2&gt; &lt;http://example/b2&gt; .
+</pre>
+</section><section id="turtle-star-annotation-5" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation object list <a href="#turtle-star-annotation-5">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-annotation-5.ttl">turtle-star-eval-annotation-5.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o1, :o2 {| :a :b |} .
+
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-annotation-5.nt">turtle-star-eval-annotation-5.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o1&gt; .
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; .
+&lt;&lt; &lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o2&gt; &gt;&gt; &lt;http://example/a&gt; &lt;http://example/b&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-1" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation with embedding <a href="#turtle-star-embed-annotation-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-1.ttl">turtle-star-eval-embed-annotation-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :r &lt;&lt;:s1 :p1 :o1&gt;&gt; |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-1.nt">turtle-star-eval-embed-annotation-1.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt;&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-2" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation on triple with embedded subject <a href="#turtle-star-embed-annotation-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-2.ttl">turtle-star-eval-embed-annotation-2.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;:s1 :p1 :o1&gt;&gt; :p :o {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-2.nt">turtle-star-eval-embed-annotation-2.nt</a></code></div>
+<pre class="result">
+&lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt; .
+&lt;&lt;&lt;&lt;&lt;http://example/s1&gt; &lt;http://example/p1&gt; &lt;http://example/o1&gt;&gt;&gt; &lt;http://example/p&gt; &lt;http://example/o&gt;&gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
+</pre>
+</section><section id="turtle-star-embed-annotation-3" class="entry proposed rdft:TestTurtleEval">
+<h2>Turtle-star - Annotation on triple with embedded object <a href="#turtle-star-embed-annotation-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>rdft:TestTurtleEval</td>
+</table>
+<div><code><a href="turtle-star-eval-embed-annotation-3.ttl">turtle-star-eval-embed-annotation-3.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p &lt;&lt;:s2 :p2 :o2&gt;&gt; {| :r :z |} .
+</pre>
+<div>MUST result into</div>
+<div><code><a href="turtle-star-eval-embed-annotation-3.nt">turtle-star-eval-embed-annotation-3.nt</a></code></div>
+<pre class="result">
+&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;&lt;&lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt;&gt;&gt; .
+&lt;&lt;&lt;http://example/s&gt; &lt;http://example/p&gt; &lt;&lt;&lt;http://example/s2&gt; &lt;http://example/p2&gt; &lt;http://example/o2&gt;&gt;&gt;&gt;&gt; &lt;http://example/r&gt; &lt;http://example/z&gt; .
+</pre>
+</section>

--- a/tests/trig/eval/manifest.jsonld
+++ b/tests/trig/eval/manifest.jsonld
@@ -69,89 +69,89 @@
       "@reverse": "test:approval"
     }
   },
-  "@id": "../../turtle/eval#manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
   "label": "TriG-star Evaluation Tests",
   "entries": [
     {
-      "@id": "../../turtle/eval#trig-star-1",
+      "@id": "trs:trig-star-1",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-01.trig",
       "name": "TriG-star - subject embedded triple",
       "result": "trig-star-eval-01.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-2",
+      "@id": "trs:trig-star-2",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-02.trig",
       "name": "TriG-star - object embedded triple",
       "result": "trig-star-eval-02.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-bnode-1",
+      "@id": "trs:trig-star-bnode-1",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-bnode-1.trig",
       "name": "TriG-star - blank node label",
       "result": "trig-star-eval-bnode-1.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-bnode-2",
+      "@id": "trs:trig-star-bnode-2",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-bnode-2.trig",
       "name": "TriG-star - blank node labels",
       "result": "trig-star-eval-bnode-2.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-annotation-1",
+      "@id": "trs:trig-star-annotation-1",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-annotation-1.trig",
       "name": "TriG-star - Annotation form",
       "result": "trig-star-eval-annotation-1.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-annotation-2",
+      "@id": "trs:trig-star-annotation-2",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-annotation-2.trig",
       "name": "TriG-star - Annotation example",
       "result": "trig-star-eval-annotation-2.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-annotation-3",
+      "@id": "trs:trig-star-annotation-3",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-annotation-3.trig",
       "name": "TriG-star - Annotation - predicate and object lists",
       "result": "trig-star-eval-annotation-3.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-annotation-4",
+      "@id": "trs:trig-star-annotation-4",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-annotation-4.trig",
       "name": "TriG-star - Annotation - nested",
       "result": "trig-star-eval-annotation-4.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-annotation-5",
+      "@id": "trs:trig-star-annotation-5",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-annotation-5.trig",
       "name": "TriG-star - Annotation object list",
       "result": "trig-star-eval-annotation-5.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-embed-annotation-1",
+      "@id": "trs:trig-star-embed-annotation-1",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-embed-annotation-1.trig",
       "name": "TriG-star - Annotation with embedding",
       "result": "trig-star-eval-embed-annotation-1.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-embed-annotation-2",
+      "@id": "trs:trig-star-embed-annotation-2",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-embed-annotation-2.trig",
       "name": "TriG-star - Annotation on triple with embedded subject",
       "result": "trig-star-eval-embed-annotation-2.nq"
     },
     {
-      "@id": "../../turtle/eval#trig-star-embed-annotation-3",
+      "@id": "trs:trig-star-embed-annotation-3",
       "@type": "rdft:TestTrigEval",
       "action": "trig-star-eval-embed-annotation-3.trig",
       "name": "TriG-star - Annotation on triple with embedded object",

--- a/tests/trig/eval/manifest.jsonld
+++ b/tests/trig/eval/manifest.jsonld
@@ -1,0 +1,161 @@
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "rdft": "http://www.w3.org/ns/rdftest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
+    "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
+    "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/trig/eval#",
+    "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/trig/eval/",
+    "include": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "entries": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "recognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "unrecognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "action": {
+      "@type": "@id"
+    },
+    "qt:query": {
+      "@type": "@id"
+    },
+    "qt:data": {
+      "@type": "@id"
+    },
+    "ut:request": {
+      "@type": "@id"
+    },
+    "ut:data": {
+      "@type": "@id"
+    },
+    "result": {
+      "@type": "@id"
+    },
+    "label": "rdfs:label",
+    "comment": "rdfs:comment",
+    "seeAlso": {
+      "@id": "rdfs:seeAlso",
+      "@type": "@id"
+    },
+    "approval": {
+      "@id": "test:approval",
+      "@type": "@vocab",
+      "@context": {
+        "Approved": "test:Approved",
+        "Proposed": "test:NotClassified",
+        "NotClassified": "test:NotClassified",
+        "Rejected": "test:Rejected",
+        "Obsoleted": "test:Obsoleted",
+        "Withdrawn": "test:Withdrawn"
+      }
+    },
+    "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
+    "statusOf": {
+      "@reverse": "test:approval"
+    }
+  },
+  "@id": "../../turtle/eval#manifest",
+  "@type": "Manifest",
+  "label": "TriG-star Evaluation Tests",
+  "entries": [
+    {
+      "@id": "../../turtle/eval#trig-star-1",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-01.trig",
+      "name": "TriG-star - subject embedded triple",
+      "result": "trig-star-eval-01.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-2",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-02.trig",
+      "name": "TriG-star - object embedded triple",
+      "result": "trig-star-eval-02.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-bnode-1",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-bnode-1.trig",
+      "name": "TriG-star - blank node label",
+      "result": "trig-star-eval-bnode-1.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-bnode-2",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-bnode-2.trig",
+      "name": "TriG-star - blank node labels",
+      "result": "trig-star-eval-bnode-2.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-annotation-1",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-annotation-1.trig",
+      "name": "TriG-star - Annotation form",
+      "result": "trig-star-eval-annotation-1.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-annotation-2",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-annotation-2.trig",
+      "name": "TriG-star - Annotation example",
+      "result": "trig-star-eval-annotation-2.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-annotation-3",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-annotation-3.trig",
+      "name": "TriG-star - Annotation - predicate and object lists",
+      "result": "trig-star-eval-annotation-3.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-annotation-4",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-annotation-4.trig",
+      "name": "TriG-star - Annotation - nested",
+      "result": "trig-star-eval-annotation-4.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-annotation-5",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-annotation-5.trig",
+      "name": "TriG-star - Annotation object list",
+      "result": "trig-star-eval-annotation-5.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-embed-annotation-1",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-embed-annotation-1.trig",
+      "name": "TriG-star - Annotation with embedding",
+      "result": "trig-star-eval-embed-annotation-1.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-embed-annotation-2",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-embed-annotation-2.trig",
+      "name": "TriG-star - Annotation on triple with embedded subject",
+      "result": "trig-star-eval-embed-annotation-2.nq"
+    },
+    {
+      "@id": "../../turtle/eval#trig-star-embed-annotation-3",
+      "@type": "rdft:TestTrigEval",
+      "action": "trig-star-eval-embed-annotation-3.trig",
+      "name": "TriG-star - Annotation on triple with embedded object",
+      "result": "trig-star-eval-embed-annotation-3.nq"
+    }
+  ]
+}

--- a/tests/trig/eval/manifest.ttl
+++ b/tests/trig/eval/manifest.ttl
@@ -8,7 +8,7 @@ PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX trs:    <https://w3c.github.io/rdf-star/tests/turtle/eval#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/trig/eval#>
 
 trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "TriG-star Evaluation Tests" ;

--- a/tests/trig/eval/manifest.ttl
+++ b/tests/trig/eval/manifest.ttl
@@ -1,0 +1,101 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/turtle/eval#>
+
+trs:manifest  rdf:type mf:Manifest ;
+    rdfs:label "TriG-star Evaluation Tests" ;
+    mf:entries
+    (
+        trs:trig-star-1
+        trs:trig-star-2
+        trs:trig-star-bnode-1
+        trs:trig-star-bnode-2
+        trs:trig-star-annotation-1
+        trs:trig-star-annotation-2
+        trs:trig-star-annotation-3
+        trs:trig-star-annotation-4
+        trs:trig-star-annotation-5
+        trs:trig-star-embed-annotation-1
+        trs:trig-star-embed-annotation-2
+        trs:trig-star-embed-annotation-3
+    ) .
+
+trs:trig-star-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - subject embedded triple" ;
+   mf:action    <trig-star-eval-01.trig> ;
+   mf:result    <trig-star-eval-01.nq> ;
+   .
+
+trs:trig-star-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - object embedded triple" ;
+   mf:action    <trig-star-eval-02.trig> ;
+   mf:result    <trig-star-eval-02.nq> ;
+   .
+
+trs:trig-star-bnode-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - blank node label" ;
+   mf:action    <trig-star-eval-bnode-1.trig> ;
+   mf:result    <trig-star-eval-bnode-1.nq> ;
+   .
+   
+trs:trig-star-bnode-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - blank node labels" ;
+   mf:action    <trig-star-eval-bnode-2.trig> ;
+   mf:result    <trig-star-eval-bnode-2.nq> ;
+   .
+
+trs:trig-star-annotation-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation form" ;
+   mf:action    <trig-star-eval-annotation-1.trig> ;
+   mf:result    <trig-star-eval-annotation-1.nq> ;
+   .
+   
+trs:trig-star-annotation-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation example" ;
+   mf:action    <trig-star-eval-annotation-2.trig> ;
+   mf:result    <trig-star-eval-annotation-2.nq> ;
+   .
+   
+trs:trig-star-annotation-3 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation - predicate and object lists" ;
+   mf:action    <trig-star-eval-annotation-3.trig> ;
+   mf:result    <trig-star-eval-annotation-3.nq> ;
+   .
+   
+trs:trig-star-annotation-4 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation - nested" ;
+   mf:action    <trig-star-eval-annotation-4.trig> ;
+   mf:result    <trig-star-eval-annotation-4.nq> ;
+   .
+   
+trs:trig-star-annotation-5 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation object list" ;
+   mf:action    <trig-star-eval-annotation-5.trig> ;
+   mf:result    <trig-star-eval-annotation-5.nq> ;
+   .
+
+trs:trig-star-embed-annotation-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation with embedding" ;
+   mf:action    <trig-star-eval-embed-annotation-1.trig> ;
+   mf:result    <trig-star-eval-embed-annotation-1.nq> ;
+   .
+   
+trs:trig-star-embed-annotation-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation on triple with embedded subject" ;
+   mf:action    <trig-star-eval-embed-annotation-2.trig> ;
+   mf:result    <trig-star-eval-embed-annotation-2.nq> ;
+   .
+   
+trs:trig-star-embed-annotation-3 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation on triple with embedded object" ;
+   mf:action    <trig-star-eval-embed-annotation-3.trig> ;
+   mf:result    <trig-star-eval-embed-annotation-3.nq> ;
+   .

--- a/tests/trig/eval/trig-star-eval-01.nq
+++ b/tests/trig/eval/trig-star-eval-01.nq
@@ -1,0 +1,1 @@
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-01.trig
+++ b/tests/trig/eval/trig-star-eval-01.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {<<:s :p :o>> :q :z .}

--- a/tests/trig/eval/trig-star-eval-02.nq
+++ b/tests/trig/eval/trig-star-eval-02.nq
@@ -1,0 +1,1 @@
+<http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-02.trig
+++ b/tests/trig/eval/trig-star-eval-02.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:a :q <<:s :p :o>> .}

--- a/tests/trig/eval/trig-star-eval-annotation-1.nq
+++ b/tests/trig/eval/trig-star-eval-annotation-1.nq
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/r> <http://example/z> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-annotation-1.trig
+++ b/tests/trig/eval/trig-star-eval-annotation-1.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :r :z |} .}

--- a/tests/trig/eval/trig-star-eval-annotation-2.nq
+++ b/tests/trig/eval/trig-star-eval-annotation-2.nq
@@ -1,0 +1,7 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+_:b1 <http://example/graph> <http://host1/> <http://example/G> .
+_:b1 <http://example/date> "2020-01-20"^^<http://www.w3.org/2001/XMLSchema#date> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/source> _:b1 <http://example/G> .
+_:b2 <http://example/graph> <http://host2/> <http://example/G> .
+_:b2 <http://example/date> "2020-12-31"^^<http://www.w3.org/2001/XMLSchema#date> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/source> _:b2 <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-annotation-2.trig
+++ b/tests/trig/eval/trig-star-eval-annotation-2.trig
@@ -1,0 +1,12 @@
+PREFIX :       <http://example/>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+:G {
+  :s :p :o {| :source [ :graph <http://host1/> ;
+                        :date "2020-01-20"^^xsd:date
+                      ] ;
+              :source [ :graph <http://host2/> ;
+                        :date "2020-12-31"^^xsd:date
+                      ]
+            |} .
+}

--- a/tests/trig/eval/trig-star-eval-annotation-3.nq
+++ b/tests/trig/eval/trig-star-eval-annotation-3.nq
@@ -1,0 +1,6 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> <http://example/G> .
+<http://example/s> <http://example/p2> <http://example/o2> <http://example/G> .
+<< <http://example/s> <http://example/p2> <http://example/o2> >> <http://example/a2> <http://example/b2> <http://example/G> .
+<http://example/s> <http://example/p2> <http://example/o3> <http://example/G> .
+<< <http://example/s> <http://example/p2> <http://example/o3> >> <http://example/a3> <http://example/b3> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-annotation-3.trig
+++ b/tests/trig/eval/trig-star-eval-annotation-3.trig
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o {| :a :b |};
+      :p2 :o2 {| :a2 :b2 |},
+          :o3 {| :a3 :b3 |}.
+}

--- a/tests/trig/eval/trig-star-eval-annotation-4.nq
+++ b/tests/trig/eval/trig-star-eval-annotation-4.nq
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> <http://example/G> .
+<< << <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> >> <http://example/a2> <http://example/b2> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-annotation-4.trig
+++ b/tests/trig/eval/trig-star-eval-annotation-4.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :a :b {| :a2 :b2 |} |}.}

--- a/tests/trig/eval/trig-star-eval-annotation-5.nq
+++ b/tests/trig/eval/trig-star-eval-annotation-5.nq
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o1> <http://example/G> .
+<http://example/s> <http://example/p> <http://example/o2> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o2> >> <http://example/a> <http://example/b> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-annotation-5.trig
+++ b/tests/trig/eval/trig-star-eval-annotation-5.trig
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o1, :o2 {| :a :b |} .}
+

--- a/tests/trig/eval/trig-star-eval-bnode-1.nq
+++ b/tests/trig/eval/trig-star-eval-bnode-1.nq
@@ -1,0 +1,2 @@
+_:b9 <http://example/p> <http://example/o> <http://example/G> .
+<< _:b9 <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-bnode-1.trig
+++ b/tests/trig/eval/trig-star-eval-bnode-1.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  _:b :p :o .
+  <<_:b :p :o>> :q :z .
+}

--- a/tests/trig/eval/trig-star-eval-bnode-2.nq
+++ b/tests/trig/eval/trig-star-eval-bnode-2.nq
@@ -1,0 +1,2 @@
+_:label1 <http://example/p1> _:label1 <http://example/G> .
+<< _:label1 <http://example/p1> _:label1 >> <http://example/q> << _:label1 <http://example/p2> <http://example/o> >> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-bnode-2.trig
+++ b/tests/trig/eval/trig-star-eval-bnode-2.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  _:a :p1 _:a .
+  <<_:a :p1 _:a >> :q <<_:a :p2 :o>> .
+}

--- a/tests/trig/eval/trig-star-eval-embed-annotation-1.nq
+++ b/tests/trig/eval/trig-star-eval-embed-annotation-1.nq
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<<<http://example/s> <http://example/p> <http://example/o>>> <http://example/r> <<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-embed-annotation-1.trig
+++ b/tests/trig/eval/trig-star-eval-embed-annotation-1.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :r <<:s1 :p1 :o1>> |} .}

--- a/tests/trig/eval/trig-star-eval-embed-annotation-2.nq
+++ b/tests/trig/eval/trig-star-eval-embed-annotation-2.nq
@@ -1,0 +1,2 @@
+<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o> <http://example/G> .
+<<<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o>>> <http://example/r> <http://example/z> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-embed-annotation-2.trig
+++ b/tests/trig/eval/trig-star-eval-embed-annotation-2.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {<<:s1 :p1 :o1>> :p :o {| :r :z |} .}

--- a/tests/trig/eval/trig-star-eval-embed-annotation-3.nq
+++ b/tests/trig/eval/trig-star-eval-embed-annotation-3.nq
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>> <http://example/G> .
+<<<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>>>> <http://example/r> <http://example/z> <http://example/G> .

--- a/tests/trig/eval/trig-star-eval-embed-annotation-3.trig
+++ b/tests/trig/eval/trig-star-eval-embed-annotation-3.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p <<:s2 :p2 :o2>> {| :r :z |} .}

--- a/tests/trig/manifest.jsonld
+++ b/tests/trig/manifest.jsonld
@@ -1,0 +1,11 @@
+{
+    "@context": "../manifest-context.jsonld",
+    "@id" : "manifest",
+    "@type": "Manifest",
+    "comment": "RDF-star TriG tests",
+    "seeAlso": "https://w3c.github.io/rdf-tests/sparql11/",
+    "include": [
+        "syntax/manifest.jsonld",
+        "eval/manifest.jsonld"
+   ]
+}

--- a/tests/trig/syntax/index.html
+++ b/tests/trig/syntax/index.html
@@ -1,0 +1,404 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<style>
+    .included a, .entries a {
+        text-decoration: none;
+    }
+
+    .included a:hover, .entries a:hover {
+        text-decoration: underline;
+    }
+
+    .entries .rejected {
+        text-decoration: line-through red;
+    }
+
+    .entries .approved::after {
+        content: "✓";
+    }
+
+    .entry h2 a {
+        text-decoration: none;
+    }
+
+    .approved tr.status td {
+        color: darkGreen;
+    }
+
+    .proposed tr.status td {
+        color: orange;
+    }
+
+    .rejected tr.status td {
+        color: red;
+    }
+
+    tr.recognized td, tr.unrecognized td {
+        font-family: monospace;
+    }
+
+    pre {
+        border: thin solid black;
+        background-color: lightYellow;
+        padding: .6em 1em;
+        max-height: 25em;
+        overflow-y: scroll;
+    }
+
+    .TestTurtleNegativeSyntax pre,
+    .NegativeSyntaxTest11 pre,
+    .NegativeUpdateSyntaxTest11 pre,
+    .NegativeEntailmentTest pre.result {
+        background-color: lightPink;
+    }
+</style>
+<title>manifest</title>
+<h1>manifest</h1>
+<p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
+<ul class="entries">
+<li class="proposed"><a href="#turtle-star-1">Turtle-star - subject embedded triple</a>
+<li class="proposed"><a href="#turtle-star-2">Turtle-star - object embedded triple</a>
+<li class="proposed"><a href="#turtle-star-inside-1">Turtle-star - embedded triple inside blankNodePropertyList</a>
+<li class="proposed"><a href="#turtle-star-inside-2">Turtle-star - embedded triple inside collection</a>
+<li class="proposed"><a href="#turtle-star-nested-1">Turtle-star - nested embedded triple, subject position</a>
+<li class="proposed"><a href="#turtle-star-nested-2">Turtle-star - nested embedded triple, object position</a>
+<li class="proposed"><a href="#turtle-star-compound-1">Turtle-star - compound forms</a>
+<li class="proposed"><a href="#turtle-star-bnode-1">Turtle-star - blank node subject</a>
+<li class="proposed"><a href="#turtle-star-bnode-2">Turtle-star - blank node object</a>
+<li class="proposed"><a href="#turtle-star-bnode-3">Turtle-star - blank node</a>
+<li class="proposed"><a href="#turtle-star-bad-1">Turtle-star - bad - embedded triple as predicate</a>
+<li class="proposed"><a href="#turtle-star-bad-2">Turtle-star - bad - embedded triple outside triple</a>
+<li class="proposed"><a href="#turtle-star-bad-3">Turtle-star - bad - collection list in embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-4">Turtle-star - bad - literal in subject position of embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-5">Turtle-star - bad - blank node  as predicate in embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-6">Turtle-star - bad - compound blank node expression</a>
+<li class="proposed"><a href="#turtle-star-bad-7">Turtle-star - bad - incomplete embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-8">Turtle-star - bad - over-long embedded triple</a>
+<li class="proposed"><a href="#turtle-star-ann-1">Turtle-star - Annotation form</a>
+<li class="proposed"><a href="#turtle-star-ann-2">Turtle-star - Annotation example</a>
+<li class="proposed"><a href="#turtle-star-bad-ann-1">Turtle-star - bad - empty annotation</a>
+<li class="proposed"><a href="#turtle-star-bad-ann-2">Turtle-star - bad - triple as annotation</a>
+</ul>
+<section id="turtle-star-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - subject embedded triple <a href="#turtle-star-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-basic-01.ttl">turtle-star-syntax-basic-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+&lt;&lt;:s :p :o&gt;&gt; :q 123 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - object embedded triple <a href="#turtle-star-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-basic-02.ttl">turtle-star-syntax-basic-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+:x :p &lt;&lt;:s :p :o&gt;&gt; .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-inside-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - embedded triple inside blankNodePropertyList <a href="#turtle-star-inside-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-inside-01.ttl">turtle-star-syntax-inside-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+[ :q &lt;&lt;:s :p :o&gt;&gt; ] :b :c .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-inside-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - embedded triple inside collection <a href="#turtle-star-inside-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-inside-02.ttl">turtle-star-syntax-inside-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o1 .
+:s :p :o2 .
+( &lt;&lt;:s :p :o1&gt;&gt; &lt;&lt;:s :p :o2&gt;&gt; )  :q 123 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-nested-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - nested embedded triple, subject position <a href="#turtle-star-nested-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-nested-01.ttl">turtle-star-syntax-nested-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+
+&lt;&lt;:s :p :o &gt;&gt; :r :z .
+
+&lt;&lt; &lt;&lt;:s :p :o &gt;&gt; :r :z &gt;&gt; :q 1 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-nested-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - nested embedded triple, object position <a href="#turtle-star-nested-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-nested-02.ttl">turtle-star-syntax-nested-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+:a :q &lt;&lt;:s :p :o &gt;&gt; .
+&lt;&lt; :a :q &lt;&lt;:s :p :o &gt;&gt;&gt;&gt; :r :z .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-compound-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - compound forms <a href="#turtle-star-compound-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-compound.ttl">turtle-star-syntax-compound.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+
+:x :r :z .
+:a :b :c .
+&lt;&lt;:a :b :c&gt;&gt; :r :z .
+&lt;&lt;:x :r :z &gt;&gt; :p &lt;&lt;:a :b :c&gt;&gt; .
+
+&lt;&lt; &lt;&lt;:x :r :z &gt;&gt; :p &lt;&lt;:a :b :c&gt;&gt; &gt;&gt;
+   :q
+&lt;&lt; &lt;&lt;:x :r :z &gt;&gt; :p &lt;&lt;:a :b :c&gt;&gt; &gt;&gt; .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bnode-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node subject <a href="#turtle-star-bnode-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bnode-01.ttl">turtle-star-syntax-bnode-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+_:a :p :o .
+&lt;&lt;_:a :p :o &gt;&gt; :q 456 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bnode-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node object <a href="#turtle-star-bnode-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bnode-02.ttl">turtle-star-syntax-bnode-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p _:a .
+&lt;&lt;:s :p _:a &gt;&gt; :q 456 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bnode-3" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node <a href="#turtle-star-bnode-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bnode-03.ttl">turtle-star-syntax-bnode-03.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;[] :p [] &gt;&gt; :q :z .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bad-1" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - embedded triple as predicate <a href="#turtle-star-bad-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-01.ttl">turtle-star-syntax-bad-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+:x &lt;&lt;:s :p :o&gt;&gt; 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-2" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - embedded triple outside triple <a href="#turtle-star-bad-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-02.ttl">turtle-star-syntax-bad-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+&lt;&lt;:s :p :o&gt;&gt; .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-3" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - collection list in embedded triple <a href="#turtle-star-bad-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-03.ttl">turtle-star-syntax-bad-03.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p ("abc") .
+&lt;&lt;:s :p ("abc") &gt;&gt; :q 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-4" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - literal in subject position of embedded triple <a href="#turtle-star-bad-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-04.ttl">turtle-star-syntax-bad-04.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+&lt;&lt;3 :p :o &gt;&gt; :q :z .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-5" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - blank node  as predicate in embedded triple <a href="#turtle-star-bad-5">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-05.ttl">turtle-star-syntax-bad-05.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;:s [] :o&gt;&gt; :q 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-6" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - compound blank node expression <a href="#turtle-star-bad-6">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-06.ttl">turtle-star-syntax-bad-06.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+
+&lt;&lt;:s :p [ :p1 :o1 ]  &gt;&gt; :q 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-7" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - incomplete embedded triple <a href="#turtle-star-bad-7">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-07.ttl">turtle-star-syntax-bad-07.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p &lt;&lt; :p :r &gt;&gt; .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-8" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - over-long embedded triple <a href="#turtle-star-bad-8">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-08.ttl">turtle-star-syntax-bad-08.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p &lt;&lt; :g :s :p :o &gt;&gt; .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-ann-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - Annotation form <a href="#turtle-star-ann-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-annotation-1.ttl">turtle-star-annotation-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :r :z |} .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-ann-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - Annotation example <a href="#turtle-star-ann-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-annotation-2.ttl">turtle-star-annotation-2.ttl</a></code></div>
+<pre>
+PREFIX :       &lt;http://example/&gt;
+PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
+
+:s :p :o {| :source [ :graph &lt;http://host1/&gt; ;
+                      :date "2020-01-20"^^xsd:date
+                    ] ;
+            :source [ :graph &lt;http://host2/&gt; ;
+                      :date "2020-12-31"^^xsd:date
+                    ]
+          |} .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bad-ann-1" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - empty annotation <a href="#turtle-star-bad-ann-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-ann-1.ttl">turtle-star-syntax-bad-ann-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example.com/ns#&gt;
+
+SELECT * {
+  :s :p :o {|  |} .
+}
+
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-ann-2" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - triple as annotation <a href="#turtle-star-bad-ann-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-ann-2.ttl">turtle-star-syntax-bad-ann-2.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example.com/ns#&gt;
+
+:a :b :c {| :s :p :o |} .
+</pre>
+<div>MUST be rejected</div>
+</section>

--- a/tests/trig/syntax/manifest.html
+++ b/tests/trig/syntax/manifest.html
@@ -1,0 +1,404 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<style>
+    .included a, .entries a {
+        text-decoration: none;
+    }
+
+    .included a:hover, .entries a:hover {
+        text-decoration: underline;
+    }
+
+    .entries .rejected {
+        text-decoration: line-through red;
+    }
+
+    .entries .approved::after {
+        content: "✓";
+    }
+
+    .entry h2 a {
+        text-decoration: none;
+    }
+
+    .approved tr.status td {
+        color: darkGreen;
+    }
+
+    .proposed tr.status td {
+        color: orange;
+    }
+
+    .rejected tr.status td {
+        color: red;
+    }
+
+    tr.recognized td, tr.unrecognized td {
+        font-family: monospace;
+    }
+
+    pre {
+        border: thin solid black;
+        background-color: lightYellow;
+        padding: .6em 1em;
+        max-height: 25em;
+        overflow-y: scroll;
+    }
+
+    .TestTurtleNegativeSyntax pre,
+    .NegativeSyntaxTest11 pre,
+    .NegativeUpdateSyntaxTest11 pre,
+    .NegativeEntailmentTest pre.result {
+        background-color: lightPink;
+    }
+</style>
+<title>manifest</title>
+<h1>manifest</h1>
+<p>Generated from <a href="manifest.jsonld">manifest.jsonld</a></p><p><strong>Entries:</strong></p>
+<ul class="entries">
+<li class="proposed"><a href="#turtle-star-1">Turtle-star - subject embedded triple</a>
+<li class="proposed"><a href="#turtle-star-2">Turtle-star - object embedded triple</a>
+<li class="proposed"><a href="#turtle-star-inside-1">Turtle-star - embedded triple inside blankNodePropertyList</a>
+<li class="proposed"><a href="#turtle-star-inside-2">Turtle-star - embedded triple inside collection</a>
+<li class="proposed"><a href="#turtle-star-nested-1">Turtle-star - nested embedded triple, subject position</a>
+<li class="proposed"><a href="#turtle-star-nested-2">Turtle-star - nested embedded triple, object position</a>
+<li class="proposed"><a href="#turtle-star-compound-1">Turtle-star - compound forms</a>
+<li class="proposed"><a href="#turtle-star-bnode-1">Turtle-star - blank node subject</a>
+<li class="proposed"><a href="#turtle-star-bnode-2">Turtle-star - blank node object</a>
+<li class="proposed"><a href="#turtle-star-bnode-3">Turtle-star - blank node</a>
+<li class="proposed"><a href="#turtle-star-bad-1">Turtle-star - bad - embedded triple as predicate</a>
+<li class="proposed"><a href="#turtle-star-bad-2">Turtle-star - bad - embedded triple outside triple</a>
+<li class="proposed"><a href="#turtle-star-bad-3">Turtle-star - bad - collection list in embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-4">Turtle-star - bad - literal in subject position of embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-5">Turtle-star - bad - blank node  as predicate in embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-6">Turtle-star - bad - compound blank node expression</a>
+<li class="proposed"><a href="#turtle-star-bad-7">Turtle-star - bad - incomplete embedded triple</a>
+<li class="proposed"><a href="#turtle-star-bad-8">Turtle-star - bad - over-long embedded triple</a>
+<li class="proposed"><a href="#turtle-star-ann-1">Turtle-star - Annotation form</a>
+<li class="proposed"><a href="#turtle-star-ann-2">Turtle-star - Annotation example</a>
+<li class="proposed"><a href="#turtle-star-bad-ann-1">Turtle-star - bad - empty annotation</a>
+<li class="proposed"><a href="#turtle-star-bad-ann-2">Turtle-star - bad - triple as annotation</a>
+</ul>
+<section id="turtle-star-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - subject embedded triple <a href="#turtle-star-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-basic-01.ttl">turtle-star-syntax-basic-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+&lt;&lt;:s :p :o&gt;&gt; :q 123 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - object embedded triple <a href="#turtle-star-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-basic-02.ttl">turtle-star-syntax-basic-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+:x :p &lt;&lt;:s :p :o&gt;&gt; .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-inside-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - embedded triple inside blankNodePropertyList <a href="#turtle-star-inside-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-inside-01.ttl">turtle-star-syntax-inside-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+[ :q &lt;&lt;:s :p :o&gt;&gt; ] :b :c .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-inside-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - embedded triple inside collection <a href="#turtle-star-inside-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-inside-02.ttl">turtle-star-syntax-inside-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o1 .
+:s :p :o2 .
+( &lt;&lt;:s :p :o1&gt;&gt; &lt;&lt;:s :p :o2&gt;&gt; )  :q 123 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-nested-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - nested embedded triple, subject position <a href="#turtle-star-nested-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-nested-01.ttl">turtle-star-syntax-nested-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+
+&lt;&lt;:s :p :o &gt;&gt; :r :z .
+
+&lt;&lt; &lt;&lt;:s :p :o &gt;&gt; :r :z &gt;&gt; :q 1 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-nested-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - nested embedded triple, object position <a href="#turtle-star-nested-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-nested-02.ttl">turtle-star-syntax-nested-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+:a :q &lt;&lt;:s :p :o &gt;&gt; .
+&lt;&lt; :a :q &lt;&lt;:s :p :o &gt;&gt;&gt;&gt; :r :z .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-compound-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - compound forms <a href="#turtle-star-compound-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-compound.ttl">turtle-star-syntax-compound.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+
+:x :r :z .
+:a :b :c .
+&lt;&lt;:a :b :c&gt;&gt; :r :z .
+&lt;&lt;:x :r :z &gt;&gt; :p &lt;&lt;:a :b :c&gt;&gt; .
+
+&lt;&lt; &lt;&lt;:x :r :z &gt;&gt; :p &lt;&lt;:a :b :c&gt;&gt; &gt;&gt;
+   :q
+&lt;&lt; &lt;&lt;:x :r :z &gt;&gt; :p &lt;&lt;:a :b :c&gt;&gt; &gt;&gt; .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bnode-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node subject <a href="#turtle-star-bnode-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bnode-01.ttl">turtle-star-syntax-bnode-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+_:a :p :o .
+&lt;&lt;_:a :p :o &gt;&gt; :q 456 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bnode-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node object <a href="#turtle-star-bnode-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bnode-02.ttl">turtle-star-syntax-bnode-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p _:a .
+&lt;&lt;:s :p _:a &gt;&gt; :q 456 .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bnode-3" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - blank node <a href="#turtle-star-bnode-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bnode-03.ttl">turtle-star-syntax-bnode-03.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;[] :p [] &gt;&gt; :q :z .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bad-1" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - embedded triple as predicate <a href="#turtle-star-bad-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-01.ttl">turtle-star-syntax-bad-01.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+:x &lt;&lt;:s :p :o&gt;&gt; 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-2" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - embedded triple outside triple <a href="#turtle-star-bad-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-02.ttl">turtle-star-syntax-bad-02.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+&lt;&lt;:s :p :o&gt;&gt; .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-3" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - collection list in embedded triple <a href="#turtle-star-bad-3">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-03.ttl">turtle-star-syntax-bad-03.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p ("abc") .
+&lt;&lt;:s :p ("abc") &gt;&gt; :q 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-4" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - literal in subject position of embedded triple <a href="#turtle-star-bad-4">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-04.ttl">turtle-star-syntax-bad-04.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o .
+&lt;&lt;3 :p :o &gt;&gt; :q :z .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-5" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - blank node  as predicate in embedded triple <a href="#turtle-star-bad-5">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-05.ttl">turtle-star-syntax-bad-05.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+&lt;&lt;:s [] :o&gt;&gt; :q 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-6" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - compound blank node expression <a href="#turtle-star-bad-6">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-06.ttl">turtle-star-syntax-bad-06.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+
+&lt;&lt;:s :p [ :p1 :o1 ]  &gt;&gt; :q 123 .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-7" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - incomplete embedded triple <a href="#turtle-star-bad-7">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-07.ttl">turtle-star-syntax-bad-07.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p &lt;&lt; :p :r &gt;&gt; .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-8" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - over-long embedded triple <a href="#turtle-star-bad-8">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-08.ttl">turtle-star-syntax-bad-08.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p &lt;&lt; :g :s :p :o &gt;&gt; .
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-ann-1" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - Annotation form <a href="#turtle-star-ann-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-annotation-1.ttl">turtle-star-annotation-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example/&gt;
+
+:s :p :o {| :r :z |} .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-ann-2" class="entry proposed TestTurtlePositiveSyntax">
+<h2>Turtle-star - Annotation example <a href="#turtle-star-ann-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtlePositiveSyntax</td>
+</table>
+<div><code><a href="turtle-star-annotation-2.ttl">turtle-star-annotation-2.ttl</a></code></div>
+<pre>
+PREFIX :       &lt;http://example/&gt;
+PREFIX xsd:     &lt;http://www.w3.org/2001/XMLSchema#&gt;
+
+:s :p :o {| :source [ :graph &lt;http://host1/&gt; ;
+                      :date "2020-01-20"^^xsd:date
+                    ] ;
+            :source [ :graph &lt;http://host2/&gt; ;
+                      :date "2020-12-31"^^xsd:date
+                    ]
+          |} .
+</pre>
+<div>MUST be accepted</div>
+</section><section id="turtle-star-bad-ann-1" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - empty annotation <a href="#turtle-star-bad-ann-1">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-ann-1.ttl">turtle-star-syntax-bad-ann-1.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example.com/ns#&gt;
+
+SELECT * {
+  :s :p :o {|  |} .
+}
+
+</pre>
+<div>MUST be rejected</div>
+</section><section id="turtle-star-bad-ann-2" class="entry proposed TestTurtleNegativeSyntax">
+<h2>Turtle-star - bad - triple as annotation <a href="#turtle-star-bad-ann-2">🔗</a></h2>
+<table class="properties">
+<tr class="status"><th>status:</th><td>proposed</td>
+<tr class="type"><th>type:</th><td>TestTurtleNegativeSyntax</td>
+</table>
+<div><code><a href="turtle-star-syntax-bad-ann-2.ttl">turtle-star-syntax-bad-ann-2.ttl</a></code></div>
+<pre>
+PREFIX : &lt;http://example.com/ns#&gt;
+
+:a :b :c {| :s :p :o |} .
+</pre>
+<div>MUST be rejected</div>
+</section>

--- a/tests/trig/syntax/manifest.jsonld
+++ b/tests/trig/syntax/manifest.jsonld
@@ -69,138 +69,138 @@
       "@reverse": "test:approval"
     }
   },
-  "@id": "../../turtle/syntax#manifest",
+  "@id": "trs:manifest",
   "@type": "Manifest",
   "label": "TriG-star Syntax Tests",
   "entries": [
     {
-      "@id": "../../turtle/syntax#trig-star-1",
+      "@id": "trs:trig-star-1",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-basic-01.trig",
       "name": "TriG-star - subject embedded triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-2",
+      "@id": "trs:trig-star-2",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-basic-02.trig",
       "name": "TriG-star - object embedded triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-inside-1",
+      "@id": "trs:trig-star-inside-1",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-inside-01.trig",
       "name": "TriG-star - embedded triple inside blankNodePropertyList"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-inside-2",
+      "@id": "trs:trig-star-inside-2",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-inside-02.trig",
       "name": "TriG-star - embedded triple inside collection"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-nested-1",
+      "@id": "trs:trig-star-nested-1",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-nested-01.trig",
       "name": "TriG-star - nested embedded triple, subject position"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-nested-2",
+      "@id": "trs:trig-star-nested-2",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-nested-02.trig",
       "name": "TriG-star - nested embedded triple, object position"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-compound-1",
+      "@id": "trs:trig-star-compound-1",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-compound.trig",
       "name": "TriG-star - compound forms"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bnode-1",
+      "@id": "trs:trig-star-bnode-1",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-bnode-01.trig",
       "name": "TriG-star - blank node subject"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bnode-2",
+      "@id": "trs:trig-star-bnode-2",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-bnode-02.trig",
       "name": "TriG-star - blank node object"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bnode-3",
+      "@id": "trs:trig-star-bnode-3",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-syntax-bnode-03.trig",
       "name": "TriG-star - blank node"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-1",
+      "@id": "trs:trig-star-bad-1",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-01.trig",
       "name": "TriG-star - bad - embedded triple as predicate"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-2",
+      "@id": "trs:trig-star-bad-2",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-02.trig",
       "name": "TriG-star - bad - embedded triple outside triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-3",
+      "@id": "trs:trig-star-bad-3",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-03.trig",
       "name": "TriG-star - bad - collection list in embedded triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-4",
+      "@id": "trs:trig-star-bad-4",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-04.trig",
       "name": "TriG-star - bad - literal in subject position of embedded triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-5",
+      "@id": "trs:trig-star-bad-5",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-05.trig",
       "name": "TriG-star - bad - blank node  as predicate in embedded triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-6",
+      "@id": "trs:trig-star-bad-6",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-06.trig",
       "name": "TriG-star - bad - compound blank node expression"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-7",
+      "@id": "trs:trig-star-bad-7",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-07.trig",
       "name": "TriG-star - bad - incomplete embedded triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-8",
+      "@id": "trs:trig-star-bad-8",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-08.trig",
       "name": "TriG-star - bad - over-long embedded triple"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-ann-1",
+      "@id": "trs:trig-star-ann-1",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-annotation-1.trig",
       "name": "TriG-star - Annotation form"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-ann-2",
+      "@id": "trs:trig-star-ann-2",
       "@type": "rdft:TestTrigPositiveSyntax",
       "action": "trig-star-annotation-2.trig",
       "name": "TriG-star - Annotation example"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-ann-1",
+      "@id": "trs:trig-star-bad-ann-1",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-ann-1.trig",
       "name": "TriG-star - bad - empty annotation"
     },
     {
-      "@id": "../../turtle/syntax#trig-star-bad-ann-2",
+      "@id": "trs:trig-star-bad-ann-2",
       "@type": "rdft:TestTrigNegativeSyntax",
       "action": "trig-star-syntax-bad-ann-2.trig",
       "name": "TriG-star - bad - triple as annotation"

--- a/tests/trig/syntax/manifest.jsonld
+++ b/tests/trig/syntax/manifest.jsonld
@@ -1,0 +1,209 @@
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "rdft": "http://www.w3.org/ns/rdftest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "qt": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
+    "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
+    "test": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#",
+    "trs": "https://w3c.github.io/rdf-star/tests/trig/syntax#",
+    "@vocab": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "@base": "https://w3c.github.io/rdf-star/tests/trig/syntax/",
+    "include": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "entries": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "recognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "unrecognizedDatatypes": {
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "action": {
+      "@type": "@id"
+    },
+    "qt:query": {
+      "@type": "@id"
+    },
+    "qt:data": {
+      "@type": "@id"
+    },
+    "ut:request": {
+      "@type": "@id"
+    },
+    "ut:data": {
+      "@type": "@id"
+    },
+    "result": {
+      "@type": "@id"
+    },
+    "label": "rdfs:label",
+    "comment": "rdfs:comment",
+    "seeAlso": {
+      "@id": "rdfs:seeAlso",
+      "@type": "@id"
+    },
+    "approval": {
+      "@id": "test:approval",
+      "@type": "@vocab",
+      "@context": {
+        "Approved": "test:Approved",
+        "Proposed": "test:NotClassified",
+        "NotClassified": "test:NotClassified",
+        "Rejected": "test:Rejected",
+        "Obsoleted": "test:Obsoleted",
+        "Withdrawn": "test:Withdrawn"
+      }
+    },
+    "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
+    "statusOf": {
+      "@reverse": "test:approval"
+    }
+  },
+  "@id": "../../turtle/syntax#manifest",
+  "@type": "Manifest",
+  "label": "TriG-star Syntax Tests",
+  "entries": [
+    {
+      "@id": "../../turtle/syntax#trig-star-1",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-basic-01.trig",
+      "name": "TriG-star - subject embedded triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-2",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-basic-02.trig",
+      "name": "TriG-star - object embedded triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-inside-1",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-inside-01.trig",
+      "name": "TriG-star - embedded triple inside blankNodePropertyList"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-inside-2",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-inside-02.trig",
+      "name": "TriG-star - embedded triple inside collection"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-nested-1",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-nested-01.trig",
+      "name": "TriG-star - nested embedded triple, subject position"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-nested-2",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-nested-02.trig",
+      "name": "TriG-star - nested embedded triple, object position"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-compound-1",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-compound.trig",
+      "name": "TriG-star - compound forms"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bnode-1",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-bnode-01.trig",
+      "name": "TriG-star - blank node subject"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bnode-2",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-bnode-02.trig",
+      "name": "TriG-star - blank node object"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bnode-3",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-syntax-bnode-03.trig",
+      "name": "TriG-star - blank node"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-1",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-01.trig",
+      "name": "TriG-star - bad - embedded triple as predicate"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-2",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-02.trig",
+      "name": "TriG-star - bad - embedded triple outside triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-3",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-03.trig",
+      "name": "TriG-star - bad - collection list in embedded triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-4",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-04.trig",
+      "name": "TriG-star - bad - literal in subject position of embedded triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-5",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-05.trig",
+      "name": "TriG-star - bad - blank node  as predicate in embedded triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-6",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-06.trig",
+      "name": "TriG-star - bad - compound blank node expression"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-7",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-07.trig",
+      "name": "TriG-star - bad - incomplete embedded triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-8",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-08.trig",
+      "name": "TriG-star - bad - over-long embedded triple"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-ann-1",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-annotation-1.trig",
+      "name": "TriG-star - Annotation form"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-ann-2",
+      "@type": "rdft:TestTrigPositiveSyntax",
+      "action": "trig-star-annotation-2.trig",
+      "name": "TriG-star - Annotation example"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-ann-1",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-ann-1.trig",
+      "name": "TriG-star - bad - empty annotation"
+    },
+    {
+      "@id": "../../turtle/syntax#trig-star-bad-ann-2",
+      "@type": "rdft:TestTrigNegativeSyntax",
+      "action": "trig-star-syntax-bad-ann-2.trig",
+      "name": "TriG-star - bad - triple as annotation"
+    }
+  ]
+}

--- a/tests/trig/syntax/manifest.ttl
+++ b/tests/trig/syntax/manifest.ttl
@@ -8,7 +8,7 @@ PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX trs:    <https://w3c.github.io/rdf-star/tests/turtle/syntax#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/trig/syntax#>
 
 trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "TriG-star Syntax Tests" ;

--- a/tests/trig/syntax/manifest.ttl
+++ b/tests/trig/syntax/manifest.ttl
@@ -1,0 +1,165 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/turtle/syntax#>
+
+trs:manifest  rdf:type mf:Manifest ;
+    rdfs:label "TriG-star Syntax Tests" ;
+    mf:entries
+    (
+        trs:trig-star-1
+        trs:trig-star-2
+
+        trs:trig-star-inside-1
+        trs:trig-star-inside-2
+
+        trs:trig-star-nested-1
+        trs:trig-star-nested-2
+
+        trs:trig-star-compound-1
+
+        trs:trig-star-bnode-1
+        trs:trig-star-bnode-2
+        trs:trig-star-bnode-3
+
+        trs:trig-star-bad-1
+        trs:trig-star-bad-2
+        trs:trig-star-bad-3
+        trs:trig-star-bad-4
+        trs:trig-star-bad-5
+        trs:trig-star-bad-6
+        trs:trig-star-bad-7
+        trs:trig-star-bad-8
+
+        trs:trig-star-ann-1
+        trs:trig-star-ann-2
+        
+        trs:trig-star-bad-ann-1
+        trs:trig-star-bad-ann-2
+    ) .
+
+## Good Syntax
+
+trs:trig-star-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - subject embedded triple" ;
+   mf:action    <trig-star-syntax-basic-01.trig> ;
+   .
+
+trs:trig-star-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - object embedded triple" ;
+   mf:action    <trig-star-syntax-basic-02.trig> ;
+   .
+
+trs:trig-star-inside-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - embedded triple inside blankNodePropertyList" ;
+   mf:action    <trig-star-syntax-inside-01.trig> ;
+   .
+
+trs:trig-star-inside-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - embedded triple inside collection" ;
+   mf:action    <trig-star-syntax-inside-02.trig> ;
+   .
+
+trs:trig-star-nested-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - nested embedded triple, subject position" ;
+   mf:action    <trig-star-syntax-nested-01.trig> ;
+   .
+
+trs:trig-star-nested-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - nested embedded triple, object position" ;
+   mf:action     <trig-star-syntax-nested-02.trig> ;
+   .
+
+trs:trig-star-compound-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - compound forms" ;
+   mf:action    <trig-star-syntax-compound.trig> ;
+   .
+
+trs:trig-star-bnode-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - blank node subject" ;
+   mf:action    <trig-star-syntax-bnode-01.trig> ;
+   .
+
+trs:trig-star-bnode-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - blank node object" ;
+   mf:action    <trig-star-syntax-bnode-02.trig> ;
+   .
+
+trs:trig-star-bnode-3 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - blank node" ;
+   mf:action    <trig-star-syntax-bnode-03.trig> ;
+   .
+
+## Bad Syntax
+
+trs:trig-star-bad-1 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - embedded triple as predicate" ;
+    mf:action    <trig-star-syntax-bad-01.trig> ;
+    .
+
+trs:trig-star-bad-2 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - embedded triple outside triple" ;
+    mf:action    <trig-star-syntax-bad-02.trig> ;
+    .
+
+trs:trig-star-bad-3 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - collection list in embedded triple" ;
+    mf:action    <trig-star-syntax-bad-03.trig> ;
+    .
+
+trs:trig-star-bad-4 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - literal in subject position of embedded triple" ;
+    mf:action    <trig-star-syntax-bad-04.trig> ;
+    .
+
+trs:trig-star-bad-5 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - blank node  as predicate in embedded triple";
+    mf:action    <trig-star-syntax-bad-05.trig> ;
+    .
+
+trs:trig-star-bad-6 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - compound blank node expression";
+    mf:action    <trig-star-syntax-bad-06.trig> ;
+    .
+
+trs:trig-star-bad-7 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - incomplete embedded triple";
+    mf:action    <trig-star-syntax-bad-07.trig> ;
+    .
+
+trs:trig-star-bad-8 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - over-long embedded triple";
+    mf:action    <trig-star-syntax-bad-08.trig> ;
+    .
+
+## Annotation syntax
+
+trs:trig-star-ann-1 rdf:type rdft:TestTrigPositiveSyntax ;
+    mf:name      "TriG-star - Annotation form" ;
+    mf:action    <trig-star-annotation-1.trig> ;
+   .
+
+trs:trig-star-ann-2 rdf:type rdft:TestTrigPositiveSyntax ;
+    mf:name      "TriG-star - Annotation example" ;
+    mf:action    <trig-star-annotation-2.trig> ;
+    .
+
+## Bad annotation syntax
+
+trs:trig-star-bad-ann-1 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - empty annotation" ;
+    mf:action    <trig-star-syntax-bad-ann-1.trig> ;
+   .
+
+trs:trig-star-bad-ann-2 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - triple as annotation" ;
+    mf:action    <trig-star-syntax-bad-ann-2.trig> ;
+   .
+

--- a/tests/trig/syntax/trig-star-annotation-1.trig
+++ b/tests/trig/syntax/trig-star-annotation-1.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :r :z |} }

--- a/tests/trig/syntax/trig-star-annotation-2.trig
+++ b/tests/trig/syntax/trig-star-annotation-2.trig
@@ -1,0 +1,12 @@
+PREFIX :       <http://example/>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+:G {
+  :s :p :o {| :source [ :graph <http://host1/> ;
+                        :date "2020-01-20"^^xsd:date
+                      ] ;
+              :source [ :graph <http://host2/> ;
+                        :date "2020-12-31"^^xsd:date
+                      ]
+            |} .
+}

--- a/tests/trig/syntax/trig-star-syntax-bad-01.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  :x <<:s :p :o>> 123 .
+}

--- a/tests/trig/syntax/trig-star-syntax-bad-02.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-02.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  <<:s :p :o>> .
+}

--- a/tests/trig/syntax/trig-star-syntax-bad-03.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-03.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p ("abc") .
+  <<:s :p ("abc") >> :q 123 .
+}

--- a/tests/trig/syntax/trig-star-syntax-bad-04.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-04.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  <<3 :p :o >> :q :z .
+}

--- a/tests/trig/syntax/trig-star-syntax-bad-05.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-05.trig
@@ -1,0 +1,5 @@
+PREFIX : <http://example/>
+
+:G {
+  <<:s [] :o>> :q 123 .
+}

--- a/tests/trig/syntax/trig-star-syntax-bad-06.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-06.trig
@@ -1,0 +1,5 @@
+PREFIX : <http://example/>
+
+:G {
+  <<:s :p [ :p1 :o1 ]  >> :q 123 .
+}

--- a/tests/trig/syntax/trig-star-syntax-bad-07.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-07.trig
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+
+:G {:s :p << :p :r >> .}

--- a/tests/trig/syntax/trig-star-syntax-bad-08.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-08.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p << :g :s :p :o >> .}

--- a/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig
@@ -1,0 +1,4 @@
+PREFIX : <http://example.com/ns#>
+
+:G {:s :p :o {|  |} .}
+

--- a/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig
+++ b/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example.com/ns#>
+
+:G {:a :b :c {| :s :p :o |} .}

--- a/tests/trig/syntax/trig-star-syntax-basic-01.trig
+++ b/tests/trig/syntax/trig-star-syntax-basic-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  <<:s :p :o>> :q 123 .
+}

--- a/tests/trig/syntax/trig-star-syntax-basic-02.trig
+++ b/tests/trig/syntax/trig-star-syntax-basic-02.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  :x :p <<:s :p :o>> .
+}

--- a/tests/trig/syntax/trig-star-syntax-bnode-01.trig
+++ b/tests/trig/syntax/trig-star-syntax-bnode-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  _:a :p :o .
+  <<_:a :p :o >> :q 456 .
+}

--- a/tests/trig/syntax/trig-star-syntax-bnode-02.trig
+++ b/tests/trig/syntax/trig-star-syntax-bnode-02.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p _:a .
+  <<:s :p _:a >> :q 456 .
+}

--- a/tests/trig/syntax/trig-star-syntax-bnode-03.trig
+++ b/tests/trig/syntax/trig-star-syntax-bnode-03.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {<<[] :p [] >> :q :z .}

--- a/tests/trig/syntax/trig-star-syntax-compound.trig
+++ b/tests/trig/syntax/trig-star-syntax-compound.trig
@@ -1,0 +1,12 @@
+PREFIX : <http://example/>
+
+:G {
+  :x :r :z .
+  :a :b :c .
+  <<:a :b :c>> :r :z .
+  <<:x :r :z >> :p <<:a :b :c>> .
+
+  << <<:x :r :z >> :p <<:a :b :c>> >>
+     :q
+  << <<:x :r :z >> :p <<:a :b :c>> >> .
+}

--- a/tests/trig/syntax/trig-star-syntax-inside-01.trig
+++ b/tests/trig/syntax/trig-star-syntax-inside-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  [ :q <<:s :p :o>> ] :b :c .
+}

--- a/tests/trig/syntax/trig-star-syntax-inside-02.trig
+++ b/tests/trig/syntax/trig-star-syntax-inside-02.trig
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o1 .
+  :s :p :o2 .
+  ( <<:s :p :o1>> <<:s :p :o2>> )  :q 123 .
+}

--- a/tests/trig/syntax/trig-star-syntax-nested-01.trig
+++ b/tests/trig/syntax/trig-star-syntax-nested-01.trig
@@ -1,0 +1,9 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+
+  <<:s :p :o >> :r :z .
+
+  << <<:s :p :o >> :r :z >> :q 1 .
+}

--- a/tests/trig/syntax/trig-star-syntax-nested-02.trig
+++ b/tests/trig/syntax/trig-star-syntax-nested-02.trig
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  :a :q <<:s :p :o >> .
+  << :a :q <<:s :p :o >>>> :r :z .
+}

--- a/tests/turtle/eval/manifest.jsonld
+++ b/tests/turtle/eval/manifest.jsonld
@@ -60,11 +60,14 @@
         "NotClassified": "test:NotClassified",
         "Rejected": "test:Rejected",
         "Obsoleted": "test:Obsoleted",
-        "Withdrawn": "test:RejectedWithdrawn"
+        "Withdrawn": "test:Withdrawn"
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
+    "statusOf": {
+      "@reverse": "test:approval"
+    }
   },
   "@id": "trs:manifest",
   "@type": "Manifest",
@@ -73,86 +76,86 @@
     {
       "@id": "trs:turtle-star-1",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-01.nt",
+      "action": "turtle-star-eval-01.ttl",
       "name": "Turtle-star - subject embedded triple",
-      "action": "turtle-star-eval-01.ttl"
+      "result": "turtle-star-eval-01.nt"
     },
     {
       "@id": "trs:turtle-star-2",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-02.nt",
+      "action": "turtle-star-eval-02.ttl",
       "name": "Turtle-star - object embedded triple",
-      "action": "turtle-star-eval-02.ttl"
+      "result": "turtle-star-eval-02.nt"
     },
     {
       "@id": "trs:turtle-star-bnode-1",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-bnode-1.nt",
+      "action": "turtle-star-eval-bnode-1.ttl",
       "name": "Turtle-star - blank node label",
-      "action": "turtle-star-eval-bnode-1.ttl"
+      "result": "turtle-star-eval-bnode-1.nt"
     },
     {
       "@id": "trs:turtle-star-bnode-2",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-bnode-2.nt",
+      "action": "turtle-star-eval-bnode-2.ttl",
       "name": "Turtle-star - blank node labels",
-      "action": "turtle-star-eval-bnode-2.ttl"
+      "result": "turtle-star-eval-bnode-2.nt"
     },
     {
       "@id": "trs:turtle-star-annotation-1",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-annotation-1.nt",
+      "action": "turtle-star-eval-annotation-1.ttl",
       "name": "Turtle-star - Annotation form",
-      "action": "turtle-star-eval-annotation-1.ttl"
+      "result": "turtle-star-eval-annotation-1.nt"
     },
     {
       "@id": "trs:turtle-star-annotation-2",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-annotation-2.nt",
+      "action": "turtle-star-eval-annotation-2.ttl",
       "name": "Turtle-star - Annotation example",
-      "action": "turtle-star-eval-annotation-2.ttl"
+      "result": "turtle-star-eval-annotation-2.nt"
     },
     {
       "@id": "trs:turtle-star-annotation-3",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-annotation-3.nt",
+      "action": "turtle-star-eval-annotation-3.ttl",
       "name": "Turtle-star - Annotation - predicate and object lists",
-      "action": "turtle-star-eval-annotation-3.ttl"
+      "result": "turtle-star-eval-annotation-3.nt"
     },
     {
       "@id": "trs:turtle-star-annotation-4",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-annotation-4.nt",
+      "action": "turtle-star-eval-annotation-4.ttl",
       "name": "Turtle-star - Annotation - nested",
-      "action": "turtle-star-eval-annotation-4.ttl"
+      "result": "turtle-star-eval-annotation-4.nt"
     },
     {
       "@id": "trs:turtle-star-annotation-5",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-annotation-5.nt",
+      "action": "turtle-star-eval-annotation-5.ttl",
       "name": "Turtle-star - Annotation object list",
-      "action": "turtle-star-eval-annotation-5.ttl"
+      "result": "turtle-star-eval-annotation-5.nt"
     },
     {
       "@id": "trs:turtle-star-embed-annotation-1",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-embed-annotation-1.nt",
+      "action": "turtle-star-eval-embed-annotation-1.ttl",
       "name": "Turtle-star - Annotation with embedding",
-      "action": "turtle-star-eval-embed-annotation-1.ttl"
+      "result": "turtle-star-eval-embed-annotation-1.nt"
     },
     {
       "@id": "trs:turtle-star-embed-annotation-2",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-embed-annotation-2.nt",
+      "action": "turtle-star-eval-embed-annotation-2.ttl",
       "name": "Turtle-star - Annotation on triple with embedded subject",
-      "action": "turtle-star-eval-embed-annotation-2.ttl"
+      "result": "turtle-star-eval-embed-annotation-2.nt"
     },
     {
       "@id": "trs:turtle-star-embed-annotation-3",
       "@type": "rdft:TestTurtleEval",
-      "result": "turtle-star-eval-embed-annotation-3.nt",
+      "action": "turtle-star-eval-embed-annotation-3.ttl",
       "name": "Turtle-star - Annotation on triple with embedded object",
-      "action": "turtle-star-eval-embed-annotation-3.ttl"
+      "result": "turtle-star-eval-embed-annotation-3.nt"
     }
   ]
 }

--- a/tests/turtle/syntax/manifest.jsonld
+++ b/tests/turtle/syntax/manifest.jsonld
@@ -60,11 +60,14 @@
         "NotClassified": "test:NotClassified",
         "Rejected": "test:Rejected",
         "Obsoleted": "test:Obsoleted",
-        "Withdrawn": "test:RejectedWithdrawn"
+        "Withdrawn": "test:Withdrawn"
       }
     },
     "TestTurtlePositiveSyntax": "rdft:TestTurtlePositiveSyntax",
-    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax"
+    "TestTurtleNegativeSyntax": "rdft:TestTurtleNegativeSyntax",
+    "statusOf": {
+      "@reverse": "test:approval"
+    }
   },
   "@id": "trs:manifest",
   "@type": "Manifest",
@@ -73,134 +76,134 @@
     {
       "@id": "trs:turtle-star-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - subject embedded triple",
-      "action": "turtle-star-syntax-basic-01.ttl"
+      "action": "turtle-star-syntax-basic-01.ttl",
+      "name": "Turtle-star - subject embedded triple"
     },
     {
       "@id": "trs:turtle-star-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - object embedded triple",
-      "action": "turtle-star-syntax-basic-02.ttl"
+      "action": "turtle-star-syntax-basic-02.ttl",
+      "name": "Turtle-star - object embedded triple"
     },
     {
       "@id": "trs:turtle-star-inside-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - embedded triple inside blankNodePropertyList",
-      "action": "turtle-star-syntax-inside-01.ttl"
+      "action": "turtle-star-syntax-inside-01.ttl",
+      "name": "Turtle-star - embedded triple inside blankNodePropertyList"
     },
     {
       "@id": "trs:turtle-star-inside-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - embedded triple inside collection",
-      "action": "turtle-star-syntax-inside-02.ttl"
+      "action": "turtle-star-syntax-inside-02.ttl",
+      "name": "Turtle-star - embedded triple inside collection"
     },
     {
       "@id": "trs:turtle-star-nested-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - nested embedded triple, subject position",
-      "action": "turtle-star-syntax-nested-01.ttl"
+      "action": "turtle-star-syntax-nested-01.ttl",
+      "name": "Turtle-star - nested embedded triple, subject position"
     },
     {
       "@id": "trs:turtle-star-nested-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - nested embedded triple, object position",
-      "action": "turtle-star-syntax-nested-02.ttl"
+      "action": "turtle-star-syntax-nested-02.ttl",
+      "name": "Turtle-star - nested embedded triple, object position"
     },
     {
       "@id": "trs:turtle-star-compound-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - compound forms",
-      "action": "turtle-star-syntax-compound.ttl"
+      "action": "turtle-star-syntax-compound.ttl",
+      "name": "Turtle-star - compound forms"
     },
     {
       "@id": "trs:turtle-star-bnode-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - blank node subject",
-      "action": "turtle-star-syntax-bnode-01.ttl"
+      "action": "turtle-star-syntax-bnode-01.ttl",
+      "name": "Turtle-star - blank node subject"
     },
     {
       "@id": "trs:turtle-star-bnode-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - blank node object",
-      "action": "turtle-star-syntax-bnode-02.ttl"
+      "action": "turtle-star-syntax-bnode-02.ttl",
+      "name": "Turtle-star - blank node object"
     },
     {
       "@id": "trs:turtle-star-bnode-3",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - blank node",
-      "action": "turtle-star-syntax-bnode-03.ttl"
+      "action": "turtle-star-syntax-bnode-03.ttl",
+      "name": "Turtle-star - blank node"
     },
     {
       "@id": "trs:turtle-star-bad-1",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - embedded triple as predicate",
-      "action": "turtle-star-syntax-bad-01.ttl"
+      "action": "turtle-star-syntax-bad-01.ttl",
+      "name": "Turtle-star - bad - embedded triple as predicate"
     },
     {
       "@id": "trs:turtle-star-bad-2",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - embedded triple outside triple",
-      "action": "turtle-star-syntax-bad-02.ttl"
+      "action": "turtle-star-syntax-bad-02.ttl",
+      "name": "Turtle-star - bad - embedded triple outside triple"
     },
     {
       "@id": "trs:turtle-star-bad-3",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - collection list in embedded triple",
-      "action": "turtle-star-syntax-bad-03.ttl"
+      "action": "turtle-star-syntax-bad-03.ttl",
+      "name": "Turtle-star - bad - collection list in embedded triple"
     },
     {
       "@id": "trs:turtle-star-bad-4",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - literal in subject position of embedded triple",
-      "action": "turtle-star-syntax-bad-04.ttl"
+      "action": "turtle-star-syntax-bad-04.ttl",
+      "name": "Turtle-star - bad - literal in subject position of embedded triple"
     },
     {
       "@id": "trs:turtle-star-bad-5",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - blank node  as predicate in embedded triple",
-      "action": "turtle-star-syntax-bad-05.ttl"
+      "action": "turtle-star-syntax-bad-05.ttl",
+      "name": "Turtle-star - bad - blank node  as predicate in embedded triple"
     },
     {
       "@id": "trs:turtle-star-bad-6",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - compound blank node expression",
-      "action": "turtle-star-syntax-bad-06.ttl"
+      "action": "turtle-star-syntax-bad-06.ttl",
+      "name": "Turtle-star - bad - compound blank node expression"
     },
     {
       "@id": "trs:turtle-star-bad-7",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - incomplete embedded triple",
-      "action": "turtle-star-syntax-bad-07.ttl"
+      "action": "turtle-star-syntax-bad-07.ttl",
+      "name": "Turtle-star - bad - incomplete embedded triple"
     },
     {
       "@id": "trs:turtle-star-bad-8",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - over-long embedded triple",
-      "action": "turtle-star-syntax-bad-08.ttl"
+      "action": "turtle-star-syntax-bad-08.ttl",
+      "name": "Turtle-star - bad - over-long embedded triple"
     },
     {
       "@id": "trs:turtle-star-ann-1",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - Annotation form",
-      "action": "turtle-star-annotation-1.ttl"
+      "action": "turtle-star-annotation-1.ttl",
+      "name": "Turtle-star - Annotation form"
     },
     {
       "@id": "trs:turtle-star-ann-2",
       "@type": "TestTurtlePositiveSyntax",
-      "name": "Turtle-star - Annotation example",
-      "action": "turtle-star-annotation-2.ttl"
+      "action": "turtle-star-annotation-2.ttl",
+      "name": "Turtle-star - Annotation example"
     },
     {
       "@id": "trs:turtle-star-bad-ann-1",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - empty annotation",
-      "action": "turtle-star-syntax-bad-ann-1.ttl"
+      "action": "turtle-star-syntax-bad-ann-1.ttl",
+      "name": "Turtle-star - bad - empty annotation"
     },
     {
       "@id": "trs:turtle-star-bad-ann-2",
       "@type": "TestTurtleNegativeSyntax",
-      "name": "Turtle-star - bad - triple as annotation",
-      "action": "turtle-star-syntax-bad-ann-2.ttl"
+      "action": "turtle-star-syntax-bad-ann-2.ttl",
+      "name": "Turtle-star - bad - triple as annotation"
     }
   ]
 }


### PR DESCRIPTION
Adds a section on TriG-star similar to N-Quads-star.

It seems that most of the work is already done by Turtle-star, but the discussion could go into more detail about processing, if anything thinks it would be useful.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/pull/147.html" title="Last updated on Apr 4, 2021, 7:22 PM UTC (6f7c3df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/147/95b9762...6f7c3df.html" title="Last updated on Apr 4, 2021, 7:22 PM UTC (6f7c3df)">Diff</a>