### PR TITLE
SPARQL-star: Add embedded triple pattern to PrimaryExpression, define evaluation.

### DIFF
--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -895,6 +895,23 @@ SELECT ?claimer WHERE {
             <a data-cite="SPARQL11-QUERY#rTriplesNodePath">TriplesNodePath</a>
           </td>
         </tr>
+        <tr id="rPrimaryExpression">
+          <td>[119]</td>
+          <td>`PrimaryExpression`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="SPARQL11-QUERY#rBrackettedExpression">BrackettedExpression</a> `|` 
+            <a data-cite="SPARQL11-QUERY#rBuiltInCall">BuiltInCall</a> `|` 
+            <a data-cite="SPARQL11-QUERY#ririOrFunction">iriOrFunction</a> `|` 
+            <a data-cite="SPARQL11-QUERY#rRDFLiteral">RDFLiteral</a> `|` 
+            <a data-cite="SPARQL11-QUERY#rNumericLiteral">NumericLiteral</a> `|`
+            <a data-cite="SPARQL11-QUERY#rBooleanLiteral">BooleanLiteral</a> `|`
+            <a data-cite="SPARQL11-QUERY#rVar">Var</a>
+            <div style="font-weight: bold">
+            `|` <a href="#rExprEmbTP" style="font-weight: bold">ExprEmbTP</a>
+            </div>
+          </td>
+        </tr>
         <tr id="rBuiltInCall">
           <td>[121]</td>
           <td>`BuiltInCall`</td>
@@ -1401,6 +1418,31 @@ SELECT ?claimer WHERE {
             <code class="token">'|}'</code>
           </td>
         </tr>
+        <tr id="rExprEmbTP">
+          <td>[181]</td>
+          <td style="font-weight: bold">`ExprEmbTP`</td>
+          <td style="font-weight: bold">::=</td>
+          <td style="font-weight: bold">
+            <code class="token">'&lt;&lt;'</code>
+            <a href="#rExprVarOrTerm">ExprVarOrTerm</a>
+            <a data-cite="SPARQL11-QUERY#rVerb">Verb</a>
+            <a href="#rExprVarOrTerm">ExprVarOrTerm</a>
+            <code class="token">'&gt;&gt;'</code>
+          </td>
+        </tr>
+        <tr id="rExprVarOrTerm">
+          <td>[182]</td>
+          <td style="font-weight: bold">`ExprVarOrTerm`</td>
+          <td style="font-weight: bold">::=</td>
+          <td style="font-weight: bold">
+            <a data-cite="SPARQL11-QUERY#riri">iri</a> `|` 
+            <a data-cite="SPARQL11-QUERY#rRDFLiteral">RDFLiteral</a> `|` 
+            <a data-cite="SPARQL11-QUERY#rNumericLiteral">NumericLiteral</a> `|`
+            <a data-cite="SPARQL11-QUERY#rBooleanLiteral">BooleanLiteral</a> `|`
+            <a data-cite="SPARQL11-QUERY#rVar">Var</a> `|`
+	          <a href="#rExprEmbTP">ExprEmbTP</a>
+          </td>
+        </tr>
       </table>
 
       <p>
@@ -1680,6 +1722,25 @@ SELECT ?claimer WHERE {
 
         <p>Returns <code>true</code> if <code style="color:black">term</code> is an <a>RDF-star triple</a>. Returns <code>false</code> otherwise.</p>
 
+      </section>
+
+      <section>
+        <h2>Embedded Triple Expression</h2>
+        <p>
+          <code>RDF-star triple</code> &nbsp;
+          <code style="color:black;font-weight:bold">&lt;&lt;</code>
+          <code>RDF-star term</code> <code style="color:black">term1</code>,
+          <code>RDF-star term</code> <code style="color:black">term2</code>,
+          <code>RDF-star term</code> <code style="color:black">term3</code>
+          <code style="color:black;font-weight:bold">&gt;&gt;</code>
+        </p>
+        <p>
+          An <a href="#rExprEmbTP">Embedded Triple Expression</a>
+          <code>&lt;&lt;S P O&gt;&gt;</code>, where <code>S</code>, 
+          <code>P</code> and <code>O</code> conform to
+          <a href="#rExprVarOrTerm">ExprVarOrTerm</a>,
+          evaluates function <code>TRIPLE(S, P, O)</code>.
+        </p>
       </section>
 
       <section class="informative">

--- a/tests/sparql/syntax/manifest.jsonld
+++ b/tests/sparql/syntax/manifest.jsonld
@@ -314,6 +314,18 @@
       "name": "SPARQL-star - bad - blank node in embedded triple in VALUES "
     },
     {
+      "@id": "trs:sparql-star-bad-11",
+      "@type": "NegativeSyntaxTest11",
+      "action": "sparql-star-syntax-bad-11.rq",
+      "name": "SPARQL-star - bad - blank node in embedded triple in FILTER"
+    },
+    {
+      "@id": "trs:sparql-star-bad-12",
+      "@type": "NegativeSyntaxTest11",
+      "action": "sparql-star-syntax-bad-12.rq",
+      "name": "SPARQL-star - bad - blank node in embedded triple in BIND"
+    },
+    {
       "@id": "trs:sparql-star-bad-ann-1",
       "@type": "NegativeSyntaxTest11",
       "action": "sparql-star-syntax-bad-ann-1.rq",

--- a/tests/sparql/syntax/manifest.ttl
+++ b/tests/sparql/syntax/manifest.ttl
@@ -60,6 +60,8 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:sparql-star-bad-8
         trs:sparql-star-bad-9
         trs:sparql-star-bad-10
+        trs:sparql-star-bad-11
+        trs:sparql-star-bad-12
 
         trs:sparql-star-bad-ann-1
         trs:sparql-star-bad-ann-2
@@ -249,6 +251,16 @@ trs:sparql-star-bad-9 rdf:type mf:NegativeSyntaxTest11 ;
 trs:sparql-star-bad-10 rdf:type mf:NegativeSyntaxTest11 ;
     mf:name      "SPARQL-star - bad - blank node in embedded triple in VALUES ";
     mf:action    <sparql-star-syntax-bad-10.rq> ;
+    .
+
+trs:sparql-star-bad-11 rdf:type mf:NegativeSyntaxTest11 ;
+    mf:name      "SPARQL-star - bad - blank node in embedded triple in FILTER";
+    mf:action    <sparql-star-syntax-bad-11.rq> ;
+    .
+
+trs:sparql-star-bad-12 rdf:type mf:NegativeSyntaxTest11 ;
+    mf:name      "SPARQL-star - bad - blank node in embedded triple in BIND";
+    mf:action    <sparql-star-syntax-bad-12.rq> ;
     .
 
 ## Annotation syntax

--- a/tests/sparql/syntax/sparql-star-syntax-bad-11.rq
+++ b/tests/sparql/syntax/sparql-star-syntax-bad-11.rq
@@ -1,0 +1,6 @@
+PREFIX : <http://example.com/>
+
+SELECT * {
+    ?s ?p ?o .
+    BIND(<< [] ?p ?o >> AS ?t )
+}

--- a/tests/sparql/syntax/sparql-star-syntax-bad-12.rq
+++ b/tests/sparql/syntax/sparql-star-syntax-bad-12.rq
@@ -1,0 +1,6 @@
+PREFIX : <http://example.com/>
+
+SELECT * {
+    ?s ?p ?o .
+    FILTER ( isTRIPLE(<< ?s ?p [] >>) )
+}


### PR DESCRIPTION
Addresses issue #163.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/pull/167.html" title="Last updated on May 6, 2021, 8:10 AM UTC (950082c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/167/ce2db5e...950082c.html" title="Last updated on May 6, 2021, 8:10 AM UTC (950082c)">Diff</a>