### PR TITLE
Fix the rdf:type of a couple of the Turtle syntax tests

### DIFF
--- a/tests/turtle/syntax/manifest.jsonld
+++ b/tests/turtle/syntax/manifest.jsonld
@@ -225,13 +225,13 @@
     },
     {
       "@id": "trs:nt-ttl-star-4",
-      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "@type": "TestTurtlePositiveSyntax",
       "action": "nt-ttl-star-syntax-4.ttl",
       "name": "N-Triples-star as Turtle-star - whitespace and terms"
     },
     {
       "@id": "trs:nt-ttl-star-5",
-      "@type": "rdft:TestNTriplesPositiveSyntax",
+      "@type": "TestTurtlePositiveSyntax",
       "action": "nt-ttl-star-syntax-5.ttl",
       "name": "N-Triples-star as Turtle-star - Nested, no whitespace"
     },

--- a/tests/turtle/syntax/manifest.ttl
+++ b/tests/turtle/syntax/manifest.ttl
@@ -204,12 +204,12 @@ trs:nt-ttl-star-3 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:action    <nt-ttl-star-syntax-3.ttl> ;
    .
 
-trs:nt-ttl-star-4 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:nt-ttl-star-4 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - whitespace and terms" ;
    mf:action    <nt-ttl-star-syntax-4.ttl> ;
    .
 
-trs:nt-ttl-star-5 rdf:type rdft:TestNTriplesPositiveSyntax ;
+trs:nt-ttl-star-5 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "N-Triples-star as Turtle-star - Nested, no whitespace" ;
    mf:action    <nt-ttl-star-syntax-5.ttl> ;
    .


### PR DESCRIPTION
Tests 'nt-ttl-star-4' and 'nt-ttl-star-5' should both be typed as 'rdft:TestTurtlePositiveSyntax' rather than 'rdft:TestNTriplesPositiveSyntax' in the Turtle syntax test suite.