### PR TITLE
Trig-star productions

### DIFF
--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -881,7 +881,7 @@ INSERT {
 
       <p>An <dfn>N-Triples-star document</dfn> defines an <a>RDF-star graph</a>
         composed of a set of <a>RDF-star triples</a>.
-        The <a href="N-TRIPLES#grammar-production-triple">`triple`</a> production
+        The <a data-cite="N-TRIPLES#grammar-production-triple">`triple`</a> production
         produces an <a>RDF-star triple</a>
         composed of a <a href="#grammar-production-nt-subject">`subject`</a>,
         <a data-cite="N-TRIPLES#grammar-production-predicate">`predicate`</a>,
@@ -2376,7 +2376,7 @@ style="color:black;font-weight:bold">sameTerm</code></dfn></b>
        <p>
         The result of a SPARQL SELECT query is serialized in XML as defined in [[[RDF-SPARQL-XMLRES]]]. This format proposes an XML representation of variable bindings to RDF terms.
        </p>
-       <p>To accommodate the new RDF term for <a>embedded</a> triples that RDF-star introduces, the list of RDF terms and their XML representations in [<a href="rdf-sparql-XMLres#results">rdf-sparql-XMLres, Section 2.3.1</a>] is extended as follows:
+       <p>To accommodate the new RDF term for <a>embedded</a> triples that RDF-star introduces, the list of RDF terms and their XML representations in [<a data-cite="RDF-SPARQL-XMLRES#results">RDF-SPARQL-XMLRES Section 2.3.1</a>] is extended as follows:
         </p>
         <p>
         <dl>
@@ -2769,7 +2769,7 @@ style="color:black;font-weight:bold">sameTerm</code></dfn></b>
 
         <p>Second, when a legacy RDF system communicates an <a>RDF graph</a> to an RDF-star-aware system, there is no means by which the latter can determine with certainty whether the graph is the result of applying the <a>unstar mapping</a>, and thus needs to be transformed back. (The presence of `unstar:` IRIs in the graph can be used as a hint, but such IRIs can also be used independently of the mapping.) Additional metadata should therefore be attached to unstarred graphs, so that RDF-star systems know whether or not they need to apply the inverse transformation of <a>unstar</a>.</p>
 
-        <p>Finally, legacy RDF systems may alter unstarred graphs in ways that prevent their transformation back to the original <a>RDF-star graph</a>. For example, it has been <a href="combining-rdf-star-graphs">pointed out above</a> how combining several unstarred graphs may not yield the expected result. Another example is the removal of some arcs, such that an <a>embedded triple</a> is not completely described anymore, and can not be reconstructed.</p>
+        <p>Finally, legacy RDF systems may alter unstarred graphs in ways that prevent their transformation back to the original <a>RDF-star graph</a>. For example, it has been <a href="#combining-rdf-star-graphs">pointed out above</a> how combining several unstarred graphs may not yield the expected result. Another example is the removal of some arcs, such that an <a>embedded triple</a> is not completely described anymore, and can not be reconstructed.</p>
 
       </section>
 

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -657,25 +657,139 @@ INSERT {
       a single <a>default graph</a> and zero or more <a>named graphs</a>,
       all of which are <a>RDF-star graphs</a>.</p>
 
-    <p>The TriG-star grammar contains exactly the same production updates
-      described in <a href="#turtle-star-grammar" class="sectionRef"></a>.</p>
+    <section id="trig-star-grammar">
+      <h2>Grammar</h2>
+      <p>TriG-star is defined to follow the <a data-cite="TRIG#grammar-ebnf">same grammar</a> as TriG,
+        <em>except</em> for the <a data-cite="XML#sec-notation"><abbr title="Extended Backus-Naur Form">EBNF</abbr> productions</a> specified below,
+        which replace the productions having the same number (if any) in the original grammar.</p>
 
-    <p>TriG-star parsing uses the same updates described
-      in <a href="#turtle-star-parsing" class="sectionRef"></a>
-      as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
+      <p>The TriG-star grammar contains exactly the same production updates
+        described in <a href="#turtle-star-grammar" class="sectionRef"></a>
+        with an additional change to the <a href="#trig-grammar-production-triplesOrGraph">triplesOrGraph</a> production.</p>
 
-    <p class="note">As with Turtle-star,
-      the <a href="#grammar-production-embTriple">`embTriple`</a>
-      and <a href="#grammar-production-annotation">`annotation`</a>
-      are used to set either the |curSubject| or |curObject|,
-      and do not directly add the associated <a>embedded triple</a> to |curGraph|.
-      Subsequent productions which use either |curSubject| or |curObject|
-      may result in adding triples to |curGraph|.</p>
+      <table class="grammar">
+        <tr id="trig-grammar-production-triplesOrGraph">
+          <td>[3g]</td>
+          <td>`triplesOrGraph`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="TRIG#grammar-production-labelOrSubject">labelOrSubject</a>
+            `(`
+            <a data-cite="TRIG#grammar-production-wrappedGraph">wrappedGraph</a>
+            `|`
+            <a data-cite="TRIG#grammar-production-predicateObjectList">predicateObjectList</a>
+            `'.' )`
+            <div style="font-weight: bold">
+              `|`
+              <a href="#trig-grammar-production-embTriple">embTriple</a>
+              <a data-cite="TRIG#grammar-production-predicateObjectList">predicateObjectList</a>
+              `'.'`
+            </div>
+          </td>
+        </tr>
+        <tr id="trig-grammar-production-objectList">
+          <td>[8]</td>
+          <td>`objectList`</td>
+          <td>::=</td>
+          <td>
+            <a href="#trig-grammar-production-object">object</a>
+            <a style="font-weight: bold" href="#trig-grammar-production-annotation">annotation</a>`?`
+            `(`
+            <code class="grammar-literal">','</code>
+            <a href="#trig-grammar-production-object">object</a>
+            <a style="font-weight: bold" href="#trig-grammar-production-annotation">annotation</a>`?`
+            `)*`
+          </td>
+        </tr>
+        <tr id="trig-grammar-production-subject">
+          <td>[10]</td>
+          <td>`subject`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="TRIG#grammar-production-iri">iri</a> `|`
+            <a data-cite="TRIG#grammar-production-BlankNode">BlankNode</a> `|`
+            <a data-cite="TRIG#grammar-production-collection">collection</a> `|`
+            <a style="font-weight: bold" href="#trig-grammar-production-embTriple">embTriple</a>
+          </td>
+        </tr>
+        <tr id="trig-grammar-production-object">
+          <td>[12]</td>
+          <td>`object`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="TRIG#grammar-production-iri">iri</a> `|`
+            <a  data-cite="TRIG#grammar-production-BlankNode">BlankNode</a> `|`
+            <a  data-cite="TRIG#grammar-production-collection">collection</a> `|`
+            <a data-cite="TRIG#grammar-production-blankNodePropertyList">blankNodePropertyList</a> `|`
+            <a data-cite="TRIG#grammar-production-literal">literal</a> `|`
+            <a style="font-weight: bold" href="#trig-grammar-production-embTriple">embTriple</a>
+          </td>
+        </tr>
+        <tr style="font-weight: bold" id="trig-grammar-production-embTriple">
+          <td>[27t]</td>
+          <td>`embTriple`</td>
+          <td>::=</td>
+          <td>
+            <code class="grammar-literal">'&lt;&lt;'</code>
+            <a href="#trig-grammar-production-embSubject">embSubject</a>
+            <a data-cite="TURTLE#grammar-production-verb">verb</a>
+            <a href="#trig-grammar-production-embObject">embObject</a>
+            <code class="grammar-literal">'&gt;&gt;'</code>
+          </td>
+        </tr>
+        <tr style="font-weight: bold" id="trig-grammar-production-embSubject">
+          <td>[28t]</td>
+          <td>`embSubject`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="TRIG#grammar-production-iri">iri</a> `|`
+            <a  data-cite="TRIG#grammar-production-BlankNode">BlankNode</a> `|`
+            <a href="#trig-grammar-production-embTriple">embTriple</a>
+          </td>
+        </tr>
+        <tr style="font-weight: bold" id="trig-grammar-production-embObject">
+          <td>[29t]</td>
+          <td>`embObject`</td>
+          <td>::=</td>
+          <td>
+            <a data-cite="TRIG#grammar-production-iri">iri</a> `|`
+            <a  data-cite="TRIG#grammar-production-BlankNode">BlankNode</a> `|`
+            <a data-cite="TRIG#grammar-production-literal">literal</a> `|`
+            <a href="#trig-grammar-production-embTriple">embTriple</a>
+          </td>
+        </tr>
+        <tr style="font-weight: bold" id="trig-grammar-production-annotation">
+          <td>[30t]</td>
+          <td>`annotation`</td>
+          <td>::=</td>
+          <td>
+            <code class="grammar-literal">'{|'</code>
+            <a  data-cite="TRIG#grammar-production-predicateObjectList">predicateObjectList</a>
+            <code class="grammar-literal">'|}'</code>
+          </td>
+        </tr>
+      </table>
+    </section>
 
-    <p>A conforming TriG-star parser MUST parse any
-      valid <strong>TriG document</strong> and any
-      valid <a>Turtle-star document</a> in addition
-      to the <a href="#turtle-star-grammar">Turtle-star grammar</a> productions contained within a <a>named graph</a>.</p>
+    <section id="trig-star-parsing">
+      <h3>Parsing</h3>
+      <p>TriG-star parsing uses the same updates described
+        in <a href="#turtle-star-parsing" class="sectionRef"></a>
+        as applied to <a data-cite="TRIG#sec-parsing">Section 5 of the TriG specification</a> [[TRIG]].</p>
+
+      <p class="note">As with Turtle-star,
+        the <a href="#grammar-production-embTriple">`embTriple`</a>
+        and <a href="#grammar-production-annotation">`annotation`</a>
+        are used to set either the |curSubject| or |curObject|,
+        and do not directly add the associated <a>embedded triple</a> to |curGraph|.
+        Subsequent productions which use either |curSubject| or |curObject|
+        may result in adding triples to |curGraph|.</p>
+
+      <p>A conforming TriG-star parser MUST parse any
+        valid <strong>TriG document</strong> and any
+        valid <a>Turtle-star document</a> in addition
+        to the <a href="#turtle-star-grammar">Turtle-star grammar</a> productions contained within a <a>named graph</a>.</p>
+    </section>
 
     <section id="trig-star-discussion" class="informative">
       <h3>Discussion</h3>

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -447,11 +447,11 @@ INSERT {
           <td>::=</td>
           <td>
             <a href="#grammar-production-object">object</a>
-            <a href="#grammar-production-annotation">annotation</a>`?`
+            <a style="font-weight: bold" href="#grammar-production-annotation">annotation</a>`?`
             `(`
             <code class="grammar-literal">','</code>
             <a href="#grammar-production-object">object</a>
-            <a href="#grammar-production-annotation">annotation</a>`?`
+            <a style="font-weight: bold" href="#grammar-production-annotation">annotation</a>`?`
             `)*`
           </td>
         </tr>
@@ -463,7 +463,7 @@ INSERT {
             <a data-cite="TURTLE#grammar-production-iri">iri</a> `|`
             <a data-cite="TURTLE#grammar-production-BlankNode">BlankNode</a> `|`
             <a data-cite="TURTLE#grammar-production-collection">collection</a> `|`
-            <a href="#grammar-production-embTriple">embTriple</a>
+            <a style="font-weight: bold" href="#grammar-production-embTriple">embTriple</a>
           </td>
         </tr>
         <tr id="grammar-production-object">
@@ -476,10 +476,10 @@ INSERT {
             <a  data-cite="TURTLE#grammar-production-collection">collection</a> `|`
             <a data-cite="TURTLE#grammar-production-blankNodePropertyList">blankNodePropertyList</a> `|`
             <a data-cite="TURTLE#grammar-production-literal">literal</a> `|`
-            <a href="#grammar-production-embTriple">embTriple</a>
+            <a style="font-weight: bold" href="#grammar-production-embTriple">embTriple</a>
           </td>
         </tr>
-        <tr id="grammar-production-embTriple">
+        <tr style="font-weight: bold" id="grammar-production-embTriple">
           <td>[27t]</td>
           <td>`embTriple`</td>
           <td>::=</td>
@@ -491,7 +491,7 @@ INSERT {
             <code class="grammar-literal">'&gt;&gt;'</code>
           </td>
         </tr>
-        <tr id="grammar-production-embSubject">
+        <tr style="font-weight: bold" id="grammar-production-embSubject">
           <td>[28t]</td>
           <td>`embSubject`</td>
           <td>::=</td>
@@ -501,7 +501,7 @@ INSERT {
             <a href="#grammar-production-embTriple">embTriple</a>
           </td>
         </tr>
-        <tr id="grammar-production-embObject">
+        <tr style="font-weight: bold" id="grammar-production-embObject">
           <td>[29t]</td>
           <td>`embObject`</td>
           <td>::=</td>
@@ -512,7 +512,7 @@ INSERT {
             <a href="#grammar-production-embTriple">embTriple</a>
           </td>
         </tr>
-        <tr id="grammar-production-annotation">
+        <tr style="font-weight: bold" id="grammar-production-annotation">
           <td>[30t]</td>
           <td>`annotation`</td>
           <td>::=</td>
@@ -847,15 +847,15 @@ INSERT {
             <td>[3]</td>
             <td>`subject`</td>
             <td>::=</td>
-            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
+            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a style="font-weight: bold" href="#grammar-production-nt-embTriple">embTriple</a></td>
           </tr>
           <tr id="grammar-production-nt-object">
             <td>[5]</td>
             <td>`object`</td>
             <td>::=</td>
-            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-nt-embTriple">embTriple</a></td>
+            <td><a data-cite="N-TRIPLES#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a data-cite="N-TRIPLES#grammar-production-literal">literal</a> <code>|</code> <a style="font-weight: bold" href="#grammar-production-nt-embTriple">embTriple</a></td>
           </tr>
-          <tr id="grammar-production-nt-embTriple">
+          <tr style="font-weight: bold" id="grammar-production-nt-embTriple">
             <td>[7t]</td>
             <td>`embTriple`</td>
             <td>::=</td>


### PR DESCRIPTION
Adds an explicit Grammar section for TriG-star with modified `triplesOrGraph` production.

For #187.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/pull/188.html" title="Last updated on Jun 12, 2021, 7:38 PM UTC (b276c4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/188/561ce51...b276c4d.html" title="Last updated on Jun 12, 2021, 7:38 PM UTC (b276c4d)">Diff</a>