### PR TITLE
Apache Jena implementation report (2021-06-06)

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -73,8 +73,11 @@
             <td><a href="http://graphdb.ontotext.com/documentation/9.2/free/devhub/rdf-sparql-star.html">documentation</a>
             <td>
           <tr><td>Apache Jena
-            <td><a href="https://jena.apache.org/documentation/rdfstar/">documentation</a>
             <td>
+              <a href="https://w3c.github.io/rdf-star/reports/#subj_Apache_Jena_">implementation report</a>,
+              <a href="https://jena.apache.org/documentation/rdfstar/">documentation</a>
+            <td>
+              
           <tr><td>Eclipse rdf4j
             <td><a href="https://rdf4j.org/documentation/programming/rdfstar/">documentation</a>
             <td>

--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -117,11 +117,69 @@
   ],
   "bibRef": "[[rdf-star]]",
   "assertions": [
+    "jena-report-2021-06-06.ttl",
     "ruby-trig.ttl",
-    "eye-earl.ttl",
-    "ruby-sparql.ttl"
+    "ruby-sparql.ttl",
+    "eye-earl.ttl"
   ],
+  "generatedBy": {
+    "@id": "https://rubygems.org/gems/earl-report",
+    "@type": [
+      "doap:Project",
+      "Software"
+    ],
+    "developer": [
+      {
+        "@id": "https://greggkellogg.net/foaf#me",
+        "@type": [
+          "foaf:Person",
+          "Assertor"
+        ],
+        "foaf:homepage": "https://greggkellogg.net/",
+        "foaf:name": "Gregg Kellogg"
+      }
+    ],
+    "language": "Ruby",
+    "homepage": "https://github.com/gkellogg/earl-report",
+    "license": "http://unlicense.org",
+    "shortdesc": "Earl Report summary generator",
+    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
+    "name": "earl-report",
+    "release": {
+      "@id": "https://github.com/gkellogg/earl-report/tree/0.7.0",
+      "@type": "doap:Version",
+      "revision": "0.7.0",
+      "doap:created": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-04-09"
+      },
+      "name": "earl-report-0.7.0"
+    }
+  },
   "testSubjects": [
+    {
+      "@id": "http://jena.apache.org/#jena",
+      "@type": [
+        "TestSubject",
+        "doap:Project",
+        "Software"
+      ],
+      "developer": [
+        {
+          "@id": "_:b16",
+          "@type": "foaf:Agent",
+          "foaf:homepage": "http://jena.apache.org/",
+          "foaf:name": "Apache Jena Community"
+        }
+      ],
+      "homepage": "http://jena.apache.org/",
+      "release": {
+        "@id": "_:b17",
+        "revision": "4.1.0"
+      },
+      "doapDesc": "Apache Jena : RDF system and SPARQL triple store",
+      "name": "Apache Jena"
+    },
     {
       "@id": "https://josd.github.io/eye/",
       "@type": [
@@ -129,19 +187,18 @@
         "doap:Project",
         "Software"
       ],
-      "language": "Prolog",
       "developer": [
         {
           "@id": "https://josd.github.io/",
           "@type": [
-            "Assertor",
-            "foaf:Person"
+            "foaf:Person",
+            "Assertor"
           ],
           "foaf:homepage": {
             "@id": "https://josd.github.io/",
             "@type": [
-              "Assertor",
-              "foaf:Person"
+              "foaf:Person",
+              "Assertor"
             ],
             "foaf:homepage": "https://josd.github.io/",
             "foaf:name": "Jos De Roo"
@@ -149,12 +206,13 @@
           "foaf:name": "Jos De Roo"
         }
       ],
+      "language": "Prolog",
       "homepage": "https://josd.github.io/eye/index.html",
-      "doapDesc": "Euler Yet another proof Engine",
       "release": {
-        "@id": "_:b18",
+        "@id": "_:b24",
         "revision": "EYE v21.0530.2141 josd"
       },
+      "doapDesc": "Euler Yet another proof Engine",
       "name": "EYE"
     },
     {
@@ -164,24 +222,24 @@
         "doap:Project",
         "Software"
       ],
-      "language": "Ruby",
       "developer": [
         {
           "@id": "https://greggkellogg.net/foaf#me",
           "@type": [
-            "Assertor",
-            "foaf:Person"
+            "foaf:Person",
+            "Assertor"
           ],
           "foaf:homepage": "https://greggkellogg.net/",
           "foaf:name": "Gregg Kellogg"
         }
       ],
+      "language": "Ruby",
       "homepage": "https://github.com/ruby-rdf/rdf-trig",
-      "doap:description": "TriG reader/writer for RDF.rb",
       "release": {
         "@id": "https://github.com/ruby-rdf/rdf-trig/tree/3.1.2",
         "revision": "3.1.2"
       },
+      "doap:description": "TriG reader/writer for RDF.rb",
       "name": "RDF::TriG"
     },
     {
@@ -191,97 +249,91 @@
         "doap:Project",
         "Software"
       ],
-      "language": "Ruby",
       "developer": [
         {
           "@id": "https://greggkellogg.net/foaf#me",
           "@type": [
-            "Assertor",
-            "foaf:Person"
+            "foaf:Person",
+            "Assertor"
           ],
           "foaf:homepage": "https://greggkellogg.net/",
           "foaf:name": "Gregg Kellogg"
         }
       ],
+      "language": "Ruby",
       "homepage": "https://github.com/ruby-rdf/sparql",
-      "doapDesc": "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite.",
       "release": {
-        "@id": "_:b3",
+        "@id": "_:b10",
         "revision": "3.1.7"
       },
+      "doapDesc": "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite.",
       "name": "Ruby SPARQL"
     }
   ],
   "entries": [
     {
-      "@id": "https://w3c.github.io/rdf-star/tests/semantics#manifest",
+      "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#manifest",
       "@type": [
         "Report",
         "mf:Manifest"
       ],
-      "rdfs:seeAlso": {
-        "@id": "https://w3c.github.io/rdf-star/tests/semantics/README"
-      },
-      "rdfs:label": "RDF-star Semantics tests",
+      "rdfs:label": "N-Triples-star Syntax Tests",
       "entries": [
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:PositiveEntailmentTest"
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
           ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "all-identical-embedded-triples-are-the-same",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl",
+          "title": "N-Triples-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt",
           "assertions": [
             {
-              "@id": "_:b822",
+              "@id": "_:b1497",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
               "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
               "result": {
-                "@id": "_:b823",
+                "@id": "_:b1498",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b1311",
+              "@id": "_:b1743",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
               "result": {
-                "@id": "_:b1154",
+                "@id": "_:b1205",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b803",
+              "@id": "_:b1764",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
-              "subject": "https://rubygems.org/gems/sparql",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
               "result": {
-                "@id": "_:b804",
+                "@id": "_:b1085",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1687",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
+              "result": {
+                "@id": "_:b1453",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -290,63 +342,60 @@
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
           "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
           ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "embedded-triples-no-spurious",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "This test ensures that other entailments are not spurious.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test005.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "title": "N-Triples-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt",
           "assertions": [
             {
-              "@id": "_:b536",
+              "@id": "_:b346",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
               "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
               "result": {
-                "@id": "_:b283",
+                "@id": "_:b347",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b891",
+              "@id": "_:b1648",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
               "result": {
-                "@id": "_:b663",
+                "@id": "_:b1606",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b692",
+              "@id": "_:b1506",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
-              "subject": "https://rubygems.org/gems/sparql",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
               "result": {
-                "@id": "_:b477",
+                "@id": "_:b1404",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b664",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
+              "result": {
+                "@id": "_:b665",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -355,49 +404,467 @@
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:PositiveEntailmentTest"
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
           ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "bnodes-in-embedded-subject",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "title": "N-Triples-star - subject and object embedded triples",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt",
           "assertions": [
             {
-              "@id": "_:b1162",
+              "@id": "_:b1347",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
               "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
               "result": {
-                "@id": "_:b901",
+                "@id": "_:b1348",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b439",
+              "@id": "_:b981",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
+              "result": {
+                "@id": "_:b976",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b223",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
+              "result": {
+                "@id": "_:b224",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1530",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
+              "result": {
+                "@id": "_:b1531",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star - whitespace and terms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt",
+          "assertions": [
+            {
+              "@id": "_:b1172",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "result": {
+                "@id": "_:b934",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b770",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "result": {
+                "@id": "_:b771",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1011",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "result": {
+                "@id": "_:b1012",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1384",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "result": {
+                "@id": "_:b837",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star - Nested, no whitespace",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt",
+          "assertions": [
+            {
+              "@id": "_:b521",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+              "result": {
+                "@id": "_:b522",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b56",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+              "result": {
+                "@id": "_:b20",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1709",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+              "result": {
+                "@id": "_:b1092",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b852",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+              "result": {
+                "@id": "_:b853",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star - Blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt",
+          "assertions": [
+            {
+              "@id": "_:b921",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+              "result": {
+                "@id": "_:b922",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b38",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+              "result": {
+                "@id": "_:b39",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1429",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+              "result": {
+                "@id": "_:b1430",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1592",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+              "result": {
+                "@id": "_:b400",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star - Blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt",
+          "assertions": [
+            {
+              "@id": "_:b1806",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+              "result": {
+                "@id": "_:b1275",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1647",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+              "result": {
+                "@id": "_:b747",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b274",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+              "result": {
+                "@id": "_:b275",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b153",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+              "result": {
+                "@id": "_:b154",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star - Nested subject term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt",
+          "assertions": [
+            {
+              "@id": "_:b1435",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+              "result": {
+                "@id": "_:b1436",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1063",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+              "result": {
+                "@id": "_:b1064",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1405",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+              "result": {
+                "@id": "_:b1393",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b359",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+              "result": {
+                "@id": "_:b360",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star - Nested object term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt",
+          "assertions": [
+            {
+              "@id": "_:b986",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "result": {
+                "@id": "_:b987",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b777",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "result": {
+                "@id": "_:b778",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1014",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "result": {
+                "@id": "_:b893",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1141",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "result": {
+                "@id": "_:b1068",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star - Bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt",
+          "assertions": [
+            {
+              "@id": "_:b1213",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
+              "result": {
+                "@id": "_:b1214",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1800",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
               "result": {
                 "@id": "_:b440",
                 "@type": "TestResult",
@@ -406,12 +873,25 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b649",
+              "@id": "_:b1109",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
-              "subject": "https://rubygems.org/gems/sparql",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
               "result": {
-                "@id": "_:b650",
+                "@id": "_:b1110",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b670",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
+              "result": {
+                "@id": "_:b553",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -420,63 +900,60 @@
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:PositiveEntailmentTest"
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCriterion"
           ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "bnodes-in-embedded-object",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "title": "N-Triples-star - Bad - embedded triple, literal subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt",
           "assertions": [
             {
-              "@id": "_:b366",
+              "@id": "_:b1541",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
               "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
               "result": {
-                "@id": "_:b367",
+                "@id": "_:b1372",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b888",
+              "@id": "_:b1471",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
               "result": {
-                "@id": "_:b889",
+                "@id": "_:b1145",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b145",
+              "@id": "_:b1310",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/sparql",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
               "result": {
-                "@id": "_:b117",
+                "@id": "_:b985",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b513",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
+              "result": {
+                "@id": "_:b514",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -485,723 +962,58 @@
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:PositiveEntailmentTest"
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCriterion"
           ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "bnodes-in-embedded-subject-and-object",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "title": "N-Triples-star - Bad - embedded triple, literal predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt",
           "assertions": [
             {
-              "@id": "_:b1289",
+              "@id": "_:b727",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
               "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
               "result": {
-                "@id": "_:b1257",
+                "@id": "_:b728",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b638",
+              "@id": "_:b1779",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b639",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b672",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b673",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "bnodes-in-embedded-subject-and-object-fail",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "The same bnode can not match different embedded terms.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1166",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-              "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
               "result": {
-                "@id": "_:b559",
+                "@id": "_:b561",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b230",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
+              "result": {
+                "@id": "_:b231",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b28",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b29",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
               },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1237",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b717",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "same-bnode-same-embedded-term",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Identical embedded term can be replaced by the same fresh bnode multiple times.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b713",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b323",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b842",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b836",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b534",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b535",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "different-bnodes-same-embedded-term",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Different bnodes can match identical embedded terms.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1182",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1136",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1308",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b826",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b449",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b450",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "constrained-bnodes-in-embedded-subject",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1225",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b395",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b43",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b44",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1326",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b377",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "constrained-bnodes-in-embedded-object",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1231",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b640",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b409",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b410",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b472",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b249",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "constrained-bnodes-in-embedded-fail",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1234",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1235",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b457",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b458",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b899",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b900",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "constrained-bnodes-on-literal",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1163",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b833",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1203",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b814",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b686",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b660",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "malformed-literal-control",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
-          "mf:result": {
-            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-            "@value": "false"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl",
-          "assertions": [
-            {
-              "@id": "_:b757",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b100",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1344",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1193",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1361",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1109",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "malformed-literal",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "rdfs:comment": "Malformed literals are allowed when embedded.",
-          "mf:result": {
-            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-            "@value": "false"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "assertions": [
-            {
-              "@id": "_:b487",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b488",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b845",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b846",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b655",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b656",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "malformed-literal-accepted",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "rdfs:comment": "Malformed literals are allowed when embedded.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "assertions": [
-            {
-              "@id": "_:b848",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b849",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1256",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b864",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
               "@id": "_:b1036",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
               "result": {
                 "@id": "_:b1037",
                 "@type": "TestResult",
@@ -1212,786 +1024,60 @@
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
           "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "malformed-literal-no-spurious",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "rdfs:comment": "Embedded malformed literals do not lead to spurious entailment.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "assertions": [
-            {
-              "@id": "_:b204",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b205",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b936",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b937",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b530",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b343",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "malformed-literal-bnode",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "rdfs:comment": "Malformed literals can not be replaced by blank nodes.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "assertions": [
-            {
-              "@id": "_:b838",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b297",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1170",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b837",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b704",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b642",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-          "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:PositiveEntailmentTest"
+            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
+            "TestCriterion"
           ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "opaque-literal-control",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl",
+          "title": "N-Triples-star - Bad - embedded triple, blank node predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt",
           "assertions": [
             {
-              "@id": "_:b1277",
+              "@id": "_:b1548",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
               "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
               "result": {
-                "@id": "_:b498",
+                "@id": "_:b758",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b319",
+              "@id": "_:b1591",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b275",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b383",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b384",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "opaque-literal",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "rdfs:comment": "Embedded literals are opaque, even when their datatype is recognized.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl",
-          "assertions": [
-            {
-              "@id": "_:b644",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
               "result": {
-                "@id": "_:b645",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b728",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b611",
+                "@id": "_:b156",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b45",
+              "@id": "_:b1211",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b46",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "opaque-language-string-control",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl",
-          "assertions": [
-            {
-              "@id": "_:b617",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
               "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
               "result": {
-                "@id": "_:b436",
+                "@id": "_:b1212",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b852",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b853",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
               },
-              "assertedBy": null
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b974",
+              "@id": "_:b1248",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
               "result": {
-                "@id": "_:b885",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "opaque-language-string",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl",
-          "assertions": [
-            {
-              "@id": "_:b333",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b334",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b775",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b122",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b733",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b734",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDFS-Plus",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "opaque-iri-control",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b886",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b887",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1123",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1124",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1273",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b531",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDFS-Plus",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "opaque-iri",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Embedded IRIs are opaque.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/superman.ttl",
-          "assertions": [
-            {
-              "@id": "_:b401",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b402",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b999",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b857",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1358",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b236",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-          "@type": [
-            "TestCriterion",
-            "mf:NegativeEntailmentTest",
-            "TestCase"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "embedded-not-asserted",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Embedded triples are not asserted.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b879",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b880",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b958",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b959",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b771",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b144",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "annotated-asserted",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Annotated triples are asserted.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1192",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1034",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1194",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b215",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1038",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1039",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "annotation",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Annotation are about the annotated triple.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1247",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1248",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1241",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1116",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b824",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b825",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "title": "annotation-unfolded",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "rdfs:comment": "Annotation is the same as separate assertions.",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl",
-          "assertions": [
-            {
-              "@id": "_:b890",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b785",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b600",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b601",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1186",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1155",
+                "@id": "_:b1187",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2012,45 +1098,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - subject embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig",
           "assertions": [
             {
-              "@id": "_:b942",
+              "@id": "_:b868",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b579",
+                "@id": "_:b256",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1479",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+              "result": {
+                "@id": "_:b206",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1302",
+              "@id": "_:b1104",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
               "result": {
-                "@id": "_:b1045",
+                "@id": "_:b850",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1152",
+              "@id": "_:b1047",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
               "result": {
-                "@id": "_:b88",
+                "@id": "_:b963",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2061,45 +1160,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - object embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig",
           "assertions": [
             {
-              "@id": "_:b1254",
+              "@id": "_:b887",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b1255",
+                "@id": "_:b888",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1221",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+              "result": {
+                "@id": "_:b1222",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1066",
+              "@id": "_:b1010",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
               "result": {
-                "@id": "_:b302",
+                "@id": "_:b221",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b797",
+              "@id": "_:b126",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
               "result": {
-                "@id": "_:b798",
+                "@id": "_:b127",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2110,45 +1222,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - embedded triple inside blankNodePropertyList",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig",
           "assertions": [
             {
-              "@id": "_:b467",
+              "@id": "_:b262",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b468",
+                "@id": "_:b190",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1444",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+              "result": {
+                "@id": "_:b1321",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b967",
+              "@id": "_:b804",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
               "result": {
-                "@id": "_:b666",
+                "@id": "_:b805",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1238",
+              "@id": "_:b1679",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
               "result": {
-                "@id": "_:b476",
+                "@id": "_:b911",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2159,45 +1284,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - embedded triple inside collection",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig",
           "assertions": [
             {
-              "@id": "_:b227",
+              "@id": "_:b1291",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b228",
+                "@id": "_:b686",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1333",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+              "result": {
+                "@id": "_:b1334",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1228",
+              "@id": "_:b1008",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
               "result": {
-                "@id": "_:b1229",
+                "@id": "_:b685",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1095",
+              "@id": "_:b272",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
               "result": {
-                "@id": "_:b338",
+                "@id": "_:b273",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2208,45 +1346,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - nested embedded triple, subject position",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig",
           "assertions": [
             {
-              "@id": "_:b1199",
+              "@id": "_:b943",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b1200",
+                "@id": "_:b944",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b654",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+              "result": {
+                "@id": "_:b655",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1030",
+              "@id": "_:b636",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
               "result": {
-                "@id": "_:b451",
+                "@id": "_:b637",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b349",
+              "@id": "_:b1197",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
               "result": {
-                "@id": "_:b335",
+                "@id": "_:b408",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2257,45 +1408,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - nested embedded triple, object position",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig",
           "assertions": [
             {
-              "@id": "_:b613",
+              "@id": "_:b1586",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b614",
+                "@id": "_:b1587",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b22",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+              "result": {
+                "@id": "_:b23",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b586",
+              "@id": "_:b1570",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
               "result": {
-                "@id": "_:b587",
+                "@id": "_:b1513",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b150",
+              "@id": "_:b1683",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
               "result": {
-                "@id": "_:b151",
+                "@id": "_:b1247",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2306,45 +1470,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - compound forms",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig",
           "assertions": [
             {
-              "@id": "_:b983",
+              "@id": "_:b640",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b984",
+                "@id": "_:b641",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1602",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+              "result": {
+                "@id": "_:b1112",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b835",
+              "@id": "_:b1538",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
               "result": {
-                "@id": "_:b646",
+                "@id": "_:b1271",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b599",
+              "@id": "_:b564",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
               "result": {
-                "@id": "_:b492",
+                "@id": "_:b565",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2355,45 +1532,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - blank node subject",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig",
           "assertions": [
             {
-              "@id": "_:b146",
+              "@id": "_:b1343",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b147",
+                "@id": "_:b726",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1622",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+              "result": {
+                "@id": "_:b1358",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1207",
+              "@id": "_:b1272",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
               "result": {
-                "@id": "_:b1208",
+                "@id": "_:b45",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b206",
+              "@id": "_:b1717",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
               "result": {
-                "@id": "_:b207",
+                "@id": "_:b367",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2404,45 +1594,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - blank node object",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig",
           "assertions": [
             {
-              "@id": "_:b662",
+              "@id": "_:b855",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b643",
+                "@id": "_:b856",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b705",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
+              "result": {
+                "@id": "_:b706",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1167",
+              "@id": "_:b1223",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
               "result": {
-                "@id": "_:b1168",
+                "@id": "_:b191",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b80",
+              "@id": "_:b997",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
               "result": {
-                "@id": "_:b67",
+                "@id": "_:b988",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2453,45 +1656,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - blank node",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig",
           "assertions": [
             {
-              "@id": "_:b1106",
+              "@id": "_:b1700",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b1107",
+                "@id": "_:b1701",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b369",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+              "result": {
+                "@id": "_:b370",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b301",
+              "@id": "_:b889",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
               "result": {
-                "@id": "_:b194",
+                "@id": "_:b474",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1293",
+              "@id": "_:b519",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
               "result": {
-                "@id": "_:b243",
+                "@id": "_:b166",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2502,45 +1718,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - embedded triple as predicate",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig",
           "assertions": [
             {
-              "@id": "_:b470",
+              "@id": "_:b1578",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b471",
+                "@id": "_:b1494",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1621",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+              "result": {
+                "@id": "_:b1074",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b918",
+              "@id": "_:b1401",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
               "result": {
-                "@id": "_:b919",
+                "@id": "_:b1280",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b970",
+              "@id": "_:b1276",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
               "result": {
-                "@id": "_:b971",
+                "@id": "_:b1046",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2551,45 +1780,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - embedded triple outside triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig",
           "assertions": [
             {
-              "@id": "_:b287",
+              "@id": "_:b713",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b288",
+                "@id": "_:b714",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b906",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+              "result": {
+                "@id": "_:b74",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b624",
+              "@id": "_:b1045",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
               "result": {
-                "@id": "_:b540",
+                "@id": "_:b913",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b120",
+              "@id": "_:b903",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
               "result": {
-                "@id": "_:b121",
+                "@id": "_:b904",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2600,45 +1842,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - collection list in embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig",
           "assertions": [
             {
-              "@id": "_:b1103",
+              "@id": "_:b1411",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b183",
+                "@id": "_:b1412",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1810",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+              "result": {
+                "@id": "_:b1179",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1362",
+              "@id": "_:b227",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
               "result": {
-                "@id": "_:b907",
+                "@id": "_:b228",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b200",
+              "@id": "_:b1641",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
               "result": {
-                "@id": "_:b201",
+                "@id": "_:b1220",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2649,45 +1904,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - literal in subject position of embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig",
           "assertions": [
             {
-              "@id": "_:b1278",
+              "@id": "_:b1674",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b1268",
+                "@id": "_:b1423",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1457",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+              "result": {
+                "@id": "_:b1458",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1149",
+              "@id": "_:b1027",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
               "result": {
-                "@id": "_:b769",
+                "@id": "_:b1028",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b604",
+              "@id": "_:b1544",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
               "result": {
-                "@id": "_:b605",
+                "@id": "_:b1040",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2698,45 +1966,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - blank node  as predicate in embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig",
           "assertions": [
             {
-              "@id": "_:b154",
+              "@id": "_:b556",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b4",
+                "@id": "_:b557",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b289",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+              "result": {
+                "@id": "_:b290",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b489",
+              "@id": "_:b1292",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
               "result": {
-                "@id": "_:b490",
+                "@id": "_:b880",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b867",
+              "@id": "_:b894",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
               "result": {
-                "@id": "_:b780",
+                "@id": "_:b895",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2747,45 +2028,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - compound blank node expression",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig",
           "assertions": [
             {
-              "@id": "_:b1035",
+              "@id": "_:b1775",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b860",
+                "@id": "_:b896",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1532",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+              "result": {
+                "@id": "_:b1304",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1196",
+              "@id": "_:b1293",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
               "result": {
-                "@id": "_:b1197",
+                "@id": "_:b207",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b697",
+              "@id": "_:b1331",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
               "result": {
-                "@id": "_:b537",
+                "@id": "_:b1332",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2796,45 +2090,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - incomplete embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig",
           "assertions": [
             {
-              "@id": "_:b1336",
+              "@id": "_:b1772",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b322",
+                "@id": "_:b1605",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b625",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+              "result": {
+                "@id": "_:b151",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1156",
+              "@id": "_:b143",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
               "result": {
-                "@id": "_:b1140",
+                "@id": "_:b144",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1",
+              "@id": "_:b1612",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
               "result": {
-                "@id": "_:b2",
+                "@id": "_:b406",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2845,45 +2152,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - over-long embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig",
           "assertions": [
             {
-              "@id": "_:b429",
+              "@id": "_:b1805",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b430",
+                "@id": "_:b1711",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b955",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+              "result": {
+                "@id": "_:b677",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b787",
+              "@id": "_:b169",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
               "result": {
-                "@id": "_:b788",
+                "@id": "_:b89",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b181",
+              "@id": "_:b456",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
               "result": {
-                "@id": "_:b182",
+                "@id": "_:b457",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2894,45 +2214,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - Annotation form",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig",
           "assertions": [
             {
-              "@id": "_:b759",
+              "@id": "_:b746",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b760",
+                "@id": "_:b458",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1391",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+              "result": {
+                "@id": "_:b671",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1274",
+              "@id": "_:b1259",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
               "result": {
-                "@id": "_:b237",
+                "@id": "_:b1260",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b658",
+              "@id": "_:b1780",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
               "result": {
-                "@id": "_:b659",
+                "@id": "_:b1688",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2943,45 +2276,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
           "@type": [
-            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
+            "TestCriterion",
             "TestCase"
           ],
           "title": "TriG-star - Annotation example",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig",
           "assertions": [
             {
-              "@id": "_:b1245",
+              "@id": "_:b772",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b229",
+                "@id": "_:b599",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b790",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+              "result": {
+                "@id": "_:b791",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1112",
+              "@id": "_:b892",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
               "result": {
-                "@id": "_:b1113",
+                "@id": "_:b717",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1175",
+              "@id": "_:b87",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
               "result": {
-                "@id": "_:b876",
+                "@id": "_:b88",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2992,45 +2338,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - empty annotation",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig",
           "assertions": [
             {
-              "@id": "_:b437",
+              "@id": "_:b1472",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b438",
+                "@id": "_:b159",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b918",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+              "result": {
+                "@id": "_:b919",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b506",
+              "@id": "_:b1552",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
               "result": {
-                "@id": "_:b507",
+                "@id": "_:b861",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1065",
+              "@id": "_:b1377",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
               "result": {
-                "@id": "_:b486",
+                "@id": "_:b1378",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -3041,4410 +2400,58 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCriterion"
           ],
           "title": "TriG-star - bad - triple as annotation",
           "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig",
           "assertions": [
             {
-              "@id": "_:b336",
+              "@id": "_:b1162",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b337",
+                "@id": "_:b926",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
+                "outcome": "earl:passed"
               },
-              "assertedBy": null
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b1339",
+              "@id": "_:b613",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://josd.github.io/eye/",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b123",
+                "@id": "_:b614",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b407",
+              "@id": "_:b1536",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b408",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:label": "Turtle-star Syntax Tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - subject embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1070",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1071",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b310",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b137",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1058",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1059",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - object embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl",
-          "assertions": [
-            {
-              "@id": "_:b618",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b619",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1236",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1134",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b574",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b575",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - embedded triple inside blankNodePropertyList",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1026",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1027",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b939",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b940",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1183",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1184",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - embedded triple inside collection",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl",
-          "assertions": [
-            {
-              "@id": "_:b393",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b318",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b41",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b42",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b13",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b14",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - nested embedded triple, subject position",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl",
-          "assertions": [
-            {
-              "@id": "_:b778",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b501",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b964",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b965",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1040",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b795",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - nested embedded triple, object position",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1351",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1263",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1013",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b754",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1365",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b5",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - compound forms",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl",
-          "assertions": [
-            {
-              "@id": "_:b270",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b271",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b391",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b392",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1276",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b773",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - blank node subject",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1296",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b157",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1285",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b698",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1153",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b350",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - blank node object",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl",
-          "assertions": [
-            {
-              "@id": "_:b991",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b369",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b737",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b597",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b590",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b143",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - blank node",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl",
-          "assertions": [
-            {
-              "@id": "_:b432",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b433",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b602",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b603",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b647",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b648",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - embedded triple as predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl",
-          "assertions": [
-            {
-              "@id": "_:b962",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b963",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b1307",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b812",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b89",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b90",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - embedded triple outside triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1249",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1250",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b179",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b180",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1252",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1054",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - collection list in embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl",
-          "assertions": [
-            {
-              "@id": "_:b929",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b758",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b931",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b932",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b811",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b47",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - literal in subject position of embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl",
-          "assertions": [
-            {
-              "@id": "_:b561",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b562",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b969",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b176",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b399",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b400",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - blank node  as predicate in embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl",
-          "assertions": [
-            {
-              "@id": "_:b460",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b160",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b1016",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b217",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1161",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b748",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - compound blank node expression",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1330",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1331",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1073",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1024",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b65",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b66",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - incomplete embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl",
-          "assertions": [
-            {
-              "@id": "_:b210",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b211",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b39",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b40",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b847",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b198",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - over-long embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl",
-          "assertions": [
-            {
-              "@id": "_:b546",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b547",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b668",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b568",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b869",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b239",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - Annotation form",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1328",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1078",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1007",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1008",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b524",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b525",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "Turtle-star - Annotation example",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl",
-          "assertions": [
-            {
-              "@id": "_:b352",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b353",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b326",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b327",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1081",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1082",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - empty annotation",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl",
-          "assertions": [
-            {
-              "@id": "_:b298",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b299",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b359",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b360",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1172",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b750",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "Turtle-star - bad - triple as annotation",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1198",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b834",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1137",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1068",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b362",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b363",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - subject embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-1.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1354",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b264",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1233",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1092",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b739",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b740",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - object embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-2.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1141",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1142",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b139",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b140",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1126",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b680",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - subject and object embedded triples",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-3.ttl",
-          "assertions": [
-            {
-              "@id": "_:b828",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b829",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1211",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b892",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1345",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1190",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - whitespace and terms",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-4.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1204",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b905",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1031",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1032",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1201",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1202",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - Nested, no whitespace",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-5.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1321",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b841",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b927",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b873",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b636",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b637",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - Blank node subject",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-1.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1301",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b799",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b263",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b77",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1312",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1242",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - Blank node object",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-2.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1086",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b670",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b276",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b277",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1284",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b51",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - Nested subject term",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-1.ttl",
-          "assertions": [
-            {
-              "@id": "_:b114",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b115",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b782",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b596",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b606",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b607",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star as Turtle-star - Nested object term",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-2.ttl",
-          "assertions": [
-            {
-              "@id": "_:b461",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b462",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b222",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b223",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b128",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b129",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "N-Triples-star as Turtle-star - Bad - embedded triple as predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-1.ttl",
-          "assertions": [
-            {
-              "@id": "_:b385",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b386",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b527",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b528",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b480",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b481",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-2.ttl",
-          "assertions": [
-            {
-              "@id": "_:b87",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b24",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b371",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b372",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b993",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b994",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-3.ttl",
-          "assertions": [
-            {
-              "@id": "_:b676",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b6",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b306",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b307",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b148",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b149",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
-          ],
-          "title": "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-4.ttl",
-          "assertions": [
-            {
-              "@id": "_:b1025",
-              "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
-              "mode": "earl:automatic",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b851",
-                "@type": "TestResult",
-                "outcome": "earl:failed"
-              }
-            },
-            {
-              "@id": "_:b1262",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1006",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b585",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b136",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:label": "SPARQL-star Evaluation Tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - all graph triples (JSON results)",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj",
-          "testAction": {
-            "@id": "_:b262",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b960",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b714",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1317",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b469",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1209",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b159",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - all graph triples (XML results)",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx",
-          "testAction": {
-            "@id": "_:b569",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1043",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b116",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b952",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b856",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b972",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b520",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - match constant embedded triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj",
-          "testAction": {
-            "@id": "_:b1051",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1050",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b464",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1143",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1047",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1334",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b580",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - match embedded triple, var subject",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj",
-          "testAction": {
-            "@id": "_:b679",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1220",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b831",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1337",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1061",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1130",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1131",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - match embedded triple, var predicate",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj",
-          "testAction": {
-            "@id": "_:b17",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b15",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b16",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b420",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b421",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1138",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b373",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - match embedded triple, var object",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj",
-          "testAction": {
-            "@id": "_:b69",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b411",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b412",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1313",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1275",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b779",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b541",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - no match of embedded triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj",
-          "testAction": {
-            "@id": "_:b50",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b554",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b555",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b48",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b49",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b510",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b511",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Asserted and embedded triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj",
-          "testAction": {
-            "@id": "_:b212",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1129",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b403",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1173",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1174",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b621",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b622",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star -  Asserted and embedded triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj",
-          "testAction": {
-            "@id": "_:b715",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1338",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1164",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1264",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1265",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b793",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b794",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Pattern - Variable for embedded triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj",
-          "testAction": {
-            "@id": "_:b509",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b514",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b515",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1010",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b633",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1355",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b199",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Pattern - No match",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj",
-          "testAction": {
-            "@id": "_:b109",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b202",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b203",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1087",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b776",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1018",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1019",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Pattern - match variables in triple terms",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj",
-          "testAction": {
-            "@id": "_:b253",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b807",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b786",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1105",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b75",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b252",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b10",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Pattern - Nesting 1",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj",
-          "testAction": {
-            "@id": "_:b497",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b651",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b652",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1319",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b703",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1346",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1280",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Pattern - Nesting - 2",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj",
-          "testAction": {
-            "@id": "_:b496",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b718",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b719",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1367",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1368",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1282",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1283",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Pattern - Match and nesting",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj",
-          "testAction": {
-            "@id": "_:b12",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1375",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b934",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1160",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1029",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1259",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b815",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Pattern - Same variable",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj",
-          "testAction": {
-            "@id": "_:b241",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-5.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1108",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b770",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1177",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b539",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b240",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b192",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - CONSTRUCT with constant template",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl",
-          "testAction": {
-            "@id": "_:b197",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b473",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b474",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b305",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b112",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b195",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b196",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - CONSTRUCT WHERE with constant template",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl",
-          "testAction": {
-            "@id": "_:b0",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b345",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b346",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1157",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b153",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b830",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b783",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - CONSTRUCT - about every triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl",
-          "testAction": {
-            "@id": "_:b135",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1299",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1021",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b877",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b113",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b133",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b134",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - CONSTRUCT with annotation syntax",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl",
-          "testAction": {
-            "@id": "_:b278",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b981",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b309",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1080",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b756",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b711",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b712",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl",
-          "testAction": {
-            "@id": "_:b560",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b977",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b452",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1146",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b818",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1101",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1102",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - GRAPH",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj",
-          "testAction": {
-            "@id": "_:b23",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b566",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b567",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b522",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b523",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b819",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b820",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - GRAPHs with blank node",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj",
-          "testAction": {
-            "@id": "_:b553",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b552",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b390",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1266",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b933",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b653",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b654",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl",
-          "testAction": {
-            "@id": "_:b370",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1271",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1187",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b953",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b954",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1056",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1057",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - Functions",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj",
-          "testAction": {
-            "@id": "_:b108",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b354",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b355",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1303",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1269",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b106",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b107",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - sameTerm",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-1.srj",
-          "testAction": {
-            "@id": "_:b191",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-1.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b189",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b190",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b413",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b414",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1369",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1347",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - value-equality",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-2.srj",
-          "testAction": {
-            "@id": "_:b186",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-2.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b184",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b185",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1246",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b671",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b329",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b330",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - value-inequality",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-3.srj",
-          "testAction": {
-            "@id": "_:b95",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-3.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1348",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b755",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b93",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b94",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b881",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b882",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - value-inequality",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-4.srj",
-          "testAction": {
-            "@id": "_:b124",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-4.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b616",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b365",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1218",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1219",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1322",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b216",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - ORDER BY",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj",
-          "testAction": {
-            "@id": "_:b753",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-order-kind.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-by.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1320",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1048",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1363",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b543",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1014",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1015",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
-          "@type": [
-            "TestCriterion",
-            "mf:QueryEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple - ordering",
-          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-2.srj",
-          "testAction": {
-            "@id": "_:b565",
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-order.ttl"
-            },
-            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-by.rq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1127",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1128",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1212",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1213",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b563",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b564",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-          "@type": [
-            "TestCriterion",
-            "mf:UpdateEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Update",
-          "testResult": {
-            "@id": "_:b61",
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-1.trig"
-            }
-          },
-          "testAction": {
-            "@id": "_:b62",
-            "http://www.w3.org/2009/sparql/tests/test-update#request": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-1.ru"
-            },
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b1097",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1009",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b59",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b60",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1279",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b683",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-          "@type": [
-            "TestCriterion",
-            "mf:UpdateEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Update - annotation",
-          "testResult": {
-            "@id": "_:b102",
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-2.trig"
-            }
-          },
-          "testAction": {
-            "@id": "_:b103",
-            "http://www.w3.org/2009/sparql/tests/test-update#request": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-2.ru"
-            },
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b731",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b732",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b257",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b258",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b225",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b177",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-          "@type": [
-            "TestCriterion",
-            "mf:UpdateEvaluationTest",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Update - data",
-          "testResult": {
-            "@id": "_:b76",
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-3.trig"
-            }
-          },
-          "testAction": {
-            "@id": "_:b132",
-            "http://www.w3.org/2009/sparql/tests/test-update#request": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-3.ru"
-            },
-            "http://www.w3.org/2009/sparql/tests/test-update#data": {
-              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
-            }
-          },
-          "assertions": [
-            {
-              "@id": "_:b130",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b131",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b208",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b209",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1178",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b738",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:label": "TriG-star Evaluation Tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - subject embedded triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig",
-          "assertions": [
-            {
-              "@id": "_:b266",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b267",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b502",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b503",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b293",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b294",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - object embedded triple",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig",
-          "assertions": [
-            {
-              "@id": "_:b1135",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b861",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b912",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b913",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b55",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b56",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - blank node label",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig",
-          "assertions": [
-            {
-              "@id": "_:b30",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b31",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b289",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b290",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b817",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b111",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - blank node labels",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig",
-          "assertions": [
-            {
-              "@id": "_:b1366",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1343",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1093",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b446",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1188",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1011",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation form",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig",
-          "assertions": [
-            {
-              "@id": "_:b608",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b419",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b765",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b620",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b91",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b92",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation example",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig",
-          "assertions": [
-            {
-              "@id": "_:b687",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b688",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b315",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b316",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b979",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b772",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation - predicate and object lists",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig",
-          "assertions": [
-            {
-              "@id": "_:b752",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b126",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b976",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b25",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1324",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b125",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation - nested",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig",
-          "assertions": [
-            {
-              "@id": "_:b1243",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1227",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b843",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b844",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b921",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b97",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation object list",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig",
-          "assertions": [
-            {
-              "@id": "_:b1359",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1144",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1304",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b521",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1298",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1099",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation with embedding",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.trig",
-          "assertions": [
-            {
-              "@id": "_:b910",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b911",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b232",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b233",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1371",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b38",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation on triple with embedded subject",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.trig",
-          "assertions": [
-            {
-              "@id": "_:b1253",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1171",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b945",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b796",
+                "@id": "_:b1177",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b281",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b282",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "TriG-star - Annotation on triple with embedded object",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.nq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.trig",
-          "assertions": [
-            {
-              "@id": "_:b404",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b405",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
               },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b340",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b341",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b744",
+              "@id": "_:b27",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
               "result": {
-                "@id": "_:b551",
+                "@id": "_:b28",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7465,47 +2472,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - subject embedded triple",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl",
           "assertions": [
             {
-              "@id": "_:b1357",
+              "@id": "_:b698",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+              "result": {
+                "@id": "_:b7",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b575",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
               "result": {
-                "@id": "_:b1044",
+                "@id": "_:b576",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b1295",
+              "@id": "_:b948",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
               "result": {
-                "@id": "_:b1122",
+                "@id": "_:b949",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1316",
+              "@id": "_:b1201",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
               "result": {
-                "@id": "_:b475",
+                "@id": "_:b1202",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7516,47 +2536,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - object embedded triple",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl",
           "assertions": [
             {
-              "@id": "_:b832",
+              "@id": "_:b1582",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+              "result": {
+                "@id": "_:b1574",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1707",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
               "result": {
-                "@id": "_:b357",
+                "@id": "_:b820",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b548",
+              "@id": "_:b148",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
               "result": {
-                "@id": "_:b549",
+                "@id": "_:b149",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b118",
+              "@id": "_:b337",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
               "result": {
-                "@id": "_:b119",
+                "@id": "_:b338",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7567,47 +2600,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - blank node label",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl",
           "assertions": [
             {
-              "@id": "_:b893",
+              "@id": "_:b322",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+              "result": {
+                "@id": "_:b323",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1732",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
               "result": {
-                "@id": "_:b894",
+                "@id": "_:b1626",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b505",
+              "@id": "_:b1640",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
               "result": {
-                "@id": "_:b394",
+                "@id": "_:b1",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1117",
+              "@id": "_:b160",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
               "result": {
-                "@id": "_:b978",
+                "@id": "_:b161",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7618,47 +2664,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - blank node labels",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl",
           "assertions": [
             {
-              "@id": "_:b1329",
+              "@id": "_:b1316",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+              "result": {
+                "@id": "_:b951",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1736",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
               "result": {
-                "@id": "_:b632",
+                "@id": "_:b1496",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b990",
+              "@id": "_:b409",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
               "result": {
-                "@id": "_:b7",
+                "@id": "_:b410",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1083",
+              "@id": "_:b1568",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
               "result": {
-                "@id": "_:b142",
+                "@id": "_:b235",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7669,47 +2728,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation form",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl",
           "assertions": [
             {
-              "@id": "_:b1000",
+              "@id": "_:b882",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+              "result": {
+                "@id": "_:b883",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1619",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
               "result": {
-                "@id": "_:b1001",
+                "@id": "_:b494",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b690",
+              "@id": "_:b1413",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
               "result": {
-                "@id": "_:b691",
+                "@id": "_:b1019",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b914",
+              "@id": "_:b129",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
               "result": {
-                "@id": "_:b915",
+                "@id": "_:b130",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7720,47 +2792,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation example",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl",
           "assertions": [
             {
-              "@id": "_:b664",
+              "@id": "_:b585",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+              "result": {
+                "@id": "_:b586",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b907",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
               "result": {
-                "@id": "_:b665",
+                "@id": "_:b908",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b1300",
+              "@id": "_:b1262",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
               "result": {
-                "@id": "_:b896",
+                "@id": "_:b1263",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1096",
+              "@id": "_:b1463",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
               "result": {
-                "@id": "_:b504",
+                "@id": "_:b1464",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7771,47 +2856,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation - predicate and object lists",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl",
           "assertions": [
             {
-              "@id": "_:b1314",
+              "@id": "_:b29",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+              "result": {
+                "@id": "_:b30",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b287",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
               "result": {
-                "@id": "_:b361",
+                "@id": "_:b32",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b1332",
+              "@id": "_:b1364",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
               "result": {
-                "@id": "_:b1333",
+                "@id": "_:b1305",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1232",
+              "@id": "_:b1076",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
               "result": {
-                "@id": "_:b508",
+                "@id": "_:b1077",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7822,47 +2920,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation - nested",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl",
           "assertions": [
             {
-              "@id": "_:b455",
+              "@id": "_:b1787",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+              "result": {
+                "@id": "_:b1727",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1792",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
               "result": {
-                "@id": "_:b456",
+                "@id": "_:b1788",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b163",
+              "@id": "_:b616",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
               "result": {
-                "@id": "_:b164",
+                "@id": "_:b617",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b1118",
+              "@id": "_:b568",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
               "result": {
-                "@id": "_:b1119",
+                "@id": "_:b569",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7873,47 +2984,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation object list",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl",
           "assertions": [
             {
-              "@id": "_:b674",
+              "@id": "_:b1061",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+              "result": {
+                "@id": "_:b1062",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1723",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
               "result": {
-                "@id": "_:b675",
+                "@id": "_:b580",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b854",
+              "@id": "_:b593",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
               "result": {
-                "@id": "_:b855",
+                "@id": "_:b594",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b425",
+              "@id": "_:b1421",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
               "result": {
-                "@id": "_:b426",
+                "@id": "_:b874",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7924,47 +3048,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation with embedding",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl",
           "assertions": [
             {
-              "@id": "_:b320",
+              "@id": "_:b1537",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
+              "result": {
+                "@id": "_:b675",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1607",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
               "result": {
-                "@id": "_:b321",
+                "@id": "_:b333",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b725",
+              "@id": "_:b69",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
               "result": {
-                "@id": "_:b424",
+                "@id": "_:b21",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b173",
+              "@id": "_:b490",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1",
               "result": {
-                "@id": "_:b174",
+                "@id": "_:b486",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -7975,47 +3112,60 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation on triple with embedded subject",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl",
           "assertions": [
             {
-              "@id": "_:b1239",
+              "@id": "_:b1226",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
+              "result": {
+                "@id": "_:b1227",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b241",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
               "result": {
-                "@id": "_:b615",
+                "@id": "_:b242",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b1020",
+              "@id": "_:b1553",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
               "result": {
-                "@id": "_:b493",
+                "@id": "_:b1257",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b865",
+              "@id": "_:b1069",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2",
               "result": {
-                "@id": "_:b866",
+                "@id": "_:b332",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -8026,47 +3176,2273 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleEval"
+            "TestCriterion"
           ],
           "title": "Turtle-star - Annotation on triple with embedded object",
           "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt",
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl",
           "assertions": [
             {
-              "@id": "_:b1165",
+              "@id": "_:b434",
               "@type": "Assertion",
-              "assertedBy": "https://josd.github.io/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
+              "result": {
+                "@id": "_:b435",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1515",
+              "@type": "Assertion",
               "mode": "earl:automatic",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
               "result": {
-                "@id": "_:b1121",
+                "@id": "_:b1516",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://josd.github.io/"
             },
             {
-              "@id": "_:b995",
+              "@id": "_:b318",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
               "result": {
-                "@id": "_:b364",
+                "@id": "_:b319",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b570",
+              "@id": "_:b563",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3",
               "result": {
-                "@id": "_:b571",
+                "@id": "_:b75",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "Turtle-star Syntax Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1730",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "result": {
+                "@id": "_:b1279",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1756",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "result": {
+                "@id": "_:b1757",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1107",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "result": {
+                "@id": "_:b864",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b291",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "result": {
+                "@id": "_:b292",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1281",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "result": {
+                "@id": "_:b813",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1649",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "result": {
+                "@id": "_:b1477",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1135",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "result": {
+                "@id": "_:b1136",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1551",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "result": {
+                "@id": "_:b1090",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - embedded triple inside blankNodePropertyList",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b841",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "result": {
+                "@id": "_:b183",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b394",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "result": {
+                "@id": "_:b238",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1185",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "result": {
+                "@id": "_:b1186",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b923",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "result": {
+                "@id": "_:b924",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - embedded triple inside collection",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1403",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "result": {
+                "@id": "_:b1344",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1781",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "result": {
+                "@id": "_:b279",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b881",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "result": {
+                "@id": "_:b784",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1314",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "result": {
+                "@id": "_:b1315",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - nested embedded triple, subject position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1744",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "result": {
+                "@id": "_:b1745",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1803",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "result": {
+                "@id": "_:b1339",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b942",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "result": {
+                "@id": "_:b77",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1662",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "result": {
+                "@id": "_:b1296",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - nested embedded triple, object position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1299",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "result": {
+                "@id": "_:b1217",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b733",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "result": {
+                "@id": "_:b734",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b2",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "result": {
+                "@id": "_:b3",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b371",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "result": {
+                "@id": "_:b372",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - compound forms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl",
+          "assertions": [
+            {
+              "@id": "_:b214",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "result": {
+                "@id": "_:b215",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1370",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "result": {
+                "@id": "_:b1352",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1117",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "result": {
+                "@id": "_:b1118",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b573",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "result": {
+                "@id": "_:b538",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1686",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "result": {
+                "@id": "_:b1209",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1631",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "result": {
+                "@id": "_:b769",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1483",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "result": {
+                "@id": "_:b1484",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1079",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "result": {
+                "@id": "_:b293",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1824",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "result": {
+                "@id": "_:b107",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1542",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "result": {
+                "@id": "_:b222",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b479",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "result": {
+                "@id": "_:b480",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1659",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "result": {
+                "@id": "_:b972",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - blank node",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1251",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "result": {
+                "@id": "_:b1252",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b839",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "result": {
+                "@id": "_:b840",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b559",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "result": {
+                "@id": "_:b560",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1253",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "result": {
+                "@id": "_:b365",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl",
+          "assertions": [
+            {
+              "@id": "_:b589",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "result": {
+                "@id": "_:b590",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1682",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "result": {
+                "@id": "_:b1645",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1599",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "result": {
+                "@id": "_:b309",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b265",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "result": {
+                "@id": "_:b266",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - embedded triple outside triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1543",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "result": {
+                "@id": "_:b1268",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1581",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "result": {
+                "@id": "_:b544",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b591",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "result": {
+                "@id": "_:b592",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1006",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "result": {
+                "@id": "_:b1007",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - collection list in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl",
+          "assertions": [
+            {
+              "@id": "_:b751",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "result": {
+                "@id": "_:b433",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b335",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "result": {
+                "@id": "_:b336",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1290",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "result": {
+                "@id": "_:b679",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b833",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "result": {
+                "@id": "_:b110",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - literal in subject position of embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl",
+          "assertions": [
+            {
+              "@id": "_:b482",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "result": {
+                "@id": "_:b483",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b54",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "result": {
+                "@id": "_:b55",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1558",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "result": {
+                "@id": "_:b376",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b720",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "result": {
+                "@id": "_:b721",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - blank node  as predicate in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1738",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "result": {
+                "@id": "_:b1428",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b260",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "result": {
+                "@id": "_:b261",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1653",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "result": {
+                "@id": "_:b680",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1459",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "result": {
+                "@id": "_:b953",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - compound blank node expression",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl",
+          "assertions": [
+            {
+              "@id": "_:b46",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "result": {
+                "@id": "_:b47",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b533",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "result": {
+                "@id": "_:b389",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b327",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "result": {
+                "@id": "_:b328",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1485",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "result": {
+                "@id": "_:b1486",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - incomplete embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl",
+          "assertions": [
+            {
+              "@id": "_:b506",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "result": {
+                "@id": "_:b507",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b245",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "result": {
+                "@id": "_:b246",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b982",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "result": {
+                "@id": "_:b983",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b549",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "result": {
+                "@id": "_:b550",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - over-long embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1561",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "result": {
+                "@id": "_:b1562",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1507",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "result": {
+                "@id": "_:b298",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1627",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "result": {
+                "@id": "_:b1628",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1382",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "result": {
+                "@id": "_:b766",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - Annotation form",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1116",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "result": {
+                "@id": "_:b612",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1523",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "result": {
+                "@id": "_:b1524",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1415",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "result": {
+                "@id": "_:b914",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1188",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "result": {
+                "@id": "_:b663",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - Annotation example",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1232",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "result": {
+                "@id": "_:b1233",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b525",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "result": {
+                "@id": "_:b526",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b236",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "result": {
+                "@id": "_:b237",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1300",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "result": {
+                "@id": "_:b1301",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - empty annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1131",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "result": {
+                "@id": "_:b1132",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b901",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "result": {
+                "@id": "_:b902",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1346",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "result": {
+                "@id": "_:b611",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b82",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "result": {
+                "@id": "_:b83",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "Turtle-star - bad - triple as annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b736",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "result": {
+                "@id": "_:b64",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b40",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "result": {
+                "@id": "_:b41",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1250",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "result": {
+                "@id": "_:b795",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1356",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "result": {
+                "@id": "_:b339",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - subject embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b604",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
+              "result": {
+                "@id": "_:b605",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b823",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
+              "result": {
+                "@id": "_:b824",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1269",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
+              "result": {
+                "@id": "_:b1270",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1098",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
+              "result": {
+                "@id": "_:b1099",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - object embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b285",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
+              "result": {
+                "@id": "_:b286",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1383",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
+              "result": {
+                "@id": "_:b407",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b891",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
+              "result": {
+                "@id": "_:b13",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1695",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
+              "result": {
+                "@id": "_:b199",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - subject and object embedded triples",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-3.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1527",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
+              "result": {
+                "@id": "_:b1528",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b233",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
+              "result": {
+                "@id": "_:b234",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b119",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
+              "result": {
+                "@id": "_:b120",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1546",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
+              "result": {
+                "@id": "_:b1406",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - whitespace and terms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-4.ttl",
+          "assertions": [
+            {
+              "@id": "_:b443",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
+              "result": {
+                "@id": "_:b444",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b648",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
+              "result": {
+                "@id": "_:b649",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b210",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
+              "result": {
+                "@id": "_:b211",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1128",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
+              "result": {
+                "@id": "_:b1129",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Nested, no whitespace",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-5.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1601",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
+              "result": {
+                "@id": "_:b167",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1242",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
+              "result": {
+                "@id": "_:b1243",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1081",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
+              "result": {
+                "@id": "_:b1082",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1328",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
+              "result": {
+                "@id": "_:b660",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b669",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
+              "result": {
+                "@id": "_:b528",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1021",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
+              "result": {
+                "@id": "_:b1022",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b831",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
+              "result": {
+                "@id": "_:b832",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b638",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
+              "result": {
+                "@id": "_:b639",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1240",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
+              "result": {
+                "@id": "_:b1174",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1473",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
+              "result": {
+                "@id": "_:b1456",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1798",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
+              "result": {
+                "@id": "_:b1155",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1639",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
+              "result": {
+                "@id": "_:b1105",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Nested subject term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1161",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
+              "result": {
+                "@id": "_:b1134",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1218",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
+              "result": {
+                "@id": "_:b1169",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1804",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
+              "result": {
+                "@id": "_:b527",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b969",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
+              "result": {
+                "@id": "_:b970",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Nested object term",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b137",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
+              "result": {
+                "@id": "_:b138",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b973",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
+              "result": {
+                "@id": "_:b974",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b643",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
+              "result": {
+                "@id": "_:b644",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b909",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
+              "result": {
+                "@id": "_:b910",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-1.ttl",
+          "assertions": [
+            {
+              "@id": "_:b835",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
+              "result": {
+                "@id": "_:b836",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1776",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
+              "result": {
+                "@id": "_:b1239",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1410",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
+              "result": {
+                "@id": "_:b873",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1666",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
+              "result": {
+                "@id": "_:b1324",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-2.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1734",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
+              "result": {
+                "@id": "_:b492",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1133",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
+              "result": {
+                "@id": "_:b1103",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1770",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
+              "result": {
+                "@id": "_:b872",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b912",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
+              "result": {
+                "@id": "_:b80",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-3.ttl",
+          "assertions": [
+            {
+              "@id": "_:b815",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
+              "result": {
+                "@id": "_:b816",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b200",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
+              "result": {
+                "@id": "_:b201",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1571",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
+              "result": {
+                "@id": "_:b1414",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b366",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
+              "result": {
+                "@id": "_:b142",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
+            "TestCriterion"
+          ],
+          "title": "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-4.ttl",
+          "assertions": [
+            {
+              "@id": "_:b1389",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
+              "result": {
+                "@id": "_:b1390",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1790",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
+              "result": {
+                "@id": "_:b1025",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1440",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
+              "result": {
+                "@id": "_:b1441",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b283",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
+              "result": {
+                "@id": "_:b284",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -8087,2627 +5463,155 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
           "@type": [
+            "TestCase",
             "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
           "title": "SPARQL-star - subject embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq",
           "assertions": [
             {
-              "@id": "_:b1052",
+              "@id": "_:b1766",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b398",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1360",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b512",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1005",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
               "result": {
-                "@id": "_:b729",
+                "@id": "_:b1249",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b783",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+              "result": {
+                "@id": "_:b485",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1642",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+              "result": {
+                "@id": "_:b1643",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1675",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+              "result": {
+                "@id": "_:b752",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
           "@type": [
+            "TestCase",
             "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
           "title": "SPARQL-star - object embedded triple",
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq",
           "assertions": [
             {
-              "@id": "_:b351",
+              "@id": "_:b1167",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b339",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b324",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b325",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1100",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
               "result": {
-                "@id": "_:b261",
+                "@id": "_:b1168",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b785",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+              "result": {
+                "@id": "_:b377",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1796",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+              "result": {
+                "@id": "_:b1644",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1365",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+              "result": {
+                "@id": "_:b1236",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
           "@type": [
+            "TestCase",
             "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
           "title": "SPARQL-star - subject embedded triple - vars",
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq",
           "assertions": [
             {
-              "@id": "_:b1064",
+              "@id": "_:b505",
               "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-              "subject": "https://josd.github.io/eye/",
               "result": {
-                "@id": "_:b982",
+                "@id": "_:b381",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
+                "outcome": "earl:passed"
               },
-              "assertedBy": null
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b63",
+              "@id": "_:b1119",
               "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b64",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1060",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b494",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - object embedded triple - vars",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq",
-          "assertions": [
-            {
-              "@id": "_:b1210",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b170",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b57",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b58",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1191",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b878",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple in VALUES",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq",
-          "assertions": [
-            {
-              "@id": "_:b761",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b544",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1158",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b792",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b557",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b558",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triple in CONSTRUCT",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq",
-          "assertions": [
-            {
-              "@id": "_:b930",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b317",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b735",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b736",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b695",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b696",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Embedded triples in CONSTRUCT WHERE",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq",
-          "assertions": [
-            {
-              "@id": "_:b724",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b300",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1286",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b906",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b998",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b226",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - embedded triple inside blankNodePropertyList",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq",
-          "assertions": [
-            {
-              "@id": "_:b1110",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b246",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b948",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b463",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1217",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b895",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - embedded triple inside collection",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq",
-          "assertions": [
-            {
-              "@id": "_:b1281",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b538",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b985",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b986",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b33",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b34",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - nested embedded triple, subject position",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq",
-          "assertions": [
-            {
-              "@id": "_:b581",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b582",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1104",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b694",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b726",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b727",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - nested embedded triple, object position",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq",
-          "assertions": [
-            {
-              "@id": "_:b1291",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b902",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1251",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b328",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b928",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b500",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - compound forms",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq",
-          "assertions": [
-            {
-              "@id": "_:b422",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b423",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1340",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b308",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1230",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b495",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - blank node subject",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq",
-          "assertions": [
-            {
-              "@id": "_:b627",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b628",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b805",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b806",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1072",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b595",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - blank node object",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq",
-          "assertions": [
-            {
-              "@id": "_:b1132",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1133",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b946",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b947",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b272",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b273",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - blank node",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq",
-          "assertions": [
-            {
-              "@id": "_:b956",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b957",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1240",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b68",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b85",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b86",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation form",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq",
-          "assertions": [
-            {
-              "@id": "_:b870",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b871",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b720",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b721",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b746",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b747",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation example",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq",
-          "assertions": [
-            {
-              "@id": "_:b331",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b332",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1318",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1222",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b858",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b859",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation example",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq",
-          "assertions": [
-            {
-              "@id": "_:b441",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b442",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1139",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b368",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1325",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1028",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation with embedding",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq",
-          "assertions": [
-            {
-              "@id": "_:b839",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b840",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1125",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b743",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1373",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b32",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation on triple with embedded object",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq",
-          "assertions": [
-            {
-              "@id": "_:b767",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b768",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1341",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1342",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b705",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b706",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation with path",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq",
-          "assertions": [
-            {
-              "@id": "_:b762",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b573",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b259",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b260",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b641",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b623",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation with nested path",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq",
-          "assertions": [
-            {
-              "@id": "_:b800",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b801",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b279",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b280",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b872",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b286",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation in CONSTRUCT ",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq",
-          "assertions": [
-            {
-              "@id": "_:b387",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b388",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b313",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b314",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b922",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b827",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Annotation in CONSTRUCT WHERE",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq",
-          "assertions": [
-            {
-              "@id": "_:b1041",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1042",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b966",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b406",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1223",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b220",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Expressions - Embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq",
-          "assertions": [
-            {
-              "@id": "_:b1088",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b667",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b268",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b269",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1176",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1067",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Expressions - Embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq",
-          "assertions": [
-            {
-              "@id": "_:b1374",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b789",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1049",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b693",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b250",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b251",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Expressions - Functions",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq",
-          "assertions": [
-            {
-              "@id": "_:b465",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b466",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b83",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b84",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b532",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b533",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Expressions - TRIPLE",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq",
-          "assertions": [
-            {
-              "@id": "_:b1145",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b973",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b171",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b172",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b625",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b626",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Expressions - Functions",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq",
-          "assertions": [
-            {
-              "@id": "_:b1270",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1181",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1305",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1306",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b897",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b898",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - Expressions - BIND - CONSTRUCT",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq",
-          "assertions": [
-            {
-              "@id": "_:b478",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b479",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b630",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b631",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b8",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b9",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - embedded triple as predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq",
-          "assertions": [
-            {
-              "@id": "_:b1017",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b949",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b751",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b657",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1290",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b745",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - embedded triple outside triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq",
-          "assertions": [
-            {
-              "@id": "_:b78",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b79",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b380",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b178",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b883",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b884",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - collection list in embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq",
-          "assertions": [
-            {
-              "@id": "_:b1292",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b813",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b218",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b219",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b434",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b435",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - literal in subject position of embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq",
-          "assertions": [
-            {
-              "@id": "_:b378",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b379",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1267",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1206",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b482",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b483",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - blank node  as predicate in embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq",
-          "assertions": [
-            {
-              "@id": "_:b874",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b875",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b975",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b955",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1352",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1085",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - compound blank node expression",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq",
-          "assertions": [
-            {
-              "@id": "_:b1074",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1075",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b862",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b863",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1272",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b238",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - incomplete embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq",
-          "assertions": [
-            {
-              "@id": "_:b741",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b459",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b920",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b766",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b213",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b214",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - quad embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq",
-          "assertions": [
-            {
-              "@id": "_:b593",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b594",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1179",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1180",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1148",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b781",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - variable in embedded triple in VALUES ",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq",
-          "assertions": [
-            {
-              "@id": "_:b1003",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1004",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b19",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b20",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1094",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1046",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - blank node in embedded triple in VALUES ",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq",
-          "assertions": [
-            {
-              "@id": "_:b161",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b162",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1089",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b689",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b943",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b944",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - blank node in embedded triple in FILTER",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-11.rq",
-          "assertions": [
-            {
-              "@id": "_:b1114",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1115",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1076",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1077",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b677",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b678",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - blank node in embedded triple in BIND",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-12.rq",
-          "assertions": [
-            {
-              "@id": "_:b1224",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1151",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b669",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b598",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b166",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b167",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - empty annotation",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq",
-          "assertions": [
-            {
-              "@id": "_:b707",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b545",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1261",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b491",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b790",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b791",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - triples in annotation",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq",
-          "assertions": [
-            {
-              "@id": "_:b572",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b110",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1221",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b265",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b26",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b27",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - path - seq",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq",
-          "assertions": [
-            {
-              "@id": "_:b925",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b445",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b52",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b53",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b716",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b152",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - path - alt",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq",
-          "assertions": [
-            {
-              "@id": "_:b187",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b188",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1159",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b992",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b417",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b374",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - path - p*",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq",
-          "assertions": [
-            {
-              "@id": "_:b612",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b389",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b356",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b54",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1062",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1063",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - path - p+",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq",
-          "assertions": [
-            {
-              "@id": "_:b1090",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b542",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b661",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b141",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b968",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b418",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - path - p?",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq",
-          "assertions": [
-            {
-              "@id": "_:b916",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b917",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b809",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b810",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b98",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b99",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - path in CONSTRUCT",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq",
-          "assertions": [
-            {
-              "@id": "_:b1310",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b193",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b348",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b74",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1288",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b254",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-          "@type": [
-            "mf:NegativeSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - bad - path in CONSTRUCT",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq",
-          "assertions": [
-            {
-              "@id": "_:b722",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b723",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b699",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b700",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b284",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b285",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - update",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru",
-          "assertions": [
-            {
-              "@id": "_:b1364",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b764",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b396",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b397",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b303",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b304",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - update",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru",
-          "assertions": [
-            {
-              "@id": "_:b35",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b36",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b255",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b256",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b168",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b169",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - update",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru",
-          "assertions": [
-            {
-              "@id": "_:b988",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b989",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1195",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
                 "@id": "_:b1120",
                 "@type": "TestResult",
@@ -10716,390 +5620,692 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b1002",
+              "@id": "_:b788",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b224",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - update with embedding",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru",
-          "assertions": [
-            {
-              "@id": "_:b1053",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b127",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b516",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
               "result": {
-                "@id": "_:b517",
+                "@id": "_:b789",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1150",
+              "@id": "_:b8",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
               "result": {
-                "@id": "_:b961",
+                "@id": "_:b9",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
           "@type": [
+            "TestCase",
             "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "SPARQL-star - update with embedded object",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru",
+          "title": "SPARQL-star - object embedded triple - vars",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq",
           "assertions": [
+            {
+              "@id": "_:b508",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
+              "result": {
+                "@id": "_:b509",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
             {
               "@id": "_:b1353",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
               "result": {
-                "@id": "_:b1309",
+                "@id": "_:b1354",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1091",
+              "@id": "_:b773",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
               "result": {
-                "@id": "_:b808",
+                "@id": "_:b774",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1055",
+              "@id": "_:b1445",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
               "result": {
-                "@id": "_:b556",
+                "@id": "_:b398",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
           "@type": [
-            "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - update with annotation template",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru",
-          "assertions": [
-            {
-              "@id": "_:b1226",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1033",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b70",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b71",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1376",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b342",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - update with annotation, template and pattern",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru",
-          "assertions": [
-            {
-              "@id": "_:b311",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b312",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b291",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b292",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b710",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b101",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-          "@type": [
-            "TestCriterion",
-            "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
-          ],
-          "title": "SPARQL-star - update DATA with annotation",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru",
-          "assertions": [
-            {
-              "@id": "_:b381",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b382",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b230",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b231",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1260",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b529",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-          "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:NegativeUpdateSyntaxTest11"
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "SPARQL-star - update - bad syntax",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru",
+          "title": "SPARQL-star - Embedded triple in VALUES",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq",
           "assertions": [
             {
-              "@id": "_:b518",
+              "@id": "_:b1368",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b519",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1214",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b1215",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b245",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
               "result": {
-                "@id": "_:b11",
+                "@id": "_:b814",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1724",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+              "result": {
+                "@id": "_:b558",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b968",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+              "result": {
+                "@id": "_:b851",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b741",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+              "result": {
+                "@id": "_:b742",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:NegativeUpdateSyntaxTest11"
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "SPARQL-star - update - bad syntax",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru",
+          "title": "SPARQL-star - Embedded triple in CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq",
           "assertions": [
             {
-              "@id": "_:b295",
+              "@id": "_:b1636",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b296",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b868",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b526",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b903",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
               "result": {
-                "@id": "_:b904",
+                "@id": "_:b1501",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1224",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+              "result": {
+                "@id": "_:b50",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1306",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+              "result": {
+                "@id": "_:b1307",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b281",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+              "result": {
+                "@id": "_:b282",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:NegativeUpdateSyntaxTest11"
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "SPARQL-star - update - bad syntax",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru",
+          "title": "SPARQL-star - Embedded triples in CONSTRUCT WHERE",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq",
           "assertions": [
             {
-              "@id": "_:b681",
+              "@id": "_:b1547",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
-              "subject": "https://josd.github.io/eye/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
               "result": {
-                "@id": "_:b513",
+                "@id": "_:b1073",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b729",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+              "result": {
+                "@id": "_:b133",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b72",
+              "@id": "_:b1480",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+              "result": {
+                "@id": "_:b450",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b964",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+              "result": {
+                "@id": "_:b965",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - embedded triple inside blankNodePropertyList",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b989",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "result": {
+                "@id": "_:b990",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1681",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "result": {
+                "@id": "_:b676",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b226",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "result": {
+                "@id": "_:b42",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b180",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "result": {
+                "@id": "_:b181",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - embedded triple inside collection",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b1714",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "result": {
+                "@id": "_:b674",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b254",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "result": {
+                "@id": "_:b147",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1158",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "result": {
+                "@id": "_:b1159",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b60",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "result": {
+                "@id": "_:b61",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - nested embedded triple, subject position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b1210",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "result": {
+                "@id": "_:b871",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b445",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "result": {
+                "@id": "_:b446",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1451",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "result": {
+                "@id": "_:b776",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1778",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "result": {
+                "@id": "_:b361",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - nested embedded triple, object position",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b1475",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "result": {
+                "@id": "_:b25",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1171",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "result": {
+                "@id": "_:b204",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1693",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "result": {
+                "@id": "_:b172",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1514",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "result": {
+                "@id": "_:b994",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - compound forms",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq",
+          "assertions": [
+            {
+              "@id": "_:b1799",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "result": {
+                "@id": "_:b597",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b420",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "result": {
+                "@id": "_:b421",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b652",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "result": {
+                "@id": "_:b653",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b379",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "result": {
+                "@id": "_:b380",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - blank node subject",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b1170",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "result": {
+                "@id": "_:b1067",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b418",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "result": {
+                "@id": "_:b419",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1795",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "result": {
+                "@id": "_:b1535",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b935",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "result": {
+                "@id": "_:b936",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - blank node object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b1387",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+              "result": {
+                "@id": "_:b1388",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1517",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+              "result": {
+                "@id": "_:b699",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b524",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
               "result": {
                 "@id": "_:b73",
                 "@type": "TestResult",
@@ -11108,486 +6314,2912 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b941",
+              "@id": "_:b1002",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
               "result": {
-                "@id": "_:b923",
+                "@id": "_:b1003",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:NegativeUpdateSyntaxTest11"
-          ],
-          "title": "SPARQL-star - update - bad syntax",
-          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru",
-          "assertions": [
-            {
-              "@id": "_:b81",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b82",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1349",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b926",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1370",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-              "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b1098",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:label": "N-Triples-star Syntax Tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
-          "@type": [
             "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "N-Triples-star - subject embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt",
+          "title": "SPARQL-star - blank node",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq",
           "assertions": [
             {
-              "@id": "_:b763",
+              "@id": "_:b355",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b584",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b708",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
               "result": {
-                "@id": "_:b709",
+                "@id": "_:b356",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b908",
+              "@id": "_:b1696",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
               "result": {
-                "@id": "_:b909",
+                "@id": "_:b134",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
+            },
+            {
+              "@id": "_:b489",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
+              "result": {
+                "@id": "_:b189",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1614",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
+              "result": {
+                "@id": "_:b870",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
           "@type": [
+            "TestCase",
             "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "N-Triples-star - object embedded triple",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt",
+          "title": "SPARQL-star - Annotation form",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq",
           "assertions": [
             {
-              "@id": "_:b1022",
+              "@id": "_:b950",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b1023",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b576",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
               "result": {
-                "@id": "_:b165",
+                "@id": "_:b681",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b375",
+              "@id": "_:b1760",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
               "result": {
-                "@id": "_:b376",
+                "@id": "_:b1761",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
+            },
+            {
+              "@id": "_:b1758",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
+              "result": {
+                "@id": "_:b552",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1818",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
+              "result": {
+                "@id": "_:b1731",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
           "@type": [
+            "TestCase",
             "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "N-Triples-star - subject and object embedded triples",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt",
+          "title": "SPARQL-star - Annotation example",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq",
           "assertions": [
             {
-              "@id": "_:b453",
+              "@id": "_:b1807",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b454",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b104",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
               "result": {
-                "@id": "_:b105",
+                "@id": "_:b422",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b701",
+              "@id": "_:b464",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
               "result": {
-                "@id": "_:b702",
+                "@id": "_:b465",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
+            },
+            {
+              "@id": "_:b829",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
+              "result": {
+                "@id": "_:b830",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1125",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
+              "result": {
+                "@id": "_:b493",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
           "@type": [
+            "TestCase",
             "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
+            "mf:PositiveSyntaxTest11"
           ],
-          "title": "N-Triples-star - whitespace and terms",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt",
+          "title": "SPARQL-star - Annotation example",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq",
           "assertions": [
             {
-              "@id": "_:b427",
+              "@id": "_:b1432",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
-              "subject": "https://josd.github.io/eye/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
               "result": {
-                "@id": "_:b428",
+                "@id": "_:b1433",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b848",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
+              "result": {
+                "@id": "_:b849",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1258",
+              "@id": "_:b1782",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
-              "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
               "result": {
-                "@id": "_:b1169",
+                "@id": "_:b1408",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b431",
+              "@id": "_:b511",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
+              "result": {
+                "@id": "_:b512",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Annotation with embedding",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq",
+          "assertions": [
+            {
+              "@id": "_:b779",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "result": {
+                "@id": "_:b780",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1385",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "result": {
+                "@id": "_:b1127",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1126",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "result": {
+                "@id": "_:b6",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1815",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "result": {
+                "@id": "_:b1708",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Annotation on triple with embedded object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq",
+          "assertions": [
+            {
+              "@id": "_:b343",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "result": {
+                "@id": "_:b344",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b195",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "result": {
+                "@id": "_:b196",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b280",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "result": {
+                "@id": "_:b152",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b412",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "result": {
+                "@id": "_:b413",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Annotation with path",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq",
+          "assertions": [
+            {
+              "@id": "_:b915",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "result": {
+                "@id": "_:b916",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1147",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "result": {
+                "@id": "_:b543",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b958",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "result": {
+                "@id": "_:b759",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1195",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "result": {
+                "@id": "_:b1196",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Annotation with nested path",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq",
+          "assertions": [
+            {
+              "@id": "_:b1059",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "result": {
+                "@id": "_:b1060",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1285",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "result": {
+                "@id": "_:b1286",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1721",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "result": {
+                "@id": "_:b535",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1121",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "result": {
+                "@id": "_:b1122",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Annotation in CONSTRUCT ",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq",
+          "assertions": [
+            {
+              "@id": "_:b1704",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "result": {
+                "@id": "_:b1667",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1362",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "result": {
+                "@id": "_:b1363",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1718",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "result": {
+                "@id": "_:b1706",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1113",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "result": {
+                "@id": "_:b1114",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Annotation in CONSTRUCT WHERE",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq",
+          "assertions": [
+            {
+              "@id": "_:b940",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "result": {
+                "@id": "_:b941",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b503",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "result": {
+                "@id": "_:b504",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b320",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "result": {
+                "@id": "_:b321",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1244",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "result": {
+                "@id": "_:b1245",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Expressions - Embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b1264",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b1265",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1600",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b499",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b691",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b692",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b263",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b264",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Expressions - Embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b43",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b44",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b808",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b484",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b744",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b745",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1579",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b1130",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Expressions - Functions",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq",
+          "assertions": [
+            {
+              "@id": "_:b441",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "result": {
+                "@id": "_:b388",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1380",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "result": {
+                "@id": "_:b1381",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b886",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "result": {
+                "@id": "_:b68",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1624",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "result": {
+                "@id": "_:b1308",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Expressions - TRIPLE",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq",
+          "assertions": [
+            {
+              "@id": "_:b1180",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "result": {
+                "@id": "_:b329",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b294",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "result": {
+                "@id": "_:b295",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1434",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "result": {
+                "@id": "_:b722",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1341",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "result": {
+                "@id": "_:b1342",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Expressions - Functions",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq",
+          "assertions": [
+            {
+              "@id": "_:b1702",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "result": {
+                "@id": "_:b1655",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1083",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "result": {
+                "@id": "_:b1084",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b517",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "result": {
+                "@id": "_:b518",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1650",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "result": {
+                "@id": "_:b1651",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "mf:PositiveSyntaxTest11"
+          ],
+          "title": "SPARQL-star - Expressions - BIND - CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq",
+          "assertions": [
+            {
+              "@id": "_:b426",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "result": {
+                "@id": "_:b427",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b937",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "result": {
+                "@id": "_:b581",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1208",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "result": {
+                "@id": "_:b452",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1054",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "result": {
+                "@id": "_:b121",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - embedded triple as predicate",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq",
+          "assertions": [
+            {
+              "@id": "_:b1491",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "result": {
+                "@id": "_:b520",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1722",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "result": {
+                "@id": "_:b1326",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1549",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "result": {
+                "@id": "_:b1550",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1802",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "result": {
+                "@id": "_:b1610",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - embedded triple outside triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq",
+          "assertions": [
+            {
+              "@id": "_:b715",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "result": {
+                "@id": "_:b716",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1823",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "result": {
+                "@id": "_:b793",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1611",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "result": {
+                "@id": "_:b57",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b732",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "result": {
+                "@id": "_:b188",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - collection list in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq",
+          "assertions": [
+            {
+              "@id": "_:b1461",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "result": {
+                "@id": "_:b1462",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b858",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "result": {
+                "@id": "_:b859",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b796",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "result": {
+                "@id": "_:b797",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b66",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "result": {
+                "@id": "_:b67",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - literal in subject position of embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq",
+          "assertions": [
+            {
+              "@id": "_:b646",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "result": {
+                "@id": "_:b647",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b250",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "result": {
+                "@id": "_:b251",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b998",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "result": {
+                "@id": "_:b999",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b683",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "result": {
+                "@id": "_:b684",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - blank node  as predicate in embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq",
+          "assertions": [
+            {
+              "@id": "_:b1086",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "result": {
+                "@id": "_:b1087",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1153",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "result": {
+                "@id": "_:b1091",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b666",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "result": {
+                "@id": "_:b667",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b696",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "result": {
+                "@id": "_:b697",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - compound blank node expression",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq",
+          "assertions": [
+            {
+              "@id": "_:b1139",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "result": {
+                "@id": "_:b1140",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1569",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "result": {
+                "@id": "_:b26",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b718",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "result": {
+                "@id": "_:b719",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1663",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "result": {
+                "@id": "_:b1072",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - incomplete embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq",
+          "assertions": [
+            {
+              "@id": "_:b1057",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "result": {
+                "@id": "_:b756",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b348",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "result": {
+                "@id": "_:b349",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b396",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "result": {
+                "@id": "_:b397",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1525",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "result": {
+                "@id": "_:b414",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - quad embedded triple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq",
+          "assertions": [
+            {
+              "@id": "_:b357",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "result": {
+                "@id": "_:b358",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1522",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "result": {
+                "@id": "_:b1095",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b330",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "result": {
+                "@id": "_:b331",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b178",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "result": {
+                "@id": "_:b179",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - variable in embedded triple in VALUES ",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq",
+          "assertions": [
+            {
+              "@id": "_:b1287",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
+              "result": {
+                "@id": "_:b1204",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b157",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
               "result": {
                 "@id": "_:b158",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star - Nested, no whitespace",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt",
-          "assertions": [
+            },
             {
-              "@id": "_:b1079",
+              "@id": "_:b1400",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
-              "subject": "https://josd.github.io/eye/",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
               "result": {
-                "@id": "_:b749",
+                "@id": "_:b184",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b447",
+              "@id": "_:b1427",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
               "result": {
-                "@id": "_:b448",
+                "@id": "_:b579",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b577",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b578",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
               },
-              "assertedBy": null
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
           "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
           ],
-          "title": "N-Triples-star - Blank node subject",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt",
+          "title": "SPARQL-star - bad - blank node in embedded triple in VALUES ",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq",
           "assertions": [
             {
-              "@id": "_:b1012",
+              "@id": "_:b270",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b777",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b588",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
               "result": {
-                "@id": "_:b589",
+                "@id": "_:b271",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b684",
+              "@id": "_:b1468",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b685",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
-          "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
-          ],
-          "title": "N-Triples-star - Blank node object",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt",
-          "assertions": [
-            {
-              "@id": "_:b1327",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
               "result": {
-                "@id": "_:b821",
+                "@id": "_:b1469",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b1216",
+              "@id": "_:b1322",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
-              "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
               "result": {
-                "@id": "_:b1084",
+                "@id": "_:b532",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1652",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
+              "result": {
+                "@id": "_:b1178",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1294",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b730",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
               },
-              "assertedBy": null
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
           "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
           ],
-          "title": "N-Triples-star - Nested subject term",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt",
+          "title": "SPARQL-star - bad - blank node in embedded triple in FILTER",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-11.rq",
           "assertions": [
             {
-              "@id": "_:b1356",
+              "@id": "_:b1660",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b629",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b1205",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
               "result": {
-                "@id": "_:b1069",
+                "@id": "_:b516",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b784",
+              "@id": "_:b1394",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
               "result": {
-                "@id": "_:b358",
+                "@id": "_:b1395",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
+            },
+            {
+              "@id": "_:b725",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
+              "result": {
+                "@id": "_:b405",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1303",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
+              "result": {
+                "@id": "_:b170",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
           "@type": [
-            "TestCriterion",
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCase"
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
           ],
-          "title": "N-Triples-star - Nested object term",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt",
+          "title": "SPARQL-star - bad - blank node in embedded triple in BIND",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-12.rq",
           "assertions": [
             {
-              "@id": "_:b274",
+              "@id": "_:b299",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
+              "result": {
+                "@id": "_:b300",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b775",
+              "@type": "Assertion",
               "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
+              "result": {
+                "@id": "_:b49",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1783",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
+              "result": {
+                "@id": "_:b838",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b618",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
+              "result": {
+                "@id": "_:b619",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - empty annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq",
+          "assertions": [
+            {
+              "@id": "_:b1031",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "result": {
+                "@id": "_:b510",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1589",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "result": {
+                "@id": "_:b1590",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b707",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "result": {
+                "@id": "_:b708",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1793",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "result": {
+                "@id": "_:b562",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - triples in annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq",
+          "assertions": [
+            {
+              "@id": "_:b1588",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "result": {
+                "@id": "_:b1418",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1487",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "result": {
+                "@id": "_:b1488",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1489",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "result": {
+                "@id": "_:b1078",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b633",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "result": {
+                "@id": "_:b634",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - path - seq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq",
+          "assertions": [
+            {
+              "@id": "_:b620",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "result": {
+                "@id": "_:b621",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b93",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "result": {
+                "@id": "_:b94",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b197",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "result": {
+                "@id": "_:b198",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1694",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "result": {
+                "@id": "_:b455",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - path - alt",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq",
+          "assertions": [
+            {
+              "@id": "_:b1801",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "result": {
+                "@id": "_:b1545",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1329",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "result": {
+                "@id": "_:b1330",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1746",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "result": {
+                "@id": "_:b1613",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1474",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "result": {
+                "@id": "_:b1396",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - path - p*",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq",
+          "assertions": [
+            {
+              "@id": "_:b186",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "result": {
+                "@id": "_:b187",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1754",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "result": {
+                "@id": "_:b1508",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1665",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "result": {
+                "@id": "_:b890",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1504",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "result": {
+                "@id": "_:b1505",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - path - p+",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq",
+          "assertions": [
+            {
+              "@id": "_:b600",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "result": {
+                "@id": "_:b601",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1199",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "result": {
+                "@id": "_:b1200",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1009",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "result": {
+                "@id": "_:b342",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b35",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "result": {
+                "@id": "_:b36",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - path - p?",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq",
+          "assertions": [
+            {
+              "@id": "_:b1422",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "result": {
+                "@id": "_:b925",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1656",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "result": {
+                "@id": "_:b1371",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b437",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "result": {
+                "@id": "_:b438",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1519",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "result": {
+                "@id": "_:b1520",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - path in CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq",
+          "assertions": [
+            {
+              "@id": "_:b996",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "result": {
+                "@id": "_:b819",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b762",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "result": {
+                "@id": "_:b763",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1399",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "result": {
+                "@id": "_:b1351",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1633",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "result": {
+                "@id": "_:b451",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+          "@type": [
+            "TestCase",
+            "mf:NegativeSyntaxTest11",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - bad - path in CONSTRUCT",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq",
+          "assertions": [
+            {
+              "@id": "_:b1785",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "result": {
+                "@id": "_:b1555",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b392",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "result": {
+                "@id": "_:b393",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1256",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "result": {
+                "@id": "_:b386",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1123",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "result": {
+                "@id": "_:b1124",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru",
+          "assertions": [
+            {
+              "@id": "_:b672",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "result": {
+                "@id": "_:b673",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1345",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "result": {
+                "@id": "_:b1203",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1379",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "result": {
+                "@id": "_:b897",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1443",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "result": {
+                "@id": "_:b128",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru",
+          "assertions": [
+            {
+              "@id": "_:b809",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "result": {
+                "@id": "_:b810",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b802",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "result": {
+                "@id": "_:b173",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1097",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "result": {
+                "@id": "_:b62",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1230",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "result": {
+                "@id": "_:b1231",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru",
+          "assertions": [
+            {
+              "@id": "_:b1302",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "result": {
+                "@id": "_:b182",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1609",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "result": {
+                "@id": "_:b1335",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b606",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "result": {
+                "@id": "_:b607",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b954",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "result": {
+                "@id": "_:b78",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update with embedding",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru",
+          "assertions": [
+            {
+              "@id": "_:b1277",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "result": {
+                "@id": "_:b1160",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1050",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "result": {
+                "@id": "_:b1051",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1336",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "result": {
+                "@id": "_:b86",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1194",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "result": {
+                "@id": "_:b354",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update with embedded object",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru",
+          "assertions": [
+            {
+              "@id": "_:b1297",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "result": {
+                "@id": "_:b917",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1720",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "result": {
+                "@id": "_:b1559",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1755",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "result": {
+                "@id": "_:b803",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b515",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "result": {
+                "@id": "_:b18",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update with annotation template",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru",
+          "assertions": [
+            {
+              "@id": "_:b1632",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "result": {
+                "@id": "_:b1156",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b927",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "result": {
+                "@id": "_:b928",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b33",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "result": {
+                "@id": "_:b34",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1386",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "result": {
+                "@id": "_:b31",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update with annotation, template and pattern",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru",
+          "assertions": [
+            {
+              "@id": "_:b14",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "result": {
+                "@id": "_:b15",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1093",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "result": {
+                "@id": "_:b1094",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1740",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "result": {
+                "@id": "_:b1616",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1658",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "result": {
+                "@id": "_:b811",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+          "@type": [
+            "mf:PositiveUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update DATA with annotation",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru",
+          "assertions": [
+            {
+              "@id": "_:b1630",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "result": {
+                "@id": "_:b175",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1820",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "result": {
+                "@id": "_:b905",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1481",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "result": {
+                "@id": "_:b1482",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1175",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "result": {
+                "@id": "_:b1176",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+          "@type": [
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru",
+          "assertions": [
+            {
+              "@id": "_:b1349",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "result": {
+                "@id": "_:b1350",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b877",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "result": {
+                "@id": "_:b878",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b786",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "result": {
+                "@id": "_:b787",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b481",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "result": {
+                "@id": "_:b220",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+          "@type": [
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru",
+          "assertions": [
+            {
+              "@id": "_:b945",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+              "result": {
+                "@id": "_:b11",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b496",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+              "result": {
+                "@id": "_:b497",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1784",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
               "result": {
                 "@id": "_:b37",
                 "@type": "TestResult",
@@ -11596,173 +9228,211 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b816",
+              "@id": "_:b588",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
               "result": {
-                "@id": "_:b347",
+                "@id": "_:b545",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1297",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b935",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
               },
-              "assertedBy": null
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
           ],
-          "title": "N-Triples-star - Bad - embedded triple as predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt",
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru",
           "assertions": [
             {
-              "@id": "_:b950",
+              "@id": "_:b268",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b951",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b774",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
               "result": {
-                "@id": "_:b242",
+                "@id": "_:b269",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b1287",
+              "@id": "_:b243",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
               "result": {
-                "@id": "_:b742",
+                "@id": "_:b244",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
+            },
+            {
+              "@id": "_:b1518",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+              "result": {
+                "@id": "_:b959",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b534",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+              "result": {
+                "@id": "_:b401",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
+            "mf:NegativeUpdateSyntaxTest11",
+            "TestCase",
+            "TestCriterion"
           ],
-          "title": "N-Triples-star - Bad - embedded triple, literal subject",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt",
+          "title": "SPARQL-star - update - bad syntax",
+          "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru",
           "assertions": [
             {
-              "@id": "_:b609",
+              "@id": "_:b463",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
-              "subject": "https://josd.github.io/eye/",
-              "result": {
-                "@id": "_:b610",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b244",
-              "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
               "mode": "earl:automatic",
-              "subject": "https://rubygems.org/gems/rdf-trig",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
               "result": {
-                "@id": "_:b175",
+                "@id": "_:b125",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
             },
             {
-              "@id": "_:b635",
+              "@id": "_:b98",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
               "result": {
-                "@id": "_:b415",
+                "@id": "_:b99",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
+            },
+            {
+              "@id": "_:b602",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+              "result": {
+                "@id": "_:b603",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b104",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+              "result": {
+                "@id": "_:b105",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "TriG-star Evaluation Tests",
+      "entries": [
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
           ],
-          "title": "N-Triples-star - Bad - embedded triple, literal predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt",
+          "title": "TriG-star - subject embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig",
           "assertions": [
             {
-              "@id": "_:b996",
+              "@id": "_:b687",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
-              "subject": "https://josd.github.io/eye/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
               "result": {
-                "@id": "_:b997",
+                "@id": "_:b688",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b541",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+              "result": {
+                "@id": "_:b542",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b550",
+              "@id": "_:b1359",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b138",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            },
-            {
-              "@id": "_:b1244",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
               "result": {
                 "@id": "_:b1111",
                 "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b794",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+              "result": {
+                "@id": "_:b305",
+                "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
@@ -11770,47 +9440,5242 @@
           ]
         },
         {
-          "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
           ],
-          "title": "N-Triples-star - Bad - embedded triple, blank node predicate",
-          "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt",
+          "title": "TriG-star - object embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig",
           "assertions": [
             {
-              "@id": "_:b987",
+              "@id": "_:b1773",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
-              "subject": "https://josd.github.io/eye/",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
               "result": {
-                "@id": "_:b221",
+                "@id": "_:b1442",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1646",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+              "result": {
+                "@id": "_:b1327",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b155",
+              "@id": "_:b1048",
               "@type": "Assertion",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
               "mode": "earl:automatic",
               "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
               "result": {
-                "@id": "_:b156",
+                "@id": "_:b384",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              }
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
             },
             {
-              "@id": "_:b591",
+              "@id": "_:b1741",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
               "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
               "result": {
-                "@id": "_:b592",
+                "@id": "_:b1726",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - blank node label",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b530",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "result": {
+                "@id": "_:b531",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b711",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "result": {
+                "@id": "_:b712",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1273",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "result": {
+                "@id": "_:b1274",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b491",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "result": {
+                "@id": "_:b288",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - blank node labels",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b1499",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "result": {
+                "@id": "_:b1500",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1446",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "result": {
+                "@id": "_:b635",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b748",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "result": {
+                "@id": "_:b749",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b930",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "result": {
+                "@id": "_:b931",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation form",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b980",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "result": {
+                "@id": "_:b929",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1572",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "result": {
+                "@id": "_:b1573",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b547",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "result": {
+                "@id": "_:b548",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b471",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "result": {
+                "@id": "_:b472",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation example",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b1189",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "result": {
+                "@id": "_:b1190",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b312",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "result": {
+                "@id": "_:b313",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1713",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "result": {
+                "@id": "_:b1560",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1164",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "result": {
+                "@id": "_:b1165",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation - predicate and object lists",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig",
+          "assertions": [
+            {
+              "@id": "_:b1049",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "result": {
+                "@id": "_:b176",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b975",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "result": {
+                "@id": "_:b76",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b689",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "result": {
+                "@id": "_:b690",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1618",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "result": {
+                "@id": "_:b1355",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation - nested",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig",
+          "assertions": [
+            {
+              "@id": "_:b1266",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "result": {
+                "@id": "_:b1267",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b629",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "result": {
+                "@id": "_:b630",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1771",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "result": {
+                "@id": "_:b761",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b932",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "result": {
+                "@id": "_:b933",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation object list",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig",
+          "assertions": [
+            {
+              "@id": "_:b821",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "result": {
+                "@id": "_:b822",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1822",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "result": {
+                "@id": "_:b84",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1725",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "result": {
+                "@id": "_:b1020",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b700",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "result": {
+                "@id": "_:b701",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation with embedding",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.trig",
+          "assertions": [
+            {
+              "@id": "_:b1774",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+              "result": {
+                "@id": "_:b102",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1449",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+              "result": {
+                "@id": "_:b1450",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1749",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+              "result": {
+                "@id": "_:b862",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1150",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1",
+              "result": {
+                "@id": "_:b378",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation on triple with embedded subject",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.trig",
+          "assertions": [
+            {
+              "@id": "_:b1603",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+              "result": {
+                "@id": "_:b1594",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1596",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+              "result": {
+                "@id": "_:b1597",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1510",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+              "result": {
+                "@id": "_:b1511",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b956",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2",
+              "result": {
+                "@id": "_:b957",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "title": "TriG-star - Annotation on triple with embedded object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.nq",
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.trig",
+          "assertions": [
+            {
+              "@id": "_:b1669",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+              "result": {
+                "@id": "_:b1670",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1101",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+              "result": {
+                "@id": "_:b1102",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1219",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+              "result": {
+                "@id": "_:b723",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            },
+            {
+              "@id": "_:b1465",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3",
+              "result": {
+                "@id": "_:b1466",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "SPARQL-star Evaluation Tests",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - all graph triples (JSON results)",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj",
+          "testAction": {
+            "@id": "_:b624",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1284",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "result": {
+                "@id": "_:b740",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b622",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "result": {
+                "@id": "_:b623",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b817",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "result": {
+                "@id": "_:b818",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b875",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "result": {
+                "@id": "_:b876",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - all graph triples (XML results)",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx",
+          "testAction": {
+            "@id": "_:b92",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1680",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "result": {
+                "@id": "_:b1634",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1812",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "result": {
+                "@id": "_:b1044",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b90",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "result": {
+                "@id": "_:b91",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1661",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "result": {
+                "@id": "_:b387",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - match constant embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj",
+          "testAction": {
+            "@id": "_:b124",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b122",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "result": {
+                "@id": "_:b123",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1311",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "result": {
+                "@id": "_:b1312",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b462",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "result": {
+                "@id": "_:b162",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b139",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "result": {
+                "@id": "_:b140",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - match embedded triple, var subject",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj",
+          "testAction": {
+            "@id": "_:b979",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1767",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "result": {
+                "@id": "_:b1763",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b977",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "result": {
+                "@id": "_:b978",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1288",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "result": {
+                "@id": "_:b1108",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1490",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "result": {
+                "@id": "_:b539",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - match embedded triple, var predicate",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj",
+          "testAction": {
+            "@id": "_:b735",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1742",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "result": {
+                "@id": "_:b1294",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1685",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "result": {
+                "@id": "_:b1575",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1184",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "result": {
+                "@id": "_:b442",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b737",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "result": {
+                "@id": "_:b424",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - match embedded triple, var object",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj",
+          "testAction": {
+            "@id": "_:b351",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b350",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "result": {
+                "@id": "_:b59",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1337",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "result": {
+                "@id": "_:b1338",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1191",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "result": {
+                "@id": "_:b1100",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1729",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "result": {
+                "@id": "_:b1554",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - no match of embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj",
+          "testAction": {
+            "@id": "_:b449",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b447",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "result": {
+                "@id": "_:b448",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1470",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "result": {
+                "@id": "_:b208",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1712",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "result": {
+                "@id": "_:b1154",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1392",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "result": {
+                "@id": "_:b12",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Asserted and embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj",
+          "testAction": {
+            "@id": "_:b219",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1697",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "result": {
+                "@id": "_:b1698",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1809",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "result": {
+                "@id": "_:b1509",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1043",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "result": {
+                "@id": "_:b249",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b218",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "result": {
+                "@id": "_:b48",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star -  Asserted and embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj",
+          "testAction": {
+            "@id": "_:b174",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1789",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "result": {
+                "@id": "_:b757",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1313",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "result": {
+                "@id": "_:b1096",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1719",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "result": {
+                "@id": "_:b1598",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b662",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "result": {
+                "@id": "_:b345",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Pattern - Variable for embedded triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj",
+          "testAction": {
+            "@id": "_:b0",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1234",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "result": {
+                "@id": "_:b1235",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1041",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "result": {
+                "@id": "_:b1042",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1437",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "result": {
+                "@id": "_:b962",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1366",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "result": {
+                "@id": "_:b1309",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Pattern - No match",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj",
+          "testAction": {
+            "@id": "_:b255",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b750",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "result": {
+                "@id": "_:b529",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1623",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "result": {
+                "@id": "_:b1373",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b693",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "result": {
+                "@id": "_:b488",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1615",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "result": {
+                "@id": "_:b966",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Pattern - match variables in triple terms",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj",
+          "testAction": {
+            "@id": "_:b109",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b216",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "result": {
+                "@id": "_:b217",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b500",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "result": {
+                "@id": "_:b501",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1055",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "result": {
+                "@id": "_:b1056",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b879",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "result": {
+                "@id": "_:b177",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Pattern - Nesting 1",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj",
+          "testAction": {
+            "@id": "_:b461",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b843",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "result": {
+                "@id": "_:b844",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1246",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "result": {
+                "@id": "_:b1080",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1791",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "result": {
+                "@id": "_:b1402",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b459",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "result": {
+                "@id": "_:b460",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Pattern - Nesting - 2",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj",
+          "testAction": {
+            "@id": "_:b368",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1737",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "result": {
+                "@id": "_:b1540",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1692",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "result": {
+                "@id": "_:b131",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1416",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "result": {
+                "@id": "_:b1417",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1015",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "result": {
+                "@id": "_:b1016",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Pattern - Match and nesting",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj",
+          "testAction": {
+            "@id": "_:b523",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1023",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "result": {
+                "@id": "_:b1024",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b536",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "result": {
+                "@id": "_:b537",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1261",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "result": {
+                "@id": "_:b626",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1369",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "result": {
+                "@id": "_:b1173",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Pattern - Same variable",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj",
+          "testAction": {
+            "@id": "_:b584",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-5.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b631",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "result": {
+                "@id": "_:b423",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1814",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "result": {
+                "@id": "_:b232",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1367",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "result": {
+                "@id": "_:b1282",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1495",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "result": {
+                "@id": "_:b678",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - CONSTRUCT with constant template",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl",
+          "testAction": {
+            "@id": "_:b364",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b362",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "result": {
+                "@id": "_:b363",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1752",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "result": {
+                "@id": "_:b1521",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b826",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "result": {
+                "@id": "_:b827",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1137",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "result": {
+                "@id": "_:b1138",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - CONSTRUCT WHERE with constant template",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl",
+          "testAction": {
+            "@id": "_:b430",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1672",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "result": {
+                "@id": "_:b1673",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1183",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "result": {
+                "@id": "_:b205",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1813",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "result": {
+                "@id": "_:b992",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b428",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "result": {
+                "@id": "_:b429",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - CONSTRUCT - about every triple",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl",
+          "testAction": {
+            "@id": "_:b468",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1786",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "result": {
+                "@id": "_:b632",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1225",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "result": {
+                "@id": "_:b971",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b798",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "result": {
+                "@id": "_:b799",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1058",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "result": {
+                "@id": "_:b141",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - CONSTRUCT with annotation syntax",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl",
+          "testAction": {
+            "@id": "_:b97",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1283",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "result": {
+                "@id": "_:b340",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b411",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "result": {
+                "@id": "_:b334",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b475",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "result": {
+                "@id": "_:b476",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b308",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "result": {
+                "@id": "_:b81",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl",
+          "testAction": {
+            "@id": "_:b307",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1576",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "result": {
+                "@id": "_:b1577",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1374",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "result": {
+                "@id": "_:b1375",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1585",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "result": {
+                "@id": "_:b1013",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b577",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "result": {
+                "@id": "_:b578",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - GRAPH",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj",
+          "testAction": {
+            "@id": "_:b1066",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1676",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "result": {
+                "@id": "_:b1677",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1608",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "result": {
+                "@id": "_:b812",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1657",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "result": {
+                "@id": "_:b171",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1566",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "result": {
+                "@id": "_:b1567",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - GRAPHs with blank node",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj",
+          "testAction": {
+            "@id": "_:b4",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b436",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "result": {
+                "@id": "_:b19",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b113",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "result": {
+                "@id": "_:b114",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b899",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "result": {
+                "@id": "_:b900",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b800",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "result": {
+                "@id": "_:b801",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl",
+          "testAction": {
+            "@id": "_:b642",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1426",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b1166",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b863",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b498",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1360",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b1361",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b866",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "result": {
+                "@id": "_:b867",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - Functions",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj",
+          "testAction": {
+            "@id": "_:b165",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b163",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b164",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b952",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b495",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1583",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b1584",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1739",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "result": {
+                "@id": "_:b1448",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - sameTerm",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-1.srj",
+          "testAction": {
+            "@id": "_:b755",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-1.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1278",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
+              "result": {
+                "@id": "_:b1163",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1438",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
+              "result": {
+                "@id": "_:b1439",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1148",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
+              "result": {
+                "@id": "_:b390",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b753",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
+              "result": {
+                "@id": "_:b754",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - value-equality",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-2.srj",
+          "testAction": {
+            "@id": "_:b259",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-2.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b257",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
+              "result": {
+                "@id": "_:b258",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1215",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
+              "result": {
+                "@id": "_:b467",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1638",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
+              "result": {
+                "@id": "_:b473",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b834",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
+              "result": {
+                "@id": "_:b395",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - value-inequality",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-3.srj",
+          "testAction": {
+            "@id": "_:b278",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-3.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b276",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
+              "result": {
+                "@id": "_:b277",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1228",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
+              "result": {
+                "@id": "_:b1229",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b431",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
+              "result": {
+                "@id": "_:b432",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1017",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
+              "result": {
+                "@id": "_:b1018",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - value-inequality",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-4.srj",
+          "testAction": {
+            "@id": "_:b194",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-4.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b477",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
+              "result": {
+                "@id": "_:b478",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b730",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
+              "result": {
+                "@id": "_:b267",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1397",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
+              "result": {
+                "@id": "_:b1398",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b192",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
+              "result": {
+                "@id": "_:b193",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - ORDER BY",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj",
+          "testAction": {
+            "@id": "_:b404",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-by.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-order-kind.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1625",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "result": {
+                "@id": "_:b760",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1237",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "result": {
+                "@id": "_:b1238",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b402",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "result": {
+                "@id": "_:b403",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1452",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "result": {
+                "@id": "_:b185",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
+          "@type": [
+            "mf:QueryEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Embedded triple - ordering",
+          "testResult": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-2.srj",
+          "testAction": {
+            "@id": "_:b326",
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#query": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-by.rq"
+            },
+            "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-order.ttl"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1065",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
+              "result": {
+                "@id": "_:b399",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b1604",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
+              "result": {
+                "@id": "_:b439",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1004",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
+              "result": {
+                "@id": "_:b1005",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b324",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
+              "result": {
+                "@id": "_:b325",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+          "@type": [
+            "TestCase",
+            "mf:UpdateEvaluationTest",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Update",
+          "testResult": {
+            "@id": "_:b117",
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-1.trig"
+            }
+          },
+          "testAction": {
+            "@id": "_:b118",
+            "http://www.w3.org/2009/sparql/tests/test-update#request": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-1.ru"
+            },
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b115",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "result": {
+                "@id": "_:b116",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b469",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "result": {
+                "@id": "_:b470",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1664",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "result": {
+                "@id": "_:b1295",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1808",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "result": {
+                "@id": "_:b828",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+          "@type": [
+            "TestCase",
+            "mf:UpdateEvaluationTest",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Update - annotation",
+          "testResult": {
+            "@id": "_:b303",
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-2.trig"
+            }
+          },
+          "testAction": {
+            "@id": "_:b304",
+            "http://www.w3.org/2009/sparql/tests/test-update#request": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-2.ru"
+            },
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-6.trig"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1705",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "result": {
+                "@id": "_:b743",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b453",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "result": {
+                "@id": "_:b454",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b301",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "result": {
+                "@id": "_:b302",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1070",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "result": {
+                "@id": "_:b1071",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+          "@type": [
+            "TestCase",
+            "mf:UpdateEvaluationTest",
+            "TestCriterion"
+          ],
+          "title": "SPARQL-star - Update - data",
+          "testResult": {
+            "@id": "_:b95",
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-3.trig"
+            }
+          },
+          "testAction": {
+            "@id": "_:b96",
+            "http://www.w3.org/2009/sparql/tests/test-update#request": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-3.ru"
+            },
+            "http://www.w3.org/2009/sparql/tests/test-update#data": {
+              "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
+            }
+          },
+          "assertions": [
+            {
+              "@id": "_:b1750",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "result": {
+                "@id": "_:b574",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "http://jena.apache.org/#jena"
+            },
+            {
+              "@id": "_:b145",
+              "@type": "Assertion",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "result": {
+                "@id": "_:b146",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1811",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "result": {
+                "@id": "_:b391",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b100",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "result": {
+                "@id": "_:b101",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://greggkellogg.net/foaf#me"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/semantics#manifest",
+      "@type": [
+        "Report",
+        "mf:Manifest"
+      ],
+      "rdfs:label": "RDF-star Semantics tests",
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-star/tests/semantics/README"
+      },
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl",
+          "rdfs:comment": "Multiple occurences of the same embedded triples are undistinguishable in the abstract model.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "all-identical-embedded-triples-are-the-same",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1533",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "result": {
+                "@id": "_:b1115",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1053",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "result": {
+                "@id": "_:b225",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b551",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "result": {
+                "@id": "_:b65",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b694",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same",
+              "result": {
+                "@id": "_:b695",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test005.ttl",
+          "rdfs:comment": "This test ensures that other entailments are not spurious.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "embedded-triples-no-spurious",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1821",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+              "result": {
+                "@id": "_:b898",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1747",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+              "result": {
+                "@id": "_:b1748",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1762",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+              "result": {
+                "@id": "_:b1460",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1052",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious",
+              "result": {
+                "@id": "_:b645",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl",
+          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-embedded-subject",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1146",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b203",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1735",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b1340",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b252",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b253",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1699",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b106",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
+          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-embedded-object",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1733",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b540",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1258",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b155",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b938",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b939",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1565",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b1289",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
+          "rdfs:comment": "Terms in embedded triples can be replaced by fresh bnodes.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-embedded-subject-and-object",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b70",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+              "result": {
+                "@id": "_:b71",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1580",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+              "result": {
+                "@id": "_:b598",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b658",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+              "result": {
+                "@id": "_:b659",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b296",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object",
+              "result": {
+                "@id": "_:b297",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
+          "rdfs:comment": "The same bnode can not match different embedded terms.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-embedded-subject-and-object-fail",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1620",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+              "result": {
+                "@id": "_:b229",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1376",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+              "result": {
+                "@id": "_:b487",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1034",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+              "result": {
+                "@id": "_:b1035",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1088",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail",
+              "result": {
+                "@id": "_:b1089",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
+          "rdfs:comment": "Identical embedded term can be replaced by the same fresh bnode multiple times.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "same-bnode-same-embedded-term",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b865",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+              "result": {
+                "@id": "_:b202",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1157",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+              "result": {
+                "@id": "_:b661",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1206",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+              "result": {
+                "@id": "_:b1207",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1759",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term",
+              "result": {
+                "@id": "_:b79",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
+          "rdfs:comment": "Different bnodes can match identical embedded terms.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "different-bnodes-same-embedded-term",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b650",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+              "result": {
+                "@id": "_:b651",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1768",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+              "result": {
+                "@id": "_:b111",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1703",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+              "result": {
+                "@id": "_:b1526",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1317",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term",
+              "result": {
+                "@id": "_:b1318",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl",
+          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-in-embedded-subject",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1753",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b108",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1512",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b385",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1716",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b425",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1503",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject",
+              "result": {
+                "@id": "_:b1467",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl",
+          "rdfs:comment": "Terms in embedded triples and outside can be replaced by fresh bnodes.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-in-embedded-object",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b373",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b374",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b247",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b248",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b566",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b567",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1032",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object",
+              "result": {
+                "@id": "_:b150",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl",
+          "rdfs:comment": "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-in-embedded-fail",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1149",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+              "result": {
+                "@id": "_:b502",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1715",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+              "result": {
+                "@id": "_:b967",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b310",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+              "result": {
+                "@id": "_:b311",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1454",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail",
+              "result": {
+                "@id": "_:b1455",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl",
+          "rdfs:comment": "Literals in embedded triples and outside can be replaced by fresh bnodes.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-on-literal",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b854",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "result": {
+                "@id": "_:b825",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1476",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "result": {
+                "@id": "_:b1151",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1323",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "result": {
+                "@id": "_:b1216",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1181",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "result": {
+                "@id": "_:b1182",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "mf:result": {
+            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+            "@value": "false"
+          },
+          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-control",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b847",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "result": {
+                "@id": "_:b704",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b306",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "result": {
+                "@id": "_:b5",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1765",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "result": {
+                "@id": "_:b1557",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1671",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "result": {
+                "@id": "_:b991",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "mf:result": {
+            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+            "@value": "false"
+          },
+          "rdfs:comment": "Malformed literals are allowed when embedded.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b656",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "result": {
+                "@id": "_:b657",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1794",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "result": {
+                "@id": "_:b1502",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1777",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "result": {
+                "@id": "_:b209",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b554",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "result": {
+                "@id": "_:b555",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "rdfs:comment": "Malformed literals are allowed when embedded.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-accepted",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1617",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "result": {
+                "@id": "_:b1556",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1678",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "result": {
+                "@id": "_:b1193",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1357",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "result": {
+                "@id": "_:b85",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b135",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "result": {
+                "@id": "_:b136",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl",
+          "rdfs:comment": "Embedded malformed literals do not lead to spurious entailment.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-no-spurious",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b767",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "result": {
+                "@id": "_:b768",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1710",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "result": {
+                "@id": "_:b1684",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b415",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "result": {
+                "@id": "_:b416",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1033",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "result": {
+                "@id": "_:b72",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
+          "rdfs:comment": "Malformed literals can not be replaced by blank nodes.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-bnode",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1690",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "result": {
+                "@id": "_:b132",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1668",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "result": {
+                "@id": "_:b1654",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b845",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "result": {
+                "@id": "_:b846",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b595",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "result": {
+                "@id": "_:b596",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl",
+          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-literal-control",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1029",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "result": {
+                "@id": "_:b1030",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1106",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "result": {
+                "@id": "_:b869",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b608",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "result": {
+                "@id": "_:b609",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b806",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "result": {
+                "@id": "_:b807",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl",
+          "rdfs:comment": "Embedded literals are opaque, even when their datatype is recognized.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-literal",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b51",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "result": {
+                "@id": "_:b52",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b466",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "result": {
+                "@id": "_:b53",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1691",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "result": {
+                "@id": "_:b1447",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1637",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "result": {
+                "@id": "_:b1478",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl",
+          "rdfs:comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-language-string-control",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b738",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "result": {
+                "@id": "_:b739",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1529",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "result": {
+                "@id": "_:b731",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b212",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "result": {
+                "@id": "_:b213",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b946",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "result": {
+                "@id": "_:b947",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDF",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl",
+          "rdfs:comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-language-string",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b627",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "result": {
+                "@id": "_:b628",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b781",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "result": {
+                "@id": "_:b782",
+                "@type": "TestResult",
+                "outcome": "earl:failed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b63",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "result": {
+                "@id": "_:b58",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1038",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "result": {
+                "@id": "_:b1039",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "RDFS-Plus",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl",
+          "rdfs:comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-iri-control",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1319",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "result": {
+                "@id": "_:b1320",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b383",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "result": {
+                "@id": "_:b103",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1817",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "result": {
+                "@id": "_:b857",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b570",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "result": {
+                "@id": "_:b571",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "RDFS-Plus",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/superman.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl",
+          "rdfs:comment": "Embedded IRIs are opaque.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-iri",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b993",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "result": {
+                "@id": "_:b572",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1431",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "result": {
+                "@id": "_:b860",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1563",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "result": {
+                "@id": "_:b765",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1751",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "result": {
+                "@id": "_:b668",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl",
+          "rdfs:comment": "Embedded triples are not asserted.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "embedded-not-asserted",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1728",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+              "result": {
+                "@id": "_:b792",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1593",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+              "result": {
+                "@id": "_:b1026",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1419",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+              "result": {
+                "@id": "_:b1420",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1493",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted",
+              "result": {
+                "@id": "_:b724",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl",
+          "rdfs:comment": "Annotated triples are asserted.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "annotated-asserted",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b1298",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "result": {
+                "@id": "_:b417",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b885",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "result": {
+                "@id": "_:b842",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b582",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "result": {
+                "@id": "_:b583",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1143",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "result": {
+                "@id": "_:b1144",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl",
+          "rdfs:comment": "Annotation are about the annotated triple.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "annotation",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b314",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "result": {
+                "@id": "_:b315",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1539",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "result": {
+                "@id": "_:b682",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1534",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "result": {
+                "@id": "_:b168",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1819",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "result": {
+                "@id": "_:b615",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "mf:entailmentRegime": "simple",
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "rdfs:comment": "Annotation is the same as separate assertions.",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "annotation-unfolded",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b587",
+              "@type": "Assertion",
+              "subject": "http://jena.apache.org/#jena",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "result": {
+                "@id": "_:b382",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b1635",
+              "@type": "Assertion",
+              "mode": "earl:automatic",
+              "subject": "https://josd.github.io/eye/",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "result": {
+                "@id": "_:b1142",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "assertedBy": "https://josd.github.io/"
+            },
+            {
+              "@id": "_:b1241",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "result": {
+                "@id": "_:b112",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b316",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "result": {
+                "@id": "_:b317",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -11821,39 +14686,5 @@
       ]
     }
   ],
-  "name": "RDF-star",
-  "generatedBy": {
-    "@id": "https://rubygems.org/gems/earl-report",
-    "@type": [
-      "doap:Project",
-      "Software"
-    ],
-    "language": "Ruby",
-    "developer": [
-      {
-        "@id": "https://greggkellogg.net/foaf#me",
-        "@type": [
-          "Assertor",
-          "foaf:Person"
-        ],
-        "foaf:homepage": "https://greggkellogg.net/",
-        "foaf:name": "Gregg Kellogg"
-      }
-    ],
-    "homepage": "https://github.com/gkellogg/earl-report",
-    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
-    "license": "http://unlicense.org",
-    "release": {
-      "@id": "https://github.com/gkellogg/earl-report/tree/0.7.0",
-      "@type": "doap:Version",
-      "revision": "0.7.0",
-      "doap:created": {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2021-05-05"
-      },
-      "name": "earl-report-0.7.0"
-    },
-    "shortdesc": "Earl Report summary generator",
-    "name": "earl-report"
-  }
+  "name": "RDF-star"
 }

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -9,120 +9,74 @@
 
 <> a doap:Project, earl:Software ;
   dc:bibliographicCitation "[[rdf-star]]" ;
-  mf:report earl:ruby-trig.ttl,
-    earl:eye-earl.ttl,
-    earl:ruby-sparql.ttl ;
-  earl:testSubjects <https://josd.github.io/eye/>,
+  mf:report earl:jena-report-2021-06-06.ttl,
+    earl:ruby-trig.ttl,
+    earl:ruby-sparql.ttl,
+    earl:eye-earl.ttl ;
+  earl:generatedBy <https://rubygems.org/gems/earl-report> ;
+  earl:testSubjects <http://jena.apache.org/#jena>,
+    <https://josd.github.io/eye/>,
     <https://rubygems.org/gems/rdf-trig>,
     <https://rubygems.org/gems/sparql> ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#manifest>
+  mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#manifest>
     <https://w3c.github.io/rdf-star/tests/trig/syntax#manifest>
-    <https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#manifest>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#manifest>
     <https://w3c.github.io/rdf-star/tests/turtle/eval#manifest>
+    <https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#manifest>) ;
-  doap:name "RDF-star" ;
-  earl:generatedBy <https://rubygems.org/gems/earl-report> .
+    <https://w3c.github.io/rdf-star/tests/trig/eval#manifest>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#manifest>
+    <https://w3c.github.io/rdf-star/tests/semantics#manifest>) ;
+  doap:name "RDF-star" .
 
 # Manifests
-<https://w3c.github.io/rdf-star/tests/semantics#manifest> a earl:Report, mf:Manifest ;
-  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/semantics/README> ;
-  rdfs:label "RDF-star Semantics tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same>
-    <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail>
-    <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term>
-    <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri>
-    <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotation>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded>) .
+<https://w3c.github.io/rdf-star/tests/nt/syntax#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "N-Triples-star Syntax Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4>) .
 
-<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "all-identical-embedded-triples-are-the-same" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Multiple occurences of the same embedded triples are undistinguishable in the abstract model." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - subject embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "embedded-triples-no-spurious" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "This test ensures that other entailments are not spurious." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test005.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -130,71 +84,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "bnodes-in-embedded-subject" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - object embedded triple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "bnodes-in-embedded-object" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -202,71 +123,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "bnodes-in-embedded-subject-and-object" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - subject and object embedded triples" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "bnodes-in-embedded-subject-and-object-fail" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "The same bnode can not match different embedded terms." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -274,71 +162,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "same-bnode-same-embedded-term" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Identical embedded term can be replaced by the same fresh bnode multiple times." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - whitespace and terms" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "different-bnodes-same-embedded-term" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Different bnodes can match identical embedded terms." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -346,71 +201,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "constrained-bnodes-in-embedded-subject" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Nested, no whitespace" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "constrained-bnodes-in-embedded-object" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -418,71 +240,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "constrained-bnodes-in-embedded-fail" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Blank node subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "constrained-bnodes-on-literal" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Literals in embedded triples and outside can be replaced by fresh bnodes." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -490,107 +279,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "malformed-literal-control" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously." ;
-  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Blank node object" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "malformed-literal" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  rdfs:comment "Malformed literals are allowed when embedded." ;
-  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:failed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "malformed-literal-accepted" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  rdfs:comment "Malformed literals are allowed when embedded." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -598,107 +318,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "malformed-literal-no-spurious" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  rdfs:comment "Embedded malformed literals do not lead to spurious entailment." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Nested subject term" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:failed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "malformed-literal-bnode" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  rdfs:comment "Malformed literals can not be replaced by blank nodes." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "opaque-literal-control" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -706,143 +357,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "opaque-literal" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  rdfs:comment "Embedded literals are opaque, even when their datatype is recognized." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Nested object term" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:failed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "opaque-language-string-control" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "opaque-language-string" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Embedded literals (including language strings) are opaque, even when their datatype is recognized." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:failed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDFS-Plus" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "opaque-iri-control" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
-    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -850,35 +396,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDFS-Plus" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "opaque-iri" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Embedded IRIs are opaque." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/superman.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Bad - embedded triple as predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -886,35 +435,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> a earl:TestCriterion, mf:NegativeEntailmentTest, earl:TestCase ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "embedded-not-asserted" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Embedded triples are not asserted." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Bad - embedded triple, literal subject" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -922,35 +474,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "annotated-asserted" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Annotated triples are asserted." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Bad - embedded triple, literal predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -958,71 +513,38 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/semantics#annotation> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "annotation" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Annotation are about the annotated triple." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion ;
+  mf:name "N-Triples-star - Bad - embedded triple, blank node predicate" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
-    earl:subject <https://josd.github.io/eye/> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:name "annotation-unfolded" ;
-  mf:recognizedDatatypes () ;
-  rdfs:comment "Annotation is the same as separate assertions." ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
     earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
-    earl:assertedBy <https://josd.github.io/> ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -1055,12 +577,21 @@
     <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1>
     <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2>) .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - subject embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1085,12 +616,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - object embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1115,12 +655,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - embedded triple inside blankNodePropertyList" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1145,12 +694,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - embedded triple inside collection" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1175,12 +733,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - nested embedded triple, subject position" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1205,12 +772,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - nested embedded triple, object position" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1235,12 +811,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - compound forms" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1265,12 +850,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - blank node subject" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1295,12 +889,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - blank node object" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1325,12 +928,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - blank node" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1355,12 +967,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - embedded triple as predicate" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1385,12 +1006,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - embedded triple outside triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1415,12 +1045,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - collection list in embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1445,12 +1084,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - literal in subject position of embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1475,12 +1123,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - blank node  as predicate in embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1505,12 +1162,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - compound blank node expression" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1535,12 +1201,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - incomplete embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1565,12 +1240,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - over-long embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1595,12 +1279,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - Annotation form" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1625,12 +1318,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
   mf:name "TriG-star - Annotation example" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1655,12 +1357,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - empty annotation" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1685,10 +1396,19 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCriterion ;
   mf:name "TriG-star - bad - triple as annotation" ;
   mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig> ;
   earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
     earl:subject <https://josd.github.io/eye/> ;
@@ -1708,6 +1428,513 @@
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "Turtle-star Evaluation Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3>) .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - subject embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - object embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - blank node label" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - blank node labels" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation form" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation example" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation - predicate and object lists" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation - nested" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation object list" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation with embedding" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation on triple with embedded subject" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:name "Turtle-star - Annotation on triple with embedded object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -1753,12 +1980,21 @@
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4>) .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - subject embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1784,12 +2020,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - object embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1815,12 +2060,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - embedded triple inside blankNodePropertyList" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1846,12 +2100,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - embedded triple inside collection" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1877,12 +2140,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - nested embedded triple, subject position" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1908,12 +2180,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - nested embedded triple, object position" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1939,12 +2220,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - compound forms" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -1970,12 +2260,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - blank node subject" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2001,12 +2300,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - blank node object" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2032,12 +2340,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - blank node" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2063,12 +2380,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - embedded triple as predicate" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2094,12 +2420,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - embedded triple outside triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2125,12 +2460,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - collection list in embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2156,12 +2500,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - literal in subject position of embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2187,12 +2540,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - blank node  as predicate in embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2218,12 +2580,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - compound blank node expression" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2249,12 +2620,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - incomplete embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2280,12 +2660,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - over-long embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2311,12 +2700,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - Annotation form" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2342,12 +2740,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - Annotation example" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2373,12 +2780,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - empty annotation" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2404,12 +2820,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "Turtle-star - bad - triple as annotation" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2435,12 +2860,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - subject embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2466,12 +2900,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - object embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2497,12 +2940,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - subject and object embedded triples" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-3.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2528,12 +2980,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - whitespace and terms" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-4.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2558,12 +3019,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Nested, no whitespace" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-5.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2588,12 +3058,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Blank node subject" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2619,12 +3098,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Blank node object" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2650,12 +3138,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Nested subject term" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2681,12 +3178,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Nested object term" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2712,12 +3218,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Bad - embedded triple as predicate" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-1.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2743,12 +3258,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, literal subject" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-2.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2774,12 +3298,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-3.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2805,12 +3338,21 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCriterion ;
   mf:name "N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate" ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-4.ttl> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -2829,1883 +3371,6 @@
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#manifest> a earl:Report, mf:Manifest ;
-  rdfs:label "SPARQL-star Evaluation Tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3>) .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - all graph triples (JSON results)" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj> ;
-  mf:action _:b262 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - all graph triples (XML results)" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx> ;
-  mf:action _:b569 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - match constant embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj> ;
-  mf:action _:b1051 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - match embedded triple, var subject" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj> ;
-  mf:action _:b679 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - match embedded triple, var predicate" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj> ;
-  mf:action _:b17 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - match embedded triple, var object" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj> ;
-  mf:action _:b69 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - no match of embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj> ;
-  mf:action _:b50 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Asserted and embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj> ;
-  mf:action _:b212 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star -  Asserted and embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj> ;
-  mf:action _:b715 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Pattern - Variable for embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj> ;
-  mf:action _:b509 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Pattern - No match" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj> ;
-  mf:action _:b109 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Pattern - match variables in triple terms" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj> ;
-  mf:action _:b253 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Pattern - Nesting 1" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj> ;
-  mf:action _:b497 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Pattern - Nesting - 2" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj> ;
-  mf:action _:b496 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Pattern - Match and nesting" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj> ;
-  mf:action _:b12 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Pattern - Same variable" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj> ;
-  mf:action _:b241 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - CONSTRUCT with constant template" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl> ;
-  mf:action _:b197 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - CONSTRUCT WHERE with constant template" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl> ;
-  mf:action _:b0 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - CONSTRUCT - about every triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl> ;
-  mf:action _:b135 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - CONSTRUCT with annotation syntax" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl> ;
-  mf:action _:b278 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - CONSTRUCT WHERE with annotation syntax" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl> ;
-  mf:action _:b560 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - GRAPH" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj> ;
-  mf:action _:b23 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - GRAPHs with blank node" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj> ;
-  mf:action _:b553 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - BIND - CONSTRUCT" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl> ;
-  mf:action _:b370 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - Functions" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj> ;
-  mf:action _:b108 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - sameTerm" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-1.srj> ;
-  mf:action _:b191 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - value-equality" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-2.srj> ;
-  mf:action _:b186 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - value-inequality" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-3.srj> ;
-  mf:action _:b95 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - value-inequality" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-4.srj> ;
-  mf:action _:b124 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - ORDER BY" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj> ;
-  mf:action _:b753 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> a earl:TestCriterion, mf:QueryEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Embedded triple - ordering" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-2.srj> ;
-  mf:action _:b565 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Update" ;
-  mf:result _:b61 ;
-  mf:action _:b62 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Update - annotation" ;
-  mf:result _:b102 ;
-  mf:action _:b103 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> a earl:TestCriterion, mf:UpdateEvaluationTest, earl:TestCase ;
-  mf:name "SPARQL-star - Update - data" ;
-  mf:result _:b76 ;
-  mf:action _:b132 ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#manifest> a earl:Report, mf:Manifest ;
-  rdfs:label "TriG-star Evaluation Tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3>) .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - subject embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - object embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - blank node label" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - blank node labels" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation form" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation example" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation - predicate and object lists" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation - nested" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation object list" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation with embedding" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation on triple with embedded subject" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion, earl:TestCase ;
-  mf:name "TriG-star - Annotation on triple with embedded object" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.nq> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.trig> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#manifest> a earl:Report, mf:Manifest ;
-  rdfs:label "Turtle-star Evaluation Tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3>) .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - subject embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - object embedded triple" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - blank node label" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - blank node labels" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation form" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation example" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation - predicate and object lists" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation - nested" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation object list" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation with embedding" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-1.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation on triple with embedded subject" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-2.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleEval> ;
-  mf:name "Turtle-star - Annotation on triple with embedded object" ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.nt> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-embed-annotation-3.ttl> ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
-    earl:subject <https://josd.github.io/eye/> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://josd.github.io/> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -4779,12 +3444,21 @@
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4>) .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - subject embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4809,12 +3483,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - object embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4839,12 +3522,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - subject embedded triple - vars" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4869,12 +3561,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - object embedded triple - vars" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4899,12 +3600,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Embedded triple in VALUES" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4929,12 +3639,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Embedded triple in CONSTRUCT" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4959,12 +3678,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Embedded triples in CONSTRUCT WHERE" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -4989,12 +3717,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - embedded triple inside blankNodePropertyList" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5019,12 +3756,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - embedded triple inside collection" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5049,12 +3795,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - nested embedded triple, subject position" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5079,12 +3834,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - nested embedded triple, object position" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5109,12 +3873,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - compound forms" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5139,12 +3912,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - blank node subject" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5169,12 +3951,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - blank node object" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5199,12 +3990,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - blank node" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5229,12 +4029,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation form" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5259,12 +4068,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation example" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5289,12 +4107,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation example" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5319,12 +4146,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation with embedding" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5349,12 +4185,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation on triple with embedded object" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5379,12 +4224,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation with path" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5409,12 +4263,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation with nested path" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5439,12 +4302,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation in CONSTRUCT " ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5469,12 +4341,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Annotation in CONSTRUCT WHERE" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5499,12 +4380,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Expressions - Embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5529,12 +4419,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Expressions - Embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5559,12 +4458,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Expressions - Functions" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5589,12 +4497,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Expressions - TRIPLE" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5619,12 +4536,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Expressions - Functions" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5649,12 +4575,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> a earl:TestCriterion, mf:PositiveSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> a earl:TestCase, earl:TestCriterion, mf:PositiveSyntaxTest11 ;
   mf:name "SPARQL-star - Expressions - BIND - CONSTRUCT" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5679,12 +4614,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - embedded triple as predicate" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5709,12 +4653,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - embedded triple outside triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5739,12 +4692,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - collection list in embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5769,12 +4731,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - literal in subject position of embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5799,12 +4770,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - blank node  as predicate in embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5829,12 +4809,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - compound blank node expression" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5859,12 +4848,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - incomplete embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5889,12 +4887,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - quad embedded triple" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5919,12 +4926,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - variable in embedded triple in VALUES " ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5949,12 +4965,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - blank node in embedded triple in VALUES " ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -5979,12 +5004,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - blank node in embedded triple in FILTER" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-11.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6009,12 +5043,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - blank node in embedded triple in BIND" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-12.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6039,12 +5082,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - empty annotation" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6069,12 +5121,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - triples in annotation" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6099,12 +5160,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - path - seq" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6129,12 +5199,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - path - alt" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6159,12 +5238,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - path - p*" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6189,12 +5277,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - path - p+" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6219,12 +5316,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - path - p?" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6249,12 +5355,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - path in CONSTRUCT" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6279,12 +5394,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> a earl:TestCase, mf:NegativeSyntaxTest11, earl:TestCriterion ;
   mf:name "SPARQL-star - bad - path in CONSTRUCT" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6309,12 +5433,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6339,12 +5472,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6369,12 +5511,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6399,12 +5550,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update with embedding" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6429,12 +5589,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update with embedded object" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6459,12 +5628,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update with annotation template" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6489,12 +5667,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update with annotation, template and pattern" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6519,12 +5706,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update DATA with annotation" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6549,12 +5745,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> a earl:TestCriterion, earl:TestCase, mf:NegativeUpdateSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update - bad syntax" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6579,12 +5784,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> a earl:TestCriterion, earl:TestCase, mf:NegativeUpdateSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update - bad syntax" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6609,12 +5823,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> a earl:TestCriterion, earl:TestCase, mf:NegativeUpdateSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update - bad syntax" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6639,12 +5862,21 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> a earl:TestCriterion, earl:TestCase, mf:NegativeUpdateSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:name "SPARQL-star - update - bad syntax" ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru> ;
   earl:assertions [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6669,28 +5901,37 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#manifest> a earl:Report, mf:Manifest ;
-  rdfs:label "N-Triples-star Syntax Tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4>) .
+<https://w3c.github.io/rdf-star/tests/trig/eval#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "TriG-star Evaluation Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3>) .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - subject embedded triple" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - subject embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6698,7 +5939,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6707,7 +5948,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6715,12 +5956,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - object embedded triple" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - object embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6728,7 +5979,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6737,7 +5988,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6745,12 +5996,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - subject and object embedded triples" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - blank node label" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6758,7 +6019,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6767,7 +6028,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6775,12 +6036,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - whitespace and terms" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - blank node labels" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6788,7 +6059,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6797,7 +6068,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6805,12 +6076,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - Nested, no whitespace" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation form" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6818,7 +6099,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6827,7 +6108,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6835,12 +6116,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - Blank node subject" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation example" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6848,7 +6139,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6857,7 +6148,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6865,12 +6156,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - Blank node object" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation - predicate and object lists" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6878,7 +6179,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6887,7 +6188,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6895,12 +6196,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - Nested subject term" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation - nested" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6908,7 +6219,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6917,7 +6228,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6925,12 +6236,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> a earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase ;
-  mf:name "N-Triples-star - Nested object term" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation object list" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6938,7 +6259,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6947,7 +6268,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6955,12 +6276,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> a <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:name "N-Triples-star - Bad - embedded triple as predicate" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation with embedding" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-1.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6968,7 +6299,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -6977,7 +6308,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -6985,12 +6316,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> a <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:name "N-Triples-star - Bad - embedded triple, literal subject" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation on triple with embedded subject" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-2.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -6998,7 +6339,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -7007,7 +6348,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -7015,12 +6356,22 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> a <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:name "N-Triples-star - Bad - embedded triple, literal predicate" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt> ;
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:name "TriG-star - Annotation on triple with embedded object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.nq> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-embed-annotation-3.trig> ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -7028,7 +6379,7 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
     earl:result [
       a earl:TestResult ;
@@ -7037,7 +6388,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
@@ -7045,12 +6396,59 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> a <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:name "N-Triples-star - Bad - embedded triple, blank node predicate" ;
-  mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt> ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "SPARQL-star Evaluation Tests" ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3>) .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - all graph triples (JSON results)" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj> ;
+  mf:action _:b624 ;
   earl:assertions [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
     earl:subject <https://josd.github.io/eye/> ;
     earl:result [
       a earl:TestResult ;
@@ -7058,56 +6456,2606 @@
     ] ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
     earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:passed
     ] ;
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - all graph triples (XML results)" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx> ;
+  mf:action _:b92 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
   ], [
     a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - match constant embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj> ;
+  mf:action _:b124 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - match embedded triple, var subject" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj> ;
+  mf:action _:b979 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - match embedded triple, var predicate" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj> ;
+  mf:action _:b735 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - match embedded triple, var object" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj> ;
+  mf:action _:b351 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - no match of embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj> ;
+  mf:action _:b449 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Asserted and embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj> ;
+  mf:action _:b219 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star -  Asserted and embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj> ;
+  mf:action _:b174 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Pattern - Variable for embedded triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj> ;
+  mf:action _:b0 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Pattern - No match" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj> ;
+  mf:action _:b255 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Pattern - match variables in triple terms" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj> ;
+  mf:action _:b109 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Pattern - Nesting 1" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj> ;
+  mf:action _:b461 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Pattern - Nesting - 2" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj> ;
+  mf:action _:b368 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Pattern - Match and nesting" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj> ;
+  mf:action _:b523 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Pattern - Same variable" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj> ;
+  mf:action _:b584 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - CONSTRUCT with constant template" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl> ;
+  mf:action _:b364 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - CONSTRUCT WHERE with constant template" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl> ;
+  mf:action _:b430 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - CONSTRUCT - about every triple" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl> ;
+  mf:action _:b468 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - CONSTRUCT with annotation syntax" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl> ;
+  mf:action _:b97 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - CONSTRUCT WHERE with annotation syntax" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl> ;
+  mf:action _:b307 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - GRAPH" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj> ;
+  mf:action _:b1066 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - GRAPHs with blank node" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj> ;
+  mf:action _:b4 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - BIND - CONSTRUCT" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl> ;
+  mf:action _:b642 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - Functions" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj> ;
+  mf:action _:b165 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - sameTerm" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-1.srj> ;
+  mf:action _:b755 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - value-equality" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-2.srj> ;
+  mf:action _:b259 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - value-inequality" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-3.srj> ;
+  mf:action _:b278 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - value-inequality" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-4.srj> ;
+  mf:action _:b194 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - ORDER BY" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj> ;
+  mf:action _:b404 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> a mf:QueryEvaluationTest, earl:TestCase, earl:TestCriterion ;
+  mf:name "SPARQL-star - Embedded triple - ordering" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-2.srj> ;
+  mf:action _:b326 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> a earl:TestCase, mf:UpdateEvaluationTest, earl:TestCriterion ;
+  mf:name "SPARQL-star - Update" ;
+  mf:result _:b117 ;
+  mf:action _:b118 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> a earl:TestCase, mf:UpdateEvaluationTest, earl:TestCriterion ;
+  mf:name "SPARQL-star - Update - annotation" ;
+  mf:result _:b303 ;
+  mf:action _:b304 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> a earl:TestCase, mf:UpdateEvaluationTest, earl:TestCriterion ;
+  mf:name "SPARQL-star - Update - data" ;
+  mf:result _:b95 ;
+  mf:action _:b96 ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <http://jena.apache.org/#jena> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#manifest> a earl:Report, mf:Manifest ;
+  rdfs:label "RDF-star Semantics tests" ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/semantics/README> ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same>
+    <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail>
+    <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term>
+    <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri>
+    <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotation>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded>) .
+
+<https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl> ;
+  rdfs:comment "Multiple occurences of the same embedded triples are undistinguishable in the abstract model." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "all-identical-embedded-triples-are-the-same" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-embedded-triples-are-the-same> ;
     earl:subject <https://rubygems.org/gems/sparql> ;
     earl:result [
       a earl:TestResult ;
       earl:outcome earl:untested
     ] ;
   ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test005.ttl> ;
+  rdfs:comment "This test ensures that other entailments are not spurious." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "embedded-triples-no-spurious" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-triples-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl> ;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-embedded-subject" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-embedded-object" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-object> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
+  rdfs:comment "Terms in embedded triples can be replaced by fresh bnodes." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-embedded-subject-and-object" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
+  rdfs:comment "The same bnode can not match different embedded terms." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-embedded-subject-and-object-fail" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-embedded-subject-and-object-fail> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
+  rdfs:comment "Identical embedded term can be replaced by the same fresh bnode multiple times." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "same-bnode-same-embedded-term" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-embedded-term> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
+  rdfs:comment "Different bnodes can match identical embedded terms." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "different-bnodes-same-embedded-term" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-embedded-term> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl> ;
+  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes" ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-in-embedded-subject" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-subject> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl> ;
+  rdfs:comment "Terms in embedded triples and outside can be replaced by fresh bnodes." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-in-embedded-object" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-object> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl> ;
+  rdfs:comment "Embedded bnode identifiers share the same scope as non-embedded ones. A bnode occuring both in embedded triples and in asserted triples must statisfy them all at the same time." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-in-embedded-fail" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-embedded-fail> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl> ;
+  rdfs:comment "Literals in embedded triples and outside can be replaced by fresh bnodes." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-on-literal" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-control" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+  rdfs:comment "Malformed literals are allowed when embedded." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:failed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  rdfs:comment "Malformed literals are allowed when embedded." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-accepted" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl> ;
+  rdfs:comment "Embedded malformed literals do not lead to spurious entailment." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-no-spurious" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:failed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
+  rdfs:comment "Malformed literals can not be replaced by blank nodes." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-bnode" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl> ;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-literal-control" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl> ;
+  rdfs:comment "Embedded literals are opaque, even when their datatype is recognized." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-literal" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:failed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl> ;
+  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-language-string-control" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDF" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl> ;
+  rdfs:comment "Embedded literals (including language strings) are opaque, even when their datatype is recognized." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-language-string" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:failed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "RDFS-Plus" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl> ;
+  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-iri-control" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "RDFS-Plus" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/superman.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl> ;
+  rdfs:comment "Embedded IRIs are opaque." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-iri" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl> ;
+  rdfs:comment "Embedded triples are not asserted." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "embedded-not-asserted" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#embedded-not-asserted> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl> ;
+  rdfs:comment "Annotated triples are asserted." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "annotated-asserted" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#annotation> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl> ;
+  rdfs:comment "Annotation are about the annotated triple." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "annotation" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  mf:entailmentRegime "simple" ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  rdfs:comment "Annotation is the same as separate assertions." ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "annotation-unfolded" ;
+  mf:recognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:subject <http://jena.apache.org/#jena> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:subject <https://josd.github.io/eye/> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://josd.github.io/> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<http://jena.apache.org/#jena> a earl:TestSubject, doap:Project, earl:Software ;
+  doap:developer _:b16 ;
+  doap:homepage <http://jena.apache.org/> ;
+  doap:release [doap:revision "4.1.0"] ;
+  doap:description "Apache Jena : RDF system and SPARQL triple store"@en ;
+  doap:name "Apache Jena" .
+
+_:b16 a foaf:Agent ;
+  foaf:homepage <http://jena.apache.org/> ;
+  foaf:name "Apache Jena Community" .
 
 <https://josd.github.io/eye/> a earl:TestSubject, doap:Project, earl:Software ;
-  doap:programming-language "Prolog" ;
   doap:developer <https://josd.github.io/> ;
+  doap:programming-language "Prolog" ;
   doap:homepage <https://josd.github.io/eye/index.html> ;
-  doap:description "Euler Yet another proof Engine"@en ;
   doap:release [doap:revision "EYE v21.0530.2141 josd"] ;
+  doap:description "Euler Yet another proof Engine"@en ;
   doap:name "EYE" .
 
-<https://josd.github.io/> a earl:Assertor, foaf:Person ;
+<https://josd.github.io/> a foaf:Person, earl:Assertor ;
   foaf:homepage <https://josd.github.io/> ;
   foaf:name "Jos De Roo" .
 
 <https://rubygems.org/gems/rdf-trig> a earl:TestSubject, doap:Project, earl:Software ;
-  doap:programming-language "Ruby" ;
   doap:developer <https://greggkellogg.net/foaf#me> ;
+  doap:programming-language "Ruby" ;
   doap:homepage <https://github.com/ruby-rdf/rdf-trig> ;
-  doap:description "TriG reader/writer for RDF.rb" ;
   doap:release [doap:revision "3.1.2"] ;
+  doap:description "TriG reader/writer for RDF.rb" ;
   doap:name "RDF::TriG" .
 
-<https://greggkellogg.net/foaf#me> a earl:Assertor, foaf:Person ;
+<https://greggkellogg.net/foaf#me> a foaf:Person, earl:Assertor ;
   foaf:homepage <https://greggkellogg.net/> ;
   foaf:name "Gregg Kellogg" .
 
 <https://rubygems.org/gems/sparql> a earl:TestSubject, doap:Project, earl:Software ;
-  doap:programming-language "Ruby" ;
   doap:developer <https://greggkellogg.net/foaf#me> ;
+  doap:programming-language "Ruby" ;
   doap:homepage <https://github.com/ruby-rdf/sparql> ;
-  doap:description "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite."@en ;
   doap:release [doap:revision "3.1.7"] ;
+  doap:description "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite."@en ;
   doap:name "Ruby SPARQL" .
 
-<https://greggkellogg.net/foaf#me> a earl:Assertor, foaf:Person ;
+<https://greggkellogg.net/foaf#me> a foaf:Person, earl:Assertor ;
   foaf:homepage <https://greggkellogg.net/> ;
   foaf:name "Gregg Kellogg" .
 
@@ -7125,5 +9073,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.7.0> a doap:Version;
   doap:name "earl-report-0.7.0";
-  doap:created "2021-05-05"^^xsd:date;
+  doap:created "2021-04-09"^^xsd:date;
   doap:revision "0.7.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -5,9 +5,10 @@
 <link href='earl.ttl' rel='alternate' type='text/turtle' />
 <link href='earl.jsonld' rel='alternate' type='application/ld+json' />
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
+<link href='jena-report-2021-06-06.ttl' rel='related' />
 <link href='ruby-trig.ttl' rel='related' />
-<link href='eye-earl.ttl' rel='related' />
 <link href='ruby-sparql.ttl' rel='related' />
+<link href='eye-earl.ttl' rel='related' />
 <title>
 RDF-star Processor Conformance
 </title>
@@ -94,8 +95,8 @@ RDF-star Processor Conformance
 EARL results from the RDF-star Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2021-06-05' property='dc:issued'>
-05 June 2021
+<time class='dt-published' datetime='2021-06-06' property='dc:issued'>
+06 June 2021
 </time>
 </h2>
 <dl>
@@ -234,20 +235,26 @@ Test Subjects
 <ul class='toc'>
 <li class='tocline'>
 <span class='secno'>A.1</span>
+<a class='tocxref' href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
+</li>
+<li class='tocline'>
+<span class='secno'>A.2</span>
 <a class='tocxref' href='#subj_EYE_Prolog'>
 EYE
  (Prolog)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.2</span>
+<span class='secno'>A.3</span>
 <a class='tocxref' href='#subj_RDF_TriG_Ruby'>
 RDF::TriG
  (Ruby)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.3</span>
+<span class='secno'>A.4</span>
 <a class='tocxref' href='#subj_Ruby_SPARQL_Ruby'>
 Ruby SPARQL
  (Ruby)
@@ -333,6 +340,11 @@ Test Manifests
 Test
 </th>
 <th>
+<a href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
+</th>
+<th>
 <a href='#subj_RDF_TriG_Ruby'>
 RDF::TriG
 <br />
@@ -347,10 +359,16 @@ RDF::TriG
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2'>Test ntriples-star-2: N-Triples-star - object embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -363,10 +381,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4'>Test ntriples-star-4: N-Triples-star - whitespace and terms</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -379,10 +403,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1'>Test ntriples-star-bnode-1: N-Triples-star - Blank node subject</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -395,10 +425,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1'>Test ntriples-star-nested-1: N-Triples-star - Nested subject term</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -411,10 +447,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1'>Test ntriples-star-bad-1: N-Triples-star - Bad - embedded triple as predicate</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -427,10 +469,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3'>Test ntriples-star-bad-3: N-Triples-star - Bad - embedded triple, literal predicate</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -443,10 +491,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 13 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -709,6 +763,11 @@ Percentage passed out of 27 Tests
 Test
 </th>
 <th>
+<a href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
+</th>
+<th>
 <a href='#subj_Ruby_SPARQL_Ruby'>
 Ruby SPARQL
 <br />
@@ -723,10 +782,16 @@ Ruby SPARQL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x'>Test sparql-star-results-1x: SPARQL-star - all graph triples (XML results)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -739,10 +804,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3'>Test sparql-star-basic-3: SPARQL-star - match embedded triple, var subject</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -755,10 +826,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5'>Test sparql-star-basic-5: SPARQL-star - match embedded triple, var object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -771,10 +848,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1'>Test sparql-star-pattern-1: SPARQL-star - Asserted and embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -787,10 +870,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3'>Test sparql-star-pattern-3: SPARQL-star - Pattern - Variable for embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -803,10 +892,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5'>Test sparql-star-pattern-5: SPARQL-star - Pattern - match variables in triple terms</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -819,10 +914,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7'>Test sparql-star-pattern-7: SPARQL-star - Pattern - Nesting - 2</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -835,10 +936,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9'>Test sparql-star-pattern-9: SPARQL-star - Pattern - Same variable</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -851,10 +958,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2'>Test sparql-star-construct-2: SPARQL-star - CONSTRUCT WHERE with constant template</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -867,10 +980,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4'>Test sparql-star-construct-4: SPARQL-star - CONSTRUCT with annotation syntax</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -883,10 +1002,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1'>Test sparql-star-graphs-1: SPARQL-star - GRAPH</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -899,10 +1024,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1'>Test sparql-star-expr-1: SPARQL-star - Embedded triple - BIND - CONSTRUCT</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -915,10 +1046,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1'>Test sparql-star-op-1: SPARQL-star - Embedded triple - sameTerm</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -931,10 +1068,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3'>Test sparql-star-op-3: SPARQL-star - Embedded triple - value-inequality</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -947,10 +1090,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1'>Test sparql-star-order-1: SPARQL-star - Embedded triple - ORDER BY</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -963,10 +1112,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1'>Test sparql-star-update-1: SPARQL-star - Update</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -979,6 +1134,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -987,10 +1145,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 34 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -1009,6 +1173,11 @@ Percentage passed out of 34 Tests
 Test
 </th>
 <th>
+<a href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
+</th>
+<th>
 <a href='#subj_Ruby_SPARQL_Ruby'>
 Ruby SPARQL
 <br />
@@ -1023,10 +1192,16 @@ Ruby SPARQL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2'>Test sparql-star-2: SPARQL-star - object embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1039,10 +1214,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4'>Test sparql-star-4: SPARQL-star - object embedded triple - vars</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1055,10 +1236,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6'>Test sparql-star-6: SPARQL-star - Embedded triple in CONSTRUCT</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1071,10 +1258,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1'>Test sparql-star-inside-1: SPARQL-star - embedded triple inside blankNodePropertyList</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1087,10 +1280,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1'>Test sparql-star-nested-1: SPARQL-star - nested embedded triple, subject position</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1103,10 +1302,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1'>Test sparql-star-compound-1: SPARQL-star - compound forms</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1119,10 +1324,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2'>Test sparql-star-bnode-2: SPARQL-star - blank node object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1135,10 +1346,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01'>Test sparql-star-ann-01: SPARQL-star - Annotation form</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1151,10 +1368,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03'>Test sparql-star-ann-03: SPARQL-star - Annotation example</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1167,10 +1390,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05'>Test sparql-star-ann-05: SPARQL-star - Annotation on triple with embedded object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1183,10 +1412,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07'>Test sparql-star-ann-07: SPARQL-star - Annotation with nested path</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1199,10 +1434,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09'>Test sparql-star-ann-09: SPARQL-star - Annotation in CONSTRUCT WHERE</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1215,10 +1456,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2'>Test sparql-star-expr-2: SPARQL-star - Expressions - Embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1231,10 +1478,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4'>Test sparql-star-expr-4: SPARQL-star - Expressions - TRIPLE</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1247,10 +1500,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6'>Test sparql-star-expr-6: SPARQL-star - Expressions - BIND - CONSTRUCT</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1263,10 +1522,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2'>Test sparql-star-bad-2: SPARQL-star - bad - embedded triple outside triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1279,10 +1544,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4'>Test sparql-star-bad-4: SPARQL-star - bad - literal in subject position of embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1295,10 +1566,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6'>Test sparql-star-bad-6: SPARQL-star - bad - compound blank node expression</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1311,10 +1588,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8'>Test sparql-star-bad-8: SPARQL-star - bad - quad embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1327,10 +1610,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10'>Test sparql-star-bad-10: SPARQL-star - bad - blank node in embedded triple in VALUES </a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1343,10 +1632,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12'>Test sparql-star-bad-12: SPARQL-star - bad - blank node in embedded triple in BIND</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1359,10 +1654,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2'>Test sparql-star-bad-ann-2: SPARQL-star - bad - triples in annotation</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1375,10 +1676,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2'>Test sparql-star-bad-ann-path-2: SPARQL-star - bad - path - alt</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1391,10 +1698,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4'>Test sparql-star-bad-ann-path-4: SPARQL-star - bad - path - p+</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1407,10 +1720,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6'>Test sparql-star-bad-ann-path-6: SPARQL-star - bad - path in CONSTRUCT</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1423,10 +1742,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1'>Test sparql-star-update-1: SPARQL-star - update</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1439,10 +1764,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3'>Test sparql-star-update-3: SPARQL-star - update</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1455,10 +1786,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5'>Test sparql-star-update-5: SPARQL-star - update with embedded object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1471,10 +1808,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7'>Test sparql-star-update-7: SPARQL-star - update with annotation, template and pattern</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1487,10 +1830,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1'>Test sparql-star-bad-update-1: SPARQL-star - update - bad syntax</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1503,10 +1852,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3'>Test sparql-star-bad-update-3: SPARQL-star - update - bad syntax</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1519,10 +1874,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 63 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -1541,6 +1902,11 @@ Percentage passed out of 63 Tests
 Test
 </th>
 <th>
+<a href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
+</th>
+<th>
 <a href='#subj_RDF_TriG_Ruby'>
 RDF::TriG
 <br />
@@ -1555,10 +1921,16 @@ RDF::TriG
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2'>Test trig-star-2: TriG-star - object embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1571,10 +1943,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2'>Test trig-star-bnode-2: TriG-star - blank node labels</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1587,10 +1965,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2'>Test trig-star-annotation-2: TriG-star - Annotation example</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1603,10 +1987,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4'>Test trig-star-annotation-4: TriG-star - Annotation - nested</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1619,10 +2009,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1'>Test trig-star-embed-annotation-1: TriG-star - Annotation with embedding</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1635,6 +2031,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1643,10 +2042,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 12 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -1665,6 +2070,11 @@ Percentage passed out of 12 Tests
 Test
 </th>
 <th>
+<a href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
+</th>
+<th>
 <a href='#subj_RDF_TriG_Ruby'>
 RDF::TriG
 <br />
@@ -1679,10 +2089,16 @@ RDF::TriG
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2'>Test trig-star-2: TriG-star - object embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1695,10 +2111,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2'>Test trig-star-inside-2: TriG-star - embedded triple inside collection</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1711,10 +2133,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2'>Test trig-star-nested-2: TriG-star - nested embedded triple, object position</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1727,10 +2155,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1'>Test trig-star-bnode-1: TriG-star - blank node subject</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1743,10 +2177,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3'>Test trig-star-bnode-3: TriG-star - blank node</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1759,10 +2199,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2'>Test trig-star-bad-2: TriG-star - bad - embedded triple outside triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1775,10 +2221,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4'>Test trig-star-bad-4: TriG-star - bad - literal in subject position of embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1791,10 +2243,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6'>Test trig-star-bad-6: TriG-star - bad - compound blank node expression</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1807,10 +2265,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8'>Test trig-star-bad-8: TriG-star - bad - over-long embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1823,10 +2287,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2'>Test trig-star-ann-2: TriG-star - Annotation example</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1839,6 +2309,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1847,10 +2320,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 22 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -1867,6 +2346,11 @@ Percentage passed out of 22 Tests
 <tr>
 <th>
 Test
+</th>
+<th>
+<a href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
 </th>
 <th>
 <a href='#subj_EYE_Prolog'>
@@ -1893,10 +2377,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2'>Test turtle-star-2: Turtle-star - object embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1915,10 +2405,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2'>Test turtle-star-bnode-2: Turtle-star - blank node labels</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1937,10 +2433,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2'>Test turtle-star-annotation-2: Turtle-star - Annotation example</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1959,10 +2461,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4'>Test turtle-star-annotation-4: Turtle-star - Annotation - nested</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1981,10 +2489,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1'>Test turtle-star-embed-annotation-1: Turtle-star - Annotation with embedding</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2003,6 +2517,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -2014,10 +2531,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 12 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -2037,6 +2560,11 @@ Percentage passed out of 12 Tests
 <tr>
 <th>
 Test
+</th>
+<th>
+<a href='#subj_Apache_Jena_'>
+Apache Jena
+</a>
 </th>
 <th>
 <a href='#subj_EYE_Prolog'>
@@ -2063,10 +2591,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2'>Test turtle-star-2: Turtle-star - object embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2085,10 +2619,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2'>Test turtle-star-inside-2: Turtle-star - embedded triple inside collection</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2107,10 +2647,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2'>Test turtle-star-nested-2: Turtle-star - nested embedded triple, object position</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2129,10 +2675,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1'>Test turtle-star-bnode-1: Turtle-star - blank node subject</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2151,10 +2703,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3'>Test turtle-star-bnode-3: Turtle-star - blank node</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2167,6 +2725,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1'>Test turtle-star-bad-1: Turtle-star - bad - embedded triple as predicate</a>
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -2177,6 +2738,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2'>Test turtle-star-bad-2: Turtle-star - bad - embedded triple outside triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='FAIL'>
 FAIL
@@ -2189,6 +2753,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3'>Test turtle-star-bad-3: Turtle-star - bad - collection list in embedded triple</a>
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -2200,6 +2767,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4'>Test turtle-star-bad-4: Turtle-star - bad - literal in subject position of embedded triple</a>
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -2210,6 +2780,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5'>Test turtle-star-bad-5: Turtle-star - bad - blank node  as predicate in embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='FAIL'>
 FAIL
@@ -2228,10 +2801,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7'>Test turtle-star-bad-7: Turtle-star - bad - incomplete embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2250,10 +2829,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1'>Test turtle-star-ann-1: Turtle-star - Annotation form</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2272,10 +2857,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1'>Test turtle-star-bad-ann-1: Turtle-star - bad - empty annotation</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2294,10 +2885,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1'>Test nt-ttl-star-1: N-Triples-star as Turtle-star - subject embedded triple</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2316,10 +2913,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3'>Test nt-ttl-star-3: N-Triples-star as Turtle-star - subject and object embedded triples</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2332,6 +2935,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4'>Test nt-ttl-star-4: N-Triples-star as Turtle-star - whitespace and terms</a>
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -2342,6 +2948,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5'>Test nt-ttl-star-5: N-Triples-star as Turtle-star - Nested, no whitespace</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -2360,10 +2969,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2'>Test nt-ttl-star-bnode-2: N-Triples-star as Turtle-star - Blank node object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2382,10 +2997,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2'>Test nt-ttl-star-nested-2: N-Triples-star as Turtle-star - Nested object term</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2398,6 +3019,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1'>Test nt-ttl-star-bad-1: N-Triples-star as Turtle-star - Bad - embedded triple as predicate</a>
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -2408,6 +3032,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2'>Test nt-ttl-star-bad-2: N-Triples-star as Turtle-star - Bad - embedded triple, literal subject</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='FAIL'>
 FAIL
@@ -2420,6 +3047,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3'>Test nt-ttl-star-bad-3: N-Triples-star as Turtle-star - Bad - embedded triple, literal predicate</a>
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -2431,6 +3061,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4'>Test nt-ttl-star-bad-4: N-Triples-star as Turtle-star - Bad - embedded triple, blank node predicate</a>
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -2441,6 +3074,9 @@ PASS
 <tr class='summary'>
 <td>
 Percentage passed out of 35 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-some'>
 68.6%
@@ -2461,8 +3097,102 @@ Test Subjects
 This report was tested using the following test subjects:
 </p>
 <dl>
-<dt id='subj_EYE_Prolog'>
+<dt id='subj_Apache_Jena_'>
 <span class='secno'>A.1</span>
+<a href='http://jena.apache.org/#jena'>
+<span about='http://jena.apache.org/#jena' property='doap:name'>Apache Jena</span>
+</a>
+</dt>
+<dd>
+<dl>
+<dt>Description</dt>
+<dd lang='en' property='doap:description'>Apache Jena : RDF system and SPARQL triple store</dd>
+<dt>Release</dt>
+<dd property='doap:release'><span property='doap:revision'>4.1.0</span></dd>
+<dt>Home Page</dt>
+<dd>
+<a href='http://jena.apache.org/' property='doap:homepage'>
+http://jena.apache.org/
+</a>
+</dd>
+<dt>Developer</dt>
+<dd rel='doap:developer'>
+<div>
+<span property='foaf:name'>Apache Jena Community</span>
+<a href='http://jena.apache.org/' property='foaf:homepage'>
+http://jena.apache.org/
+</a>
+</div>
+</dd>
+<dt>
+Test Suite Compliance
+</dt>
+<dd>
+<table class='report'>
+<tbody>
+<tr>
+<td>
+N-Triples-star Syntax Tests
+</td>
+<td class='passed-all'>
+13/13 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+SPARQL-star Evaluation Tests
+</td>
+<td class='passed-all'>
+34/34 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+SPARQL-star Syntax Tests
+</td>
+<td class='passed-all'>
+63/63 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+TriG-star Evaluation Tests
+</td>
+<td class='passed-all'>
+12/12 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+TriG-star Syntax Tests
+</td>
+<td class='passed-all'>
+22/22 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+Turtle-star Evaluation Tests
+</td>
+<td class='passed-all'>
+12/12 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+Turtle-star Syntax Tests
+</td>
+<td class='passed-all'>
+35/35 (100.0%)
+</td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+</dd>
+<dt id='subj_EYE_Prolog'>
+<span class='secno'>A.2</span>
 <a href='https://josd.github.io/eye/'>
 <span about='https://josd.github.io/eye/' property='doap:name'>EYE</span>
 </a>
@@ -2487,7 +3217,7 @@ https://josd.github.io/eye/index.html
 <a href='https://josd.github.io/'>
 <span property='foaf:name'>Jos De Roo</span>
 </a>
-<a href-@id='https://josd.github.io/' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://josd.github.io/' href-foaf:name='Jos De Roo' property='foaf:homepage'>
+<a href-@id='https://josd.github.io/' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://josd.github.io/' href-foaf:name='Jos De Roo' property='foaf:homepage'>
 https://josd.github.io/
 </a>
 </div>
@@ -2528,7 +3258,7 @@ Turtle-star Syntax Tests
 </dl>
 </dd>
 <dt id='subj_RDF_TriG_Ruby'>
-<span class='secno'>A.2</span>
+<span class='secno'>A.3</span>
 <a href='https://rubygems.org/gems/rdf-trig'>
 <span about='https://rubygems.org/gems/rdf-trig' property='doap:name'>RDF::TriG</span>
 </a>
@@ -2608,7 +3338,7 @@ Turtle-star Syntax Tests
 </dl>
 </dd>
 <dt id='subj_Ruby_SPARQL_Ruby'>
-<span class='secno'>A.3</span>
+<span class='secno'>A.4</span>
 <a href='https://rubygems.org/gems/sparql'>
 <span about='https://rubygems.org/gems/sparql' property='doap:name'>Ruby SPARQL</span>
 </a>
@@ -2677,13 +3407,16 @@ Individual test results used to construct this report are available here:
 </p>
 <ul>
 <li>
+<a class='source' href='jena-report-2021-06-06.ttl'>jena-report-2021-06-06.ttl</a>
+</li>
+<li>
 <a class='source' href='ruby-trig.ttl'>ruby-trig.ttl</a>
 </li>
 <li>
-<a class='source' href='eye-earl.ttl'>eye-earl.ttl</a>
+<a class='source' href='ruby-sparql.ttl'>ruby-sparql.ttl</a>
 </li>
 <li>
-<a class='source' href='ruby-sparql.ttl'>ruby-sparql.ttl</a>
+<a class='source' href='eye-earl.ttl'>eye-earl.ttl</a>
 </li>
 </ul>
 </section>

--- a/reports/jena-report-2021-06-06.ttl
+++ b/reports/jena-report-2021-06-06.ttl
@@ -1,0 +1,2140 @@
+# Apache Jena EARL Report
+PREFIX dawg: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+PREFIX dct:  <http://purl.org/dc/terms/>
+PREFIX doap: <http://usefulinc.com/ns/doap#>
+PREFIX earl: <http://www.w3.org/ns/earl#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdft: <http://www.w3.org/ns/rdftest#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-embed-annotation-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-embed-annotation-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05>
+] .
+
+[ rdf:type         earl:Assertion ;
+  earl:assertedBy  <http://jena.apache.org/#jena> ;
+  earl:mode        earl:automatic ;
+  earl:result      [ rdf:type      earl:TestResult ;
+                     dc:date       "2021-06-06+01:00"^^xsd:date ;
+                     earl:outcome  earl:passed
+                   ] ;
+  earl:subject     <http://jena.apache.org/#jena> ;
+  earl:test        <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2>
+] .
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX doap:   <http://usefulinc.com/ns/doap#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX earl:   <http://www.w3.org/ns/earl#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX dc:     <http://purl.org/dc/elements/1.1/>
+
+<http://jena.apache.org/#jena>
+        rdf:type          doap:Project ;
+        dc:creator        _:b-agent ;
+        dc:title          "Apache Jena" ;
+        doap:description  "Apache Jena : RDF system and SPARQL triple store"@en ;
+        doap:developer    _:b-agent ;
+        doap:homepage     <http://jena.apache.org/> ;
+        doap:maintainer   _:b-agent ;
+        doap:name         "Apache Jena" ;
+        doap:release      [ rdf:type       doap:Version ;
+                            doap:created   "2021-06-05+01:00"^^xsd:date ;
+                            doap:homepage  <http://jena.apache.org/> ;
+                            doap:revision  "4.1.0"
+                          ] ;
+        doap:shortdesc    "RDF and SPARQL triple store"@en .
+
+_:b-agent
+        rdf:type       foaf:Agent ;
+        foaf:homepage  <http://jena.apache.org/> ;
+        foaf:name      "Apache Jena Community" .


### PR DESCRIPTION
includes rebuilt `index.html` and `earl.*`.
