### PR TITLE
Add links as a background image to the Intro figure

### DIFF
--- a/cg-spec/branches.svg
+++ b/cg-spec/branches.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="230.71666mm"
+   height="62.177082mm"
+   viewBox="0 0 230.71666 62.177082"
+   version="1.1"
+   id="svg8"
+   preserveAspectRatio="none"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="branches.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4561128"
+     inkscape:cx="442.02302"
+     inkscape:cy="216.53461"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-7.7285051,-92.709778)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 48.586101,117.78136 83.382119,7.21379"
+       id="path847" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 49.07862,135.86334 82.8896,-10.86819 0,21.10534"
+       id="path849" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 131.96822,103.03058 v 21.96457 l 77.13933,0"
+       id="path851" />
+  </g>
+</svg>

--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -207,7 +207,15 @@
       margin: 0.7em 1em;
       padding: 0.35em 0.5em;
       box-shadow: 0.25em 0.25em 0.5em darkgray;
+      background-color: white;
       text-align: center;
+      position: relative;
+    }
+
+    #structure-map table {
+      background-image: url("branches.svg");
+      background-size: 100% 100%;
+      background-repeat: no-repeat;
     }
 
     /* remove "unofficial draft" watermark */
@@ -375,22 +383,18 @@ INSERT {
           <tr>
             <td rowspan=3>
               <div class="box">
-                <strong>querying</strong><br>
                 <a href="#sparql-star"></a><br>
               </div>
               <div class="box">
-                <strong>updating</strong><br>
-                  <a href="#sparql-star-update"></a>
+                <a href="#sparql-star-update"></a>
               </div>
             <td>
               <div class="box">
-                <strong>reasoning</strong><br>
                 <a href="#rdf-star-semantics"></a>
               </div>
             <td>
             <td rowspan=3>
               <div class="box">
-                <strong>representing</strong><br>
                 <a href="#rdf-star-vocabulary"></a>
               </div>
           <tr>
@@ -398,12 +402,13 @@ INSERT {
               <div class="box">
                 <a href="#concepts"></a>
               </div>
+            <td>
           <tr>
             <td>
               <div class="box">
-                <strong>serializing</strong><br>
                 <a href="#concrete-syntaxes"></a>
               </div>
+            <td>
         </table>
         <figcaption>A visual map of the sections of this document</figcaption>
       </figure>


### PR DESCRIPTION
This is an alternative to #213. It is more visual, and renders well at the default zoom level (on the two browsers that I tested, anyway).

When increasing the size of text, the aspect is not as good, though... the links are not as well centered, and all oblique and horizontal links grow thicker than the vertical ones...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/pull/214.html" title="Last updated on Oct 13, 2021, 4:32 PM UTC (d01d148)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/214/fa06a92...d01d148.html" title="Last updated on Oct 13, 2021, 4:32 PM UTC (d01d148)">Diff</a>