### PR TITLE
Reports update

### DIFF
--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -115,20 +115,21 @@
     "Software",
     "doap:Project"
   ],
+  "assertions": [
+    "ruby-sparql.ttl",
+    "ruby-trig.ttl"
+  ],
+  "name": "RDF-star",
   "testSubjects": [
     {
       "@id": "https://rubygems.org/gems/rdf-trig",
       "@type": [
         "Software",
-        "doap:Project",
-        "TestSubject"
+        "TestSubject",
+        "doap:Project"
       ],
-      "release": {
-        "@id": "https://github.com/ruby-rdf/rdf-trig/tree/3.1.2",
-        "revision": "3.1.2"
-      },
-      "doap:description": "TriG reader/writer for RDF.rb",
-      "language": "Ruby",
+      "homepage": "https://github.com/ruby-rdf/rdf-trig",
+      "name": "RDF::TriG",
       "developer": [
         {
           "@id": "https://greggkellogg.net/foaf#me",
@@ -140,22 +141,22 @@
           "foaf:homepage": "https://greggkellogg.net/"
         }
       ],
-      "name": "RDF::TriG",
-      "homepage": "https://github.com/ruby-rdf/rdf-trig"
+      "language": "Ruby",
+      "release": {
+        "@id": "https://github.com/ruby-rdf/rdf-trig/tree/3.1.2",
+        "revision": "3.1.2"
+      },
+      "doap:description": "TriG reader/writer for RDF.rb"
     },
     {
       "@id": "https://rubygems.org/gems/sparql",
       "@type": [
         "Software",
-        "doap:Project",
-        "TestSubject"
+        "TestSubject",
+        "doap:Project"
       ],
-      "release": {
-        "@id": "_:b6",
-        "revision": "3.1.7"
-      },
-      "doapDesc": "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite.",
-      "language": "Ruby",
+      "homepage": "https://github.com/ruby-rdf/sparql",
+      "name": "Ruby SPARQL",
       "developer": [
         {
           "@id": "https://greggkellogg.net/foaf#me",
@@ -167,88 +168,2394 @@
           "foaf:homepage": "https://greggkellogg.net/"
         }
       ],
-      "name": "Ruby SPARQL",
-      "homepage": "https://github.com/ruby-rdf/sparql"
+      "language": "Ruby",
+      "release": {
+        "@id": "_:b13",
+        "revision": "3.1.7"
+      },
+      "doapDesc": "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite."
     }
   ],
-  "generatedBy": {
-    "@id": "https://rubygems.org/gems/earl-report",
-    "@type": [
-      "Software",
-      "doap:Project"
-    ],
-    "release": {
-      "@id": "https://github.com/gkellogg/earl-report/tree/0.7.0",
-      "@type": "doap:Version",
-      "doap:created": {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2021-05-05"
-      },
-      "revision": "0.7.0",
-      "name": "earl-report-0.7.0"
-    },
-    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
-    "language": "Ruby",
-    "license": "http://unlicense.org",
-    "homepage": "https://github.com/gkellogg/earl-report",
-    "name": "earl-report",
-    "developer": [
-      {
-        "@id": "https://greggkellogg.net/foaf#me",
-        "@type": [
-          "Assertor",
-          "foaf:Person"
-        ],
-        "foaf:name": "Gregg Kellogg",
-        "foaf:homepage": "https://greggkellogg.net/"
-      }
-    ],
-    "shortdesc": "Earl Report summary generator"
-  },
-  "bibRef": "[[rdf-star]]",
-  "name": "RDF-star",
   "entries": [
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/semantics#manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-star/tests/semantics/README"
+      },
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para la semántica de RDF-star"
+        },
+        {
+          "@language": "fr",
+          "@value": "La suite des tests pour la sémantique de RDF-star"
+        }
+      ],
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Multiple occurences of the same quoted triples are undistinguishable in the abstract model.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "all-identical-quoted-triples-are-the-same",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b550",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same",
+              "result": {
+                "@id": "_:b340",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b930",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same",
+              "result": {
+                "@id": "_:b860",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "This test ensures that other entailments are not spurious.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test005.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "quoted-triples-no-spurious",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b883",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious",
+              "result": {
+                "@id": "_:b469",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b905",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious",
+              "result": {
+                "@id": "_:b58",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Terms inside quoted triples can be replaced by fresh bnodes.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-quoted-subject",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b444",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject",
+              "result": {
+                "@id": "_:b445",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b510",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject",
+              "result": {
+                "@id": "_:b511",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Terms inside quoted triples can be replaced by fresh bnodes.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-quoted-object",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b858",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object",
+              "result": {
+                "@id": "_:b764",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b781",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object",
+              "result": {
+                "@id": "_:b782",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Terms inside quoted triples can be replaced by fresh bnodes.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-quoted-subject-and-object",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b351",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object",
+              "result": {
+                "@id": "_:b239",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b516",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object",
+              "result": {
+                "@id": "_:b517",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "The same bnode can not match different quoted terms.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "bnodes-in-quoted-subject-and-object-fail",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b509",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail",
+              "result": {
+                "@id": "_:b128",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b674",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail",
+              "result": {
+                "@id": "_:b281",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Identical quoted term can be replaced by the same fresh bnode multiple times.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "same-bnode-same-quoted-term",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b791",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term",
+              "result": {
+                "@id": "_:b629",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b177",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term",
+              "result": {
+                "@id": "_:b178",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Different bnodes can match identical quoted terms.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "different-bnodes-same-quoted-term",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b724",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term",
+              "result": {
+                "@id": "_:b713",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b182",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term",
+              "result": {
+                "@id": "_:b183",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Terms inside and outside quoted triples can be replaced by fresh bnodes",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-in-quoted-subject",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b454",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject",
+              "result": {
+                "@id": "_:b313",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b179",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject",
+              "result": {
+                "@id": "_:b180",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Terms inside and outside quoted triples can be replaced by fresh bnodes.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-in-quoted-object",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b897",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object",
+              "result": {
+                "@id": "_:b852",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b161",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object",
+              "result": {
+                "@id": "_:b162",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside quoted triples and inside asserted triples must satisfy all occurrences at the same time.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-in-quoted-fail",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b729",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail",
+              "result": {
+                "@id": "_:b723",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b898",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail",
+              "result": {
+                "@id": "_:b834",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Literals inside and outside quoted triples can be replaced by fresh bnodes.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "constrained-bnodes-on-literal",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b889",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "result": {
+                "@id": "_:b815",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b839",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
+              "result": {
+                "@id": "_:b622",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
+          "mf:result": {
+            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+            "@value": "false"
+          },
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-control",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b882",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "result": {
+                "@id": "_:b156",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b291",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
+              "result": {
+                "@id": "_:b49",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Malformed literals are allowed when quoted.",
+          "mf:result": {
+            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+            "@value": "false"
+          },
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b620",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "result": {
+                "@id": "_:b593",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b611",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
+              "result": {
+                "@id": "_:b612",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Malformed literals are allowed when quoted.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-accepted",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b423",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "result": {
+                "@id": "_:b234",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b697",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
+              "result": {
+                "@id": "_:b589",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Quoted malformed literals do not lead to spurious entailment.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-no-spurious",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b828",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "result": {
+                "@id": "_:b568",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b797",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
+              "result": {
+                "@id": "_:b798",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Malformed literals can not be replaced by blank nodes.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "malformed-literal-bnode",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b98",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "result": {
+                "@id": "_:b99",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b818",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
+              "result": {
+                "@id": "_:b78",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-literal-control",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b430",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "result": {
+                "@id": "_:b431",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b641",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
+              "result": {
+                "@id": "_:b642",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Quoted literals are opaque, even when their datatype is recognized.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-literal",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+              }
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b329",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "result": {
+                "@id": "_:b54",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b270",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
+              "result": {
+                "@id": "_:b189",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-language-string-control",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b83",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "result": {
+                "@id": "_:b84",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b763",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
+              "result": {
+                "@id": "_:b356",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Quoted literals (including language strings) are opaque, even when their datatype is recognized.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-language-string",
+          "mf:entailmentRegime": "RDF",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b706",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "result": {
+                "@id": "_:b363",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b758",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
+              "result": {
+                "@id": "_:b759",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-iri-control",
+          "mf:entailmentRegime": "RDFS-Plus",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b880",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "result": {
+                "@id": "_:b327",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b487",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
+              "result": {
+                "@id": "_:b488",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Quoted IRIs are opaque.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "opaque-iri",
+          "mf:entailmentRegime": "RDFS-Plus",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/superman.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b380",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "result": {
+                "@id": "_:b381",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b442",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
+              "result": {
+                "@id": "_:b443",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted",
+          "@type": [
+            "mf:NegativeEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Quoted triples are not asserted.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "quoted-not-asserted",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b831",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted",
+              "result": {
+                "@id": "_:b775",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b648",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted",
+              "result": {
+                "@id": "_:b649",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Annotated triples are asserted.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "annotated-asserted",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b123",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "result": {
+                "@id": "_:b124",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b730",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
+              "result": {
+                "@id": "_:b731",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Annotation are about the annotated triple.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "annotation",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b712",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "result": {
+                "@id": "_:b460",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b268",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
+              "result": {
+                "@id": "_:b269",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+          "@type": [
+            "mf:PositiveEntailmentTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Annotation is the same as separate assertions.",
+          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
+          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
+            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
+          },
+          "title": "annotation-unfolded",
+          "mf:entailmentRegime": "simple",
+          "mf:recognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl",
+          "mf:unrecognizedDatatypes": {
+            "@list": [
+
+            ]
+          },
+          "assertions": [
+            {
+              "@id": "_:b18",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "result": {
+                "@id": "_:b19",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "assertedBy": null
+            },
+            {
+              "@id": "_:b24",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
+              "result": {
+                "@id": "_:b25",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        }
+      ],
+      "dc:creator": {
+        "@id": "_:b109",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "RDF-star Semantics tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-tests/"
+      },
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para la sintaxis de Trig-star"
+        },
+        {
+          "@language": "fr",
+          "@value": "La suite des tests pour la syntaxe de TriG-star"
+        }
+      ],
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig",
+          "title": "TriG-star - subject quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b913",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b799",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b389",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
+              "result": {
+                "@id": "_:b137",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig",
+          "title": "TriG-star - object quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b8",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b9",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b904",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
+              "result": {
+                "@id": "_:b868",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig",
+          "title": "TriG-star - quoted triple inside blankNodePropertyList",
+          "assertions": [
+            {
+              "@id": "_:b909",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b792",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b461",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
+              "result": {
+                "@id": "_:b462",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig",
+          "title": "TriG-star - quoted triple inside collection",
+          "assertions": [
+            {
+              "@id": "_:b886",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b800",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b541",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
+              "result": {
+                "@id": "_:b472",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig",
+          "title": "TriG-star - nested quoted triple, subject position",
+          "assertions": [
+            {
+              "@id": "_:b592",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b160",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b876",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
+              "result": {
+                "@id": "_:b320",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig",
+          "title": "TriG-star - nested quoted triple, object position",
+          "assertions": [
+            {
+              "@id": "_:b489",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b490",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b449",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
+              "result": {
+                "@id": "_:b36",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig",
+          "title": "TriG-star - compound forms",
+          "assertions": [
+            {
+              "@id": "_:b808",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b518",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b885",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
+              "result": {
+                "@id": "_:b413",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig",
+          "title": "TriG-star - blank node subject",
+          "assertions": [
+            {
+              "@id": "_:b911",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b3",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b803",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
+              "result": {
+                "@id": "_:b503",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig",
+          "title": "TriG-star - blank node object",
+          "assertions": [
+            {
+              "@id": "_:b675",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b676",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b725",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
+              "result": {
+                "@id": "_:b702",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig",
+          "title": "TriG-star - blank node",
+          "assertions": [
+            {
+              "@id": "_:b864",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b865",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b324",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
+              "result": {
+                "@id": "_:b325",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig",
+          "title": "TriG-star - bad - quoted triple as predicate",
+          "assertions": [
+            {
+              "@id": "_:b457",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b410",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b43",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
+              "result": {
+                "@id": "_:b44",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig",
+          "title": "TriG-star - bad - quoted triple outside triple",
+          "assertions": [
+            {
+              "@id": "_:b562",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b563",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b317",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
+              "result": {
+                "@id": "_:b318",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig",
+          "title": "TriG-star - bad - collection list in quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b635",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b554",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b703",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
+              "result": {
+                "@id": "_:b704",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig",
+          "title": "TriG-star - bad - literal in subject position of quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b855",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b282",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b186",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
+              "result": {
+                "@id": "_:b187",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig",
+          "title": "TriG-star - bad - blank node  as predicate in quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b850",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b229",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b741",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
+              "result": {
+                "@id": "_:b669",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig",
+          "title": "TriG-star - bad - compound blank node expression",
+          "assertions": [
+            {
+              "@id": "_:b888",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b441",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b129",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
+              "result": {
+                "@id": "_:b130",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig",
+          "title": "TriG-star - bad - incomplete quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b364",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b221",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b245",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
+              "result": {
+                "@id": "_:b57",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig",
+          "title": "TriG-star - bad - over-long quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b196",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b197",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b524",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
+              "result": {
+                "@id": "_:b525",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig",
+          "title": "TriG-star - Annotation form",
+          "assertions": [
+            {
+              "@id": "_:b645",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b646",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b429",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
+              "result": {
+                "@id": "_:b222",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+          "@type": [
+            "TestCase",
+            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig",
+          "title": "TriG-star - Annotation example",
+          "assertions": [
+            {
+              "@id": "_:b705",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b306",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b47",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
+              "result": {
+                "@id": "_:b48",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig",
+          "title": "TriG-star - bad - empty annotation",
+          "assertions": [
+            {
+              "@id": "_:b470",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b471",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b603",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
+              "result": {
+                "@id": "_:b604",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig",
+          "title": "TriG-star - bad - triple as annotation",
+          "assertions": [
+            {
+              "@id": "_:b521",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b382",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b52",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
+              "result": {
+                "@id": "_:b53",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        }
+      ],
+      "dc:creator": {
+        "@id": "_:b507",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "TriG-star Syntax Tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
+    },
     {
       "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#manifest",
       "@type": [
         "mf:Manifest",
         "Report"
       ],
-      "rdfs:label": "N-Triples-star Syntax Tests",
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax/README"
+      },
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para N-Triples-star"
+        },
+        {
+          "@language": "fr",
+          "@value": "La suite des tests pour N-Triples-star"
+        }
+      ],
       "entries": [
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt",
           "title": "N-Triples-star - subject quoted triple",
           "assertions": [
             {
-              "@id": "_:b356",
+              "@id": "_:b292",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b81",
+                "@id": "_:b293",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b517",
+              "@id": "_:b567",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b518",
+                "@id": "_:b81",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -257,35 +2564,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt",
           "title": "N-Triples-star - object quoted triple",
           "assertions": [
             {
-              "@id": "_:b655",
+              "@id": "_:b267",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b656",
+                "@id": "_:b158",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b874",
+              "@id": "_:b664",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b784",
+                "@id": "_:b564",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -294,35 +2601,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt",
           "title": "N-Triples-star - subject and object quoted triples",
           "assertions": [
             {
-              "@id": "_:b842",
+              "@id": "_:b590",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b232",
+                "@id": "_:b384",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b844",
+              "@id": "_:b556",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b169",
+                "@id": "_:b557",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -331,35 +2638,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt",
           "title": "N-Triples-star - whitespace and terms",
           "assertions": [
             {
-              "@id": "_:b379",
+              "@id": "_:b336",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b380",
+                "@id": "_:b337",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b126",
+              "@id": "_:b605",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b127",
+                "@id": "_:b606",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -368,35 +2675,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt",
           "title": "N-Triples-star - Nested, no whitespace",
           "assertions": [
             {
-              "@id": "_:b273",
+              "@id": "_:b760",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b274",
+                "@id": "_:b544",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b806",
+              "@id": "_:b812",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b807",
+                "@id": "_:b330",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -405,35 +2712,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt",
           "title": "N-Triples-star - Blank node subject",
           "assertions": [
             {
-              "@id": "_:b92",
+              "@id": "_:b820",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b93",
+                "@id": "_:b821",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b757",
+              "@id": "_:b583",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b227",
+                "@id": "_:b584",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -442,35 +2749,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt",
           "title": "N-Triples-star - Blank node object",
           "assertions": [
             {
-              "@id": "_:b65",
+              "@id": "_:b250",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b66",
+                "@id": "_:b251",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b711",
+              "@id": "_:b155",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b52",
+                "@id": "_:b30",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -479,35 +2786,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt",
           "title": "N-Triples-star - Nested subject term",
           "assertions": [
             {
-              "@id": "_:b598",
+              "@id": "_:b392",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b442",
+                "@id": "_:b31",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b264",
+              "@id": "_:b295",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b265",
+                "@id": "_:b41",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -516,35 +2823,35 @@
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
           "@type": [
             "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt",
           "title": "N-Triples-star - Nested object term",
           "assertions": [
             {
-              "@id": "_:b158",
+              "@id": "_:b265",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b139",
+                "@id": "_:b227",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b211",
+              "@id": "_:b708",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b212",
+                "@id": "_:b273",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -552,36 +2859,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
           "@type": [
-            "TestCriterion",
             "TestCase",
+            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt",
           "title": "N-Triples-star - Bad - quoted triple as predicate",
           "assertions": [
             {
-              "@id": "_:b375",
+              "@id": "_:b733",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b376",
+                "@id": "_:b715",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b508",
+              "@id": "_:b289",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b509",
+                "@id": "_:b290",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -589,36 +2896,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
           "@type": [
-            "TestCriterion",
             "TestCase",
+            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt",
           "title": "N-Triples-star - Bad - quoted triple, literal subject",
           "assertions": [
             {
-              "@id": "_:b329",
+              "@id": "_:b933",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b330",
+                "@id": "_:b923",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b925",
+              "@id": "_:b463",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b587",
+                "@id": "_:b464",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -626,36 +2933,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
           "@type": [
-            "TestCriterion",
             "TestCase",
+            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt",
           "title": "N-Triples-star - Bad - quoted triple, literal predicate",
           "assertions": [
             {
-              "@id": "_:b447",
+              "@id": "_:b848",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b256",
+                "@id": "_:b811",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b254",
+              "@id": "_:b316",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b255",
+                "@id": "_:b274",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -663,41 +2970,57 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
           "@type": [
-            "TestCriterion",
             "TestCase",
+            "TestCriterion",
             "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt",
           "title": "N-Triples-star - Bad - quoted triple, blank node predicate",
           "assertions": [
             {
-              "@id": "_:b326",
+              "@id": "_:b869",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b327",
+                "@id": "_:b435",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b182",
+              "@id": "_:b474",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b183",
+                "@id": "_:b159",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
         }
-      ]
+      ],
+      "dc:creator": {
+        "@id": "_:b0",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "N-Triples-star Syntax Tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
     },
     {
       "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest",
@@ -705,41 +3028,54 @@
         "mf:Manifest",
         "Report"
       ],
-      "rdfs:label": "Turtle-star Syntax Tests",
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "fr",
+          "@value": "La suite des tests pour la syntaxe Turtle-star"
+        },
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para la sintaxis Turtle-star"
+        }
+      ],
       "entries": [
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl",
           "title": "Turtle-star - subject quoted triple",
           "assertions": [
             {
-              "@id": "_:b592",
+              "@id": "_:b700",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b463",
+                "@id": "_:b308",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b678",
+              "@id": "_:b665",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b207",
+                "@id": "_:b666",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -747,36 +3083,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl",
           "title": "Turtle-star - object quoted triple",
           "assertions": [
             {
-              "@id": "_:b605",
+              "@id": "_:b572",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b469",
+                "@id": "_:b547",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b810",
+              "@id": "_:b670",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b141",
+                "@id": "_:b671",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -784,36 +3120,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl",
           "title": "Turtle-star - quoted triple inside blankNodePropertyList",
           "assertions": [
             {
-              "@id": "_:b394",
+              "@id": "_:b932",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b395",
+                "@id": "_:b512",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b644",
+              "@id": "_:b849",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b645",
+                "@id": "_:b142",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -821,36 +3157,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl",
           "title": "Turtle-star - quoted triple inside collection",
           "assertions": [
             {
-              "@id": "_:b676",
+              "@id": "_:b169",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b282",
+                "@id": "_:b170",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b705",
+              "@id": "_:b20",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b514",
+                "@id": "_:b21",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -858,36 +3194,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl",
           "title": "Turtle-star - nested quoted triple, subject position",
           "assertions": [
             {
-              "@id": "_:b364",
+              "@id": "_:b486",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b365",
+                "@id": "_:b433",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b903",
+              "@id": "_:b806",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b590",
+                "@id": "_:b69",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -895,36 +3231,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl",
           "title": "Turtle-star - nested quoted triple, object position",
           "assertions": [
             {
-              "@id": "_:b785",
+              "@id": "_:b749",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b89",
+                "@id": "_:b750",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b631",
+              "@id": "_:b617",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b632",
+                "@id": "_:b618",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -932,36 +3268,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl",
           "title": "Turtle-star - compound forms",
           "assertions": [
             {
-              "@id": "_:b768",
+              "@id": "_:b856",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b333",
+                "@id": "_:b857",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b407",
+              "@id": "_:b916",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b393",
+                "@id": "_:b794",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -969,36 +3305,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl",
           "title": "Turtle-star - blank node subject",
           "assertions": [
             {
-              "@id": "_:b556",
+              "@id": "_:b341",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b557",
+                "@id": "_:b323",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b577",
+              "@id": "_:b66",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b221",
+                "@id": "_:b67",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1006,36 +3342,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl",
           "title": "Turtle-star - blank node object",
           "assertions": [
             {
-              "@id": "_:b331",
+              "@id": "_:b689",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b332",
+                "@id": "_:b690",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b36",
+              "@id": "_:b577",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b37",
+                "@id": "_:b578",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1043,36 +3379,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl",
           "title": "Turtle-star - blank node",
           "assertions": [
             {
-              "@id": "_:b352",
+              "@id": "_:b513",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b353",
+                "@id": "_:b253",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b547",
+              "@id": "_:b446",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b548",
+                "@id": "_:b447",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1080,36 +3416,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl",
           "title": "Turtle-star - bad - quoted triple as predicate",
           "assertions": [
             {
-              "@id": "_:b827",
+              "@id": "_:b331",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b767",
+                "@id": "_:b89",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b701",
+              "@id": "_:b804",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b702",
+                "@id": "_:b805",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1117,36 +3453,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl",
           "title": "Turtle-star - bad - quoted triple outside triple",
           "assertions": [
             {
-              "@id": "_:b593",
+              "@id": "_:b743",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b594",
+                "@id": "_:b539",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b691",
+              "@id": "_:b683",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b692",
+                "@id": "_:b684",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1154,36 +3490,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl",
           "title": "Turtle-star - bad - collection list in quoted triple",
           "assertions": [
             {
-              "@id": "_:b703",
+              "@id": "_:b523",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b571",
+                "@id": "_:b143",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b740",
+              "@id": "_:b300",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b741",
+                "@id": "_:b301",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1191,36 +3527,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl",
           "title": "Turtle-star - bad - literal in subject position of quoted triple",
           "assertions": [
             {
-              "@id": "_:b107",
+              "@id": "_:b638",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b27",
+                "@id": "_:b559",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b633",
+              "@id": "_:b414",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b634",
+                "@id": "_:b415",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1228,36 +3564,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl",
           "title": "Turtle-star - bad - blank node  as predicate in quoted triple",
           "assertions": [
             {
-              "@id": "_:b883",
+              "@id": "_:b555",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b188",
+                "@id": "_:b171",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b908",
+              "@id": "_:b50",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b259",
+                "@id": "_:b51",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1265,36 +3601,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl",
           "title": "Turtle-star - bad - compound blank node expression",
           "assertions": [
             {
-              "@id": "_:b863",
+              "@id": "_:b668",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b334",
+                "@id": "_:b62",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b300",
+              "@id": "_:b754",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b101",
+                "@id": "_:b755",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1302,36 +3638,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl",
           "title": "Turtle-star - bad - incomplete quoted triple",
           "assertions": [
             {
-              "@id": "_:b620",
+              "@id": "_:b188",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b2",
+                "@id": "_:b173",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b875",
+              "@id": "_:b753",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b545",
+                "@id": "_:b625",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1339,36 +3675,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl",
           "title": "Turtle-star - bad - over-long quoted triple",
           "assertions": [
             {
-              "@id": "_:b129",
+              "@id": "_:b367",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b130",
+                "@id": "_:b368",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b880",
+              "@id": "_:b107",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b125",
+                "@id": "_:b108",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1376,36 +3712,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl",
           "title": "Turtle-star - Annotation form",
           "assertions": [
             {
-              "@id": "_:b911",
+              "@id": "_:b766",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b563",
+                "@id": "_:b639",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b147",
+              "@id": "_:b298",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b148",
+                "@id": "_:b299",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1413,36 +3749,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl",
           "title": "Turtle-star - Annotation example",
           "assertions": [
             {
-              "@id": "_:b682",
+              "@id": "_:b832",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b683",
+                "@id": "_:b467",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b103",
+              "@id": "_:b738",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b104",
+                "@id": "_:b426",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1450,36 +3786,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl",
           "title": "Turtle-star - bad - empty annotation",
           "assertions": [
             {
-              "@id": "_:b709",
+              "@id": "_:b829",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b263",
+                "@id": "_:b686",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b652",
+              "@id": "_:b819",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b488",
+                "@id": "_:b451",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1487,36 +3823,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl",
           "title": "Turtle-star - bad - triple as annotation",
           "assertions": [
             {
-              "@id": "_:b44",
+              "@id": "_:b385",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b45",
+                "@id": "_:b386",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b515",
+              "@id": "_:b100",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b406",
+                "@id": "_:b101",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1524,36 +3860,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-1.ttl",
           "title": "N-Triples-star as Turtle-star - subject quoted triple",
           "assertions": [
             {
-              "@id": "_:b870",
+              "@id": "_:b312",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b314",
+                "@id": "_:b17",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b374",
+              "@id": "_:b287",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b321",
+                "@id": "_:b288",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1561,36 +3897,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-2.ttl",
           "title": "N-Triples-star as Turtle-star - object quoted triple",
           "assertions": [
             {
-              "@id": "_:b178",
+              "@id": "_:b732",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b179",
+                "@id": "_:b184",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b522",
+              "@id": "_:b914",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b523",
+                "@id": "_:b785",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1598,36 +3934,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-3.ttl",
           "title": "N-Triples-star as Turtle-star - subject and object quoted triples",
           "assertions": [
             {
-              "@id": "_:b369",
+              "@id": "_:b358",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b370",
+                "@id": "_:b359",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b419",
+              "@id": "_:b846",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b294",
+                "@id": "_:b97",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1635,36 +3971,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-4.ttl",
           "title": "N-Triples-star as Turtle-star - whitespace and terms",
           "assertions": [
             {
-              "@id": "_:b489",
+              "@id": "_:b873",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b490",
+                "@id": "_:b874",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b60",
+              "@id": "_:b70",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b61",
+                "@id": "_:b71",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1672,36 +4008,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
           "@type": [
-            "http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-5.ttl",
           "title": "N-Triples-star as Turtle-star - Nested, no whitespace",
           "assertions": [
             {
-              "@id": "_:b574",
+              "@id": "_:b931",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b575",
+                "@id": "_:b701",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b924",
+              "@id": "_:b919",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b189",
+                "@id": "_:b68",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1709,36 +4045,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-1.ttl",
           "title": "N-Triples-star as Turtle-star - Blank node subject",
           "assertions": [
             {
-              "@id": "_:b906",
+              "@id": "_:b677",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b699",
+                "@id": "_:b259",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b835",
+              "@id": "_:b727",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b373",
+                "@id": "_:b728",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1746,36 +4082,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-2.ttl",
           "title": "N-Triples-star as Turtle-star - Blank node object",
           "assertions": [
             {
-              "@id": "_:b738",
+              "@id": "_:b579",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b739",
+                "@id": "_:b88",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b673",
+              "@id": "_:b432",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b674",
+                "@id": "_:b82",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1783,36 +4119,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-1.ttl",
           "title": "N-Triples-star as Turtle-star - Nested subject term",
           "assertions": [
             {
-              "@id": "_:b770",
+              "@id": "_:b166",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b771",
+                "@id": "_:b167",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b831",
+              "@id": "_:b653",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b713",
+                "@id": "_:b246",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1820,36 +4156,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-2.ttl",
           "title": "N-Triples-star as Turtle-star - Nested object term",
           "assertions": [
             {
-              "@id": "_:b159",
+              "@id": "_:b534",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b138",
+                "@id": "_:b535",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b813",
+              "@id": "_:b296",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b814",
+                "@id": "_:b297",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1857,36 +4193,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-1.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - quoted triple as predicate",
           "assertions": [
             {
-              "@id": "_:b922",
+              "@id": "_:b581",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b923",
+                "@id": "_:b582",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b185",
+              "@id": "_:b362",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b186",
+                "@id": "_:b294",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1894,36 +4230,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-2.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - quoted triple, literal subject",
           "assertions": [
             {
-              "@id": "_:b909",
+              "@id": "_:b92",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b769",
+                "@id": "_:b93",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b94",
+              "@id": "_:b602",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b95",
+                "@id": "_:b65",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1931,36 +4267,36 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-3.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - quoted triple, literal predicate",
           "assertions": [
             {
-              "@id": "_:b897",
+              "@id": "_:b144",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b462",
+                "@id": "_:b145",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b86",
+              "@id": "_:b892",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b87",
+                "@id": "_:b428",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
@@ -1968,41 +4304,57 @@
         {
           "@id": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
           "@type": [
-            "TestCriterion",
+            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax",
             "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax"
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-4.ttl",
           "title": "N-Triples-star as Turtle-star - Bad - quoted triple, blank node predicate",
           "assertions": [
             {
-              "@id": "_:b859",
+              "@id": "_:b498",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b275",
+                "@id": "_:b499",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             },
             {
-              "@id": "_:b787",
+              "@id": "_:b223",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b788",
+                "@id": "_:b224",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/sparql",
               "assertedBy": null
             }
           ]
         }
-      ]
+      ],
+      "dc:creator": {
+        "@id": "_:b346",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "Turtle-star Syntax Tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
     },
     {
       "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest",
@@ -2010,42 +4362,58 @@
         "mf:Manifest",
         "Report"
       ],
-      "rdfs:label": "SPARQL-star Syntax Tests",
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-tests/"
+      },
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "fr",
+          "@value": "La suite des tests pour SPARQL-star"
+        },
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para SPARQL-star"
+        }
+      ],
       "entries": [
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq",
           "title": "SPARQL-star - subject quoted triple",
           "assertions": [
             {
-              "@id": "_:b894",
+              "@id": "_:b225",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b486",
+                "@id": "_:b226",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b855",
+              "@id": "_:b926",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b88",
+                "@id": "_:b326",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2053,36 +4421,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq",
           "title": "SPARQL-star - object quoted triple",
           "assertions": [
             {
-              "@id": "_:b499",
+              "@id": "_:b912",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b42",
+                "@id": "_:b884",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b312",
+              "@id": "_:b838",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b313",
+                "@id": "_:b321",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2090,36 +4458,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq",
           "title": "SPARQL-star - subject quoted triple - vars",
           "assertions": [
             {
-              "@id": "_:b888",
+              "@id": "_:b146",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b428",
+                "@id": "_:b147",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b720",
+              "@id": "_:b427",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b588",
+                "@id": "_:b205",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2127,36 +4495,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq",
           "title": "SPARQL-star - object quoted triple - vars",
           "assertions": [
             {
-              "@id": "_:b884",
+              "@id": "_:b678",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b20",
+                "@id": "_:b679",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b802",
+              "@id": "_:b721",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b591",
+                "@id": "_:b417",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2164,36 +4532,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq",
           "title": "SPARQL-star - Embedded triple in VALUES",
           "assertions": [
             {
-              "@id": "_:b357",
+              "@id": "_:b935",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b335",
+                "@id": "_:b709",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b401",
+              "@id": "_:b770",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b402",
+                "@id": "_:b56",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2201,36 +4569,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq",
           "title": "SPARQL-star - Embedded triple in CONSTRUCT",
           "assertions": [
             {
-              "@id": "_:b662",
+              "@id": "_:b600",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b663",
+                "@id": "_:b569",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b266",
+              "@id": "_:b607",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b267",
+                "@id": "_:b260",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2238,36 +4606,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq",
           "title": "SPARQL-star - Embedded triples in CONSTRUCT WHERE",
           "assertions": [
             {
-              "@id": "_:b801",
+              "@id": "_:b95",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b77",
+                "@id": "_:b96",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b715",
+              "@id": "_:b779",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b502",
+                "@id": "_:b667",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2275,36 +4643,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq",
           "title": "SPARQL-star - quoted triple inside blankNodePropertyList",
           "assertions": [
             {
-              "@id": "_:b223",
+              "@id": "_:b45",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b224",
+                "@id": "_:b46",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b693",
+              "@id": "_:b717",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b694",
+                "@id": "_:b659",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2312,36 +4680,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq",
           "title": "SPARQL-star - quoted triple inside collection",
           "assertions": [
             {
-              "@id": "_:b646",
+              "@id": "_:b771",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b293",
+                "@id": "_:b772",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b876",
+              "@id": "_:b615",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b636",
+                "@id": "_:b332",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2349,36 +4717,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq",
           "title": "SPARQL-star - nested quoted triple, subject position",
           "assertions": [
             {
-              "@id": "_:b133",
+              "@id": "_:b309",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b134",
+                "@id": "_:b310",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b729",
+              "@id": "_:b608",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b730",
+                "@id": "_:b121",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2386,36 +4754,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq",
           "title": "SPARQL-star - nested quoted triple, object position",
           "assertions": [
             {
-              "@id": "_:b759",
+              "@id": "_:b742",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b760",
+                "@id": "_:b4",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b614",
+              "@id": "_:b651",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b615",
+                "@id": "_:b652",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2423,36 +4791,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq",
           "title": "SPARQL-star - compound forms",
           "assertions": [
             {
-              "@id": "_:b512",
+              "@id": "_:b570",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b513",
+                "@id": "_:b102",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b56",
+              "@id": "_:b688",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b57",
+                "@id": "_:b456",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2460,36 +4828,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq",
           "title": "SPARQL-star - blank node subject",
           "assertions": [
             {
-              "@id": "_:b252",
+              "@id": "_:b768",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b253",
+                "@id": "_:b540",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b733",
+              "@id": "_:b847",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b734",
+                "@id": "_:b599",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2497,36 +4865,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq",
           "title": "SPARQL-star - blank node object",
           "assertions": [
             {
-              "@id": "_:b296",
+              "@id": "_:b484",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b297",
+                "@id": "_:b485",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b500",
+              "@id": "_:b243",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b501",
+                "@id": "_:b244",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2534,36 +4902,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq",
           "title": "SPARQL-star - blank node",
           "assertions": [
             {
-              "@id": "_:b482",
+              "@id": "_:b404",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b19",
+                "@id": "_:b405",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b32",
+              "@id": "_:b379",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b33",
+                "@id": "_:b35",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2571,36 +4939,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq",
           "title": "SPARQL-star - Annotation form",
           "assertions": [
             {
-              "@id": "_:b777",
+              "@id": "_:b903",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b111",
+                "@id": "_:b500",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b902",
+              "@id": "_:b347",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b306",
+                "@id": "_:b348",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2608,36 +4976,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq",
           "title": "SPARQL-star - Annotation example",
           "assertions": [
             {
-              "@id": "_:b848",
+              "@id": "_:b424",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b849",
+                "@id": "_:b425",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b155",
+              "@id": "_:b896",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b156",
+                "@id": "_:b752",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2645,36 +5013,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq",
           "title": "SPARQL-star - Annotation example",
           "assertions": [
             {
-              "@id": "_:b278",
+              "@id": "_:b594",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b279",
+                "@id": "_:b595",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b307",
+              "@id": "_:b830",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b308",
+                "@id": "_:b628",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2682,36 +5050,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq",
           "title": "SPARQL-star - Annotation with quoting",
           "assertions": [
             {
-              "@id": "_:b867",
+              "@id": "_:b936",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b628",
+                "@id": "_:b680",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b560",
+              "@id": "_:b74",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b533",
+                "@id": "_:b75",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2719,36 +5087,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq",
           "title": "SPARQL-star - Annotation on triple with quoted object",
           "assertions": [
             {
-              "@id": "_:b736",
+              "@id": "_:b475",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b737",
+                "@id": "_:b476",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b622",
+              "@id": "_:b920",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b150",
+                "@id": "_:b837",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2756,36 +5124,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq",
           "title": "SPARQL-star - Annotation with path",
           "assertions": [
             {
-              "@id": "_:b714",
+              "@id": "_:b844",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b363",
+                "@id": "_:b845",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b828",
+              "@id": "_:b508",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b829",
+                "@id": "_:b371",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2793,36 +5161,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq",
           "title": "SPARQL-star - Annotation with nested path",
           "assertions": [
             {
-              "@id": "_:b839",
+              "@id": "_:b247",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b654",
+                "@id": "_:b248",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b798",
+              "@id": "_:b494",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b483",
+                "@id": "_:b495",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2830,36 +5198,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq",
           "title": "SPARQL-star - Annotation in CONSTRUCT ",
           "assertions": [
             {
-              "@id": "_:b606",
+              "@id": "_:b907",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b607",
+                "@id": "_:b235",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b196",
+              "@id": "_:b900",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b197",
+                "@id": "_:b901",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2867,36 +5235,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq",
           "title": "SPARQL-star - Annotation in CONSTRUCT WHERE",
           "assertions": [
             {
-              "@id": "_:b271",
+              "@id": "_:b493",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b272",
+                "@id": "_:b266",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b119",
+              "@id": "_:b504",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b120",
+                "@id": "_:b505",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2904,36 +5272,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq",
           "title": "SPARQL-star - Expressions - Embedded triple",
           "assertions": [
             {
-              "@id": "_:b899",
+              "@id": "_:b530",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b359",
+                "@id": "_:b531",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b303",
+              "@id": "_:b644",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b304",
+                "@id": "_:b116",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2941,36 +5309,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq",
           "title": "SPARQL-star - Expressions - Embedded triple",
           "assertions": [
             {
-              "@id": "_:b475",
+              "@id": "_:b597",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b403",
+                "@id": "_:b598",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b653",
+              "@id": "_:b694",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b11",
+                "@id": "_:b40",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -2978,36 +5346,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq",
           "title": "SPARQL-star - Expressions - Functions",
           "assertions": [
             {
-              "@id": "_:b316",
+              "@id": "_:b271",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b317",
+                "@id": "_:b272",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b625",
+              "@id": "_:b477",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b626",
+                "@id": "_:b478",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -3015,36 +5383,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq",
           "title": "SPARQL-star - Expressions - TRIPLE",
           "assertions": [
             {
-              "@id": "_:b920",
+              "@id": "_:b458",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b525",
+                "@id": "_:b459",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b526",
+              "@id": "_:b406",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b124",
+                "@id": "_:b407",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -3052,36 +5420,36 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq",
           "title": "SPARQL-star - Expressions - Functions",
           "assertions": [
             {
-              "@id": "_:b586",
+              "@id": "_:b626",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b355",
+                "@id": "_:b627",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b861",
+              "@id": "_:b342",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b786",
+                "@id": "_:b343",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
@@ -3089,1261 +5457,2273 @@
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
           "@type": [
             "mf:PositiveSyntaxTest11",
-            "TestCriterion",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq",
           "title": "SPARQL-star - Expressions - BIND - CONSTRUCT",
           "assertions": [
             {
-              "@id": "_:b53",
+              "@id": "_:b236",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b54",
+                "@id": "_:b237",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b343",
+              "@id": "_:b810",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b344",
+                "@id": "_:b751",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq",
           "title": "SPARQL-star - bad - quoted triple as predicate",
           "assertions": [
             {
-              "@id": "_:b838",
+              "@id": "_:b360",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b476",
+                "@id": "_:b361",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b16",
+              "@id": "_:b314",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b17",
+                "@id": "_:b141",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq",
           "title": "SPARQL-star - bad - quoted triple outside triple",
           "assertions": [
             {
-              "@id": "_:b629",
+              "@id": "_:b927",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b214",
+                "@id": "_:b619",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b383",
+              "@id": "_:b842",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b384",
+                "@id": "_:b596",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq",
           "title": "SPARQL-star - bad - collection list in quoted triple",
           "assertions": [
             {
-              "@id": "_:b455",
+              "@id": "_:b840",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b456",
+                "@id": "_:b27",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b596",
+              "@id": "_:b383",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b597",
+                "@id": "_:b283",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq",
           "title": "SPARQL-star - bad - literal in subject position of quoted triple",
           "assertions": [
             {
-              "@id": "_:b742",
+              "@id": "_:b895",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b743",
+                "@id": "_:b193",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b387",
+              "@id": "_:b793",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b47",
+                "@id": "_:b168",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq",
           "title": "SPARQL-star - bad - blank node  as predicate in quoted triple",
           "assertions": [
             {
-              "@id": "_:b443",
+              "@id": "_:b194",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b444",
+                "@id": "_:b195",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b180",
+              "@id": "_:b824",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b181",
+                "@id": "_:b726",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq",
           "title": "SPARQL-star - bad - compound blank node expression",
           "assertions": [
             {
-              "@id": "_:b910",
+              "@id": "_:b5",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b149",
+                "@id": "_:b6",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b385",
+              "@id": "_:b79",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b386",
+                "@id": "_:b80",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq",
           "title": "SPARQL-star - bad - incomplete quoted triple",
           "assertions": [
             {
-              "@id": "_:b243",
+              "@id": "_:b565",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b244",
+                "@id": "_:b501",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b451",
+              "@id": "_:b643",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b452",
+                "@id": "_:b573",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq",
           "title": "SPARQL-star - bad - quad quoted triple",
           "assertions": [
             {
-              "@id": "_:b550",
+              "@id": "_:b354",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b551",
+                "@id": "_:b355",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b440",
+              "@id": "_:b110",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b228",
+                "@id": "_:b111",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq",
           "title": "SPARQL-star - bad - variable in quoted triple in VALUES ",
           "assertions": [
             {
-              "@id": "_:b570",
+              "@id": "_:b609",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b229",
+                "@id": "_:b610",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b697",
+              "@id": "_:b910",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b291",
+                "@id": "_:b783",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq",
           "title": "SPARQL-star - bad - blank node in quoted triple in VALUES ",
           "assertions": [
             {
-              "@id": "_:b565",
+              "@id": "_:b219",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b90",
+                "@id": "_:b220",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b408",
+              "@id": "_:b200",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b409",
+                "@id": "_:b201",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-11.rq",
           "title": "SPARQL-star - bad - blank node in quoted triple in FILTER",
           "assertions": [
             {
-              "@id": "_:b417",
+              "@id": "_:b902",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b418",
+                "@id": "_:b151",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b421",
+              "@id": "_:b76",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b160",
+                "@id": "_:b77",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-12.rq",
           "title": "SPARQL-star - bad - blank node in quoted triple in BIND",
           "assertions": [
             {
-              "@id": "_:b823",
+              "@id": "_:b372",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b613",
+                "@id": "_:b373",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b315",
+              "@id": "_:b633",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b154",
+                "@id": "_:b634",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq",
           "title": "SPARQL-star - bad - empty annotation",
           "assertions": [
             {
-              "@id": "_:b28",
+              "@id": "_:b496",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b29",
+                "@id": "_:b497",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b237",
+              "@id": "_:b636",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b238",
+                "@id": "_:b637",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq",
           "title": "SPARQL-star - bad - triples in annotation",
           "assertions": [
             {
-              "@id": "_:b794",
+              "@id": "_:b483",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b795",
+                "@id": "_:b241",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b917",
+              "@id": "_:b418",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b479",
+                "@id": "_:b419",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq",
           "title": "SPARQL-star - bad - path - seq",
           "assertions": [
             {
-              "@id": "_:b537",
+              "@id": "_:b257",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b416",
+                "@id": "_:b258",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b429",
+              "@id": "_:b479",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b430",
+                "@id": "_:b480",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq",
           "title": "SPARQL-star - bad - path - alt",
           "assertions": [
             {
-              "@id": "_:b873",
+              "@id": "_:b835",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b681",
+                "@id": "_:b836",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b411",
+              "@id": "_:b928",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b412",
+                "@id": "_:b784",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq",
           "title": "SPARQL-star - bad - path - p*",
           "assertions": [
             {
-              "@id": "_:b301",
+              "@id": "_:b748",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b302",
+                "@id": "_:b192",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b21",
+              "@id": "_:b662",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b22",
+                "@id": "_:b663",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq",
           "title": "SPARQL-star - bad - path - p+",
           "assertions": [
             {
-              "@id": "_:b413",
+              "@id": "_:b411",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b414",
+                "@id": "_:b412",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b520",
+              "@id": "_:b174",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b521",
+                "@id": "_:b175",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq",
           "title": "SPARQL-star - bad - path - p?",
           "assertions": [
             {
-              "@id": "_:b298",
+              "@id": "_:b934",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b299",
+                "@id": "_:b613",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b695",
+              "@id": "_:b796",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b696",
+                "@id": "_:b185",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq",
           "title": "SPARQL-star - bad - path in CONSTRUCT",
           "assertions": [
             {
-              "@id": "_:b510",
+              "@id": "_:b302",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b511",
+                "@id": "_:b303",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b388",
+              "@id": "_:b393",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b389",
+                "@id": "_:b231",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
           "@type": [
+            "mf:NegativeSyntaxTest11",
             "TestCriterion",
-            "TestCase",
-            "mf:NegativeSyntaxTest11"
+            "TestCase"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq",
           "title": "SPARQL-star - bad - path in CONSTRUCT",
           "assertions": [
             {
-              "@id": "_:b825",
+              "@id": "_:b261",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b39",
+                "@id": "_:b218",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b778",
+              "@id": "_:b481",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b756",
+                "@id": "_:b482",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru",
           "title": "SPARQL-star - update",
           "assertions": [
             {
-              "@id": "_:b112",
+              "@id": "_:b843",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b113",
+                "@id": "_:b747",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b749",
+              "@id": "_:b899",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b566",
+                "@id": "_:b734",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru",
           "title": "SPARQL-star - update",
           "assertions": [
             {
-              "@id": "_:b638",
+              "@id": "_:b131",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b162",
+                "@id": "_:b132",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b424",
+              "@id": "_:b924",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b425",
+                "@id": "_:b255",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru",
           "title": "SPARQL-star - update",
           "assertions": [
             {
-              "@id": "_:b799",
+              "@id": "_:b795",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b630",
+                "@id": "_:b558",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b465",
+              "@id": "_:b813",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b466",
+                "@id": "_:b661",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru",
           "title": "SPARQL-star - update with quoting",
           "assertions": [
             {
-              "@id": "_:b762",
+              "@id": "_:b918",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b661",
+                "@id": "_:b26",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b856",
+              "@id": "_:b117",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b780",
+                "@id": "_:b118",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru",
           "title": "SPARQL-star - update with quoted object",
           "assertions": [
             {
-              "@id": "_:b204",
+              "@id": "_:b937",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b205",
+                "@id": "_:b780",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b7",
+              "@id": "_:b439",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b8",
+                "@id": "_:b440",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru",
           "title": "SPARQL-star - update with annotation template",
           "assertions": [
             {
-              "@id": "_:b270",
+              "@id": "_:b654",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
                 "@id": "_:b172",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b872",
+              "@id": "_:b401",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b434",
+                "@id": "_:b402",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru",
           "title": "SPARQL-star - update with annotation, template and pattern",
           "assertions": [
             {
-              "@id": "_:b651",
+              "@id": "_:b814",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b627",
+                "@id": "_:b745",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b435",
+              "@id": "_:b718",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b436",
+                "@id": "_:b719",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
           "@type": [
-            "TestCriterion",
             "mf:PositiveUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru",
           "title": "SPARQL-star - update DATA with annotation",
           "assertions": [
             {
-              "@id": "_:b377",
+              "@id": "_:b199",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b378",
+                "@id": "_:b115",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b704",
+              "@id": "_:b545",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b210",
+                "@id": "_:b546",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
           "@type": [
-            "TestCriterion",
             "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru",
           "title": "SPARQL-star - update - bad syntax",
           "assertions": [
             {
-              "@id": "_:b583",
+              "@id": "_:b390",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b532",
+                "@id": "_:b391",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b826",
+              "@id": "_:b851",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b258",
+                "@id": "_:b94",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
           "@type": [
-            "TestCriterion",
             "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru",
           "title": "SPARQL-star - update - bad syntax",
           "assertions": [
             {
-              "@id": "_:b495",
+              "@id": "_:b63",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b496",
+                "@id": "_:b64",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b608",
+              "@id": "_:b894",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b487",
+                "@id": "_:b853",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
           "@type": [
-            "TestCriterion",
             "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru",
           "title": "SPARQL-star - update - bad syntax",
           "assertions": [
             {
-              "@id": "_:b671",
+              "@id": "_:b809",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b672",
+                "@id": "_:b657",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b558",
+              "@id": "_:b11",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b559",
+                "@id": "_:b12",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
           "@type": [
-            "TestCriterion",
             "mf:NegativeUpdateSyntaxTest11",
-            "TestCase"
+            "TestCase",
+            "TestCriterion"
           ],
           "testAction": "https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru",
           "title": "SPARQL-star - update - bad syntax",
           "assertions": [
             {
-              "@id": "_:b276",
+              "@id": "_:b655",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b277",
+                "@id": "_:b656",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b684",
+              "@id": "_:b722",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b685",
+                "@id": "_:b696",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         }
-      ]
+      ],
+      "dc:creator": {
+        "@id": "_:b1",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "SPARQL-star Syntax Tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-tests/"
+      },
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "fr",
+          "@value": "La suite des tests pour évaluation de TriG-star"
+        },
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para evaluar Trig-star"
+        }
+      ],
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq",
+          "title": "TriG-star - subject quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b206",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b207",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b906",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
+              "result": {
+                "@id": "_:b136",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq",
+          "title": "TriG-star - object quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b349",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b350",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b887",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
+              "result": {
+                "@id": "_:b551",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq",
+          "title": "TriG-star - blank node label",
+          "assertions": [
+            {
+              "@id": "_:b862",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b228",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b90",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
+              "result": {
+                "@id": "_:b91",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq",
+          "title": "TriG-star - blank node labels",
+          "assertions": [
+            {
+              "@id": "_:b801",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b802",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b623",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
+              "result": {
+                "@id": "_:b624",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq",
+          "title": "TriG-star - Annotation form",
+          "assertions": [
+            {
+              "@id": "_:b22",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b23",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b375",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
+              "result": {
+                "@id": "_:b376",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq",
+          "title": "TriG-star - Annotation example",
+          "assertions": [
+            {
+              "@id": "_:b925",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b468",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b203",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
+              "result": {
+                "@id": "_:b204",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq",
+          "title": "TriG-star - Annotation - predicate and object lists",
+          "assertions": [
+            {
+              "@id": "_:b333",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b334",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b879",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
+              "result": {
+                "@id": "_:b286",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq",
+          "title": "TriG-star - Annotation - nested",
+          "assertions": [
+            {
+              "@id": "_:b769",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b240",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b921",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
+              "result": {
+                "@id": "_:b455",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq",
+          "title": "TriG-star - Annotation object list",
+          "assertions": [
+            {
+              "@id": "_:b816",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b181",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b917",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
+              "result": {
+                "@id": "_:b533",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.nq",
+          "title": "TriG-star - Annotation with quoting",
+          "assertions": [
+            {
+              "@id": "_:b387",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b388",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b807",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1",
+              "result": {
+                "@id": "_:b311",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.nq",
+          "title": "TriG-star - Annotation on triple with quoted subject",
+          "assertions": [
+            {
+              "@id": "_:b304",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b305",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b872",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2",
+              "result": {
+                "@id": "_:b254",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3",
+          "@type": [
+            "TestCase",
+            "http://www.w3.org/ns/rdftest#TestTrigEval",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.trig",
+          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.nq",
+          "title": "TriG-star - Annotation on triple with quoted object",
+          "assertions": [
+            {
+              "@id": "_:b859",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b682",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b526",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3",
+              "result": {
+                "@id": "_:b527",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        }
+      ],
+      "dc:creator": {
+        "@id": "_:b420",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "TriG-star Evaluation Tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
+    },
+    {
+      "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-tests/"
+      },
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para Turtle-star"
+        },
+        {
+          "@language": "fr",
+          "@value": "La suite des tests pour Turtle-star"
+        }
+      ],
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt",
+          "title": "Turtle-star - subject quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b616",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b42",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b817",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
+              "result": {
+                "@id": "_:b55",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt",
+          "title": "Turtle-star - object quoted triple",
+          "assertions": [
+            {
+              "@id": "_:b352",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b353",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b553",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
+              "result": {
+                "@id": "_:b335",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt",
+          "title": "Turtle-star - blank node label",
+          "assertions": [
+            {
+              "@id": "_:b528",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b529",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b536",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
+              "result": {
+                "@id": "_:b537",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt",
+          "title": "Turtle-star - blank node labels",
+          "assertions": [
+            {
+              "@id": "_:b826",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b827",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b506",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
+              "result": {
+                "@id": "_:b285",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt",
+          "title": "Turtle-star - Annotation form",
+          "assertions": [
+            {
+              "@id": "_:b574",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b473",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b890",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
+              "result": {
+                "@id": "_:b714",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt",
+          "title": "Turtle-star - Annotation example",
+          "assertions": [
+            {
+              "@id": "_:b575",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b576",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b776",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
+              "result": {
+                "@id": "_:b601",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt",
+          "title": "Turtle-star - Annotation - predicate and object lists",
+          "assertions": [
+            {
+              "@id": "_:b394",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b395",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b765",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
+              "result": {
+                "@id": "_:b520",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt",
+          "title": "Turtle-star - Annotation - nested",
+          "assertions": [
+            {
+              "@id": "_:b190",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b191",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b650",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
+              "result": {
+                "@id": "_:b621",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt",
+          "title": "Turtle-star - Annotation object list",
+          "assertions": [
+            {
+              "@id": "_:b788",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b315",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b465",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
+              "result": {
+                "@id": "_:b466",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.nt",
+          "title": "Turtle-star - Annotation with quoting",
+          "assertions": [
+            {
+              "@id": "_:b448",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b10",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b789",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1",
+              "result": {
+                "@id": "_:b790",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.nt",
+          "title": "Turtle-star - Annotation on triple with quoted subject",
+          "assertions": [
+            {
+              "@id": "_:b409",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b176",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b773",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2",
+              "result": {
+                "@id": "_:b774",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestTurtleEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.ttl",
+          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.nt",
+          "title": "Turtle-star - Annotation on triple with quoted object",
+          "assertions": [
+            {
+              "@id": "_:b275",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "subject": "https://rubygems.org/gems/rdf-trig",
+              "result": {
+                "@id": "_:b276",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            },
+            {
+              "@id": "_:b915",
+              "@type": "Assertion",
+              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3",
+              "result": {
+                "@id": "_:b369",
+                "@type": "TestResult",
+                "outcome": "earl:untested"
+              },
+              "subject": "https://rubygems.org/gems/sparql",
+              "assertedBy": null
+            }
+          ]
+        }
+      ],
+      "dc:creator": {
+        "@id": "_:b681",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "Turtle-star Evaluation Tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
     },
     {
       "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#manifest",
@@ -4351,17 +7731,33 @@
         "mf:Manifest",
         "Report"
       ],
-      "rdfs:label": "SPARQL-star Evaluation Tests",
+      "rdfs:seeAlso": {
+        "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/README"
+      },
+      "dc:issued": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-06-21"
+      },
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "fr",
+          "@value": "La suite des tests d'évaluation de SPARQL-star"
+        },
+        {
+          "@language": "es",
+          "@value": "Conjunto de pruebas para evaluar SPARQL-star"
+        }
+      ],
       "entries": [
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b427",
+            "@id": "_:b127",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
             },
@@ -4373,41 +7769,41 @@
           "title": "SPARQL-star - all graph triples (JSON results)",
           "assertions": [
             {
-              "@id": "_:b659",
+              "@id": "_:b841",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b660",
+                "@id": "_:b695",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b753",
+              "@id": "_:b125",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b635",
+                "@id": "_:b126",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b195",
+            "@id": "_:b345",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-0.ttl"
             },
@@ -4419,41 +7815,41 @@
           "title": "SPARQL-star - all graph triples (XML results)",
           "assertions": [
             {
-              "@id": "_:b193",
+              "@id": "_:b866",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b194",
+                "@id": "_:b542",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b233",
+              "@id": "_:b672",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b234",
+                "@id": "_:b673",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b55",
+            "@id": "_:b150",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
             },
@@ -4465,41 +7861,41 @@
           "title": "SPARQL-star - match constant quoted triple",
           "assertions": [
             {
-              "@id": "_:b862",
+              "@id": "_:b148",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b470",
+                "@id": "_:b149",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b623",
+              "@id": "_:b908",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b624",
+                "@id": "_:b399",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b23",
+            "@id": "_:b114",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
             },
@@ -4511,41 +7907,41 @@
           "title": "SPARQL-star - match quoted triple, var subject",
           "assertions": [
             {
-              "@id": "_:b262",
+              "@id": "_:b112",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b166",
+                "@id": "_:b113",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b616",
+              "@id": "_:b875",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b617",
+                "@id": "_:b502",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b121",
+            "@id": "_:b87",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
             },
@@ -4557,41 +7953,41 @@
           "title": "SPARQL-star - match quoted triple, var predicate",
           "assertions": [
             {
-              "@id": "_:b800",
+              "@id": "_:b560",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b619",
+                "@id": "_:b561",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b865",
+              "@id": "_:b630",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b555",
+                "@id": "_:b631",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b305",
+            "@id": "_:b165",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
             },
@@ -4603,41 +7999,41 @@
           "title": "SPARQL-star - match quoted triple, var object",
           "assertions": [
             {
-              "@id": "_:b817",
+              "@id": "_:b822",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b818",
+                "@id": "_:b823",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b567",
+              "@id": "_:b854",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b170",
+                "@id": "_:b370",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b261",
+            "@id": "_:b277",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-1.ttl"
             },
@@ -4649,41 +8045,41 @@
           "title": "SPARQL-star - no match of quoted triple",
           "assertions": [
             {
-              "@id": "_:b287",
+              "@id": "_:b377",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b288",
+                "@id": "_:b378",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b460",
+              "@id": "_:b698",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b461",
+                "@id": "_:b571",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b157",
+            "@id": "_:b416",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -4695,41 +8091,41 @@
           "title": "SPARQL-star - Asserted and quoted triple",
           "assertions": [
             {
-              "@id": "_:b664",
+              "@id": "_:b870",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b98",
+                "@id": "_:b861",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b640",
+              "@id": "_:b893",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b641",
+                "@id": "_:b735",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b110",
+            "@id": "_:b154",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -4741,41 +8137,41 @@
           "title": "SPARQL-star -  Asserted and quoted triple",
           "assertions": [
             {
-              "@id": "_:b309",
+              "@id": "_:b519",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b310",
+                "@id": "_:b230",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b108",
+              "@id": "_:b152",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b109",
+                "@id": "_:b153",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b230",
+            "@id": "_:b140",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -4787,41 +8183,41 @@
           "title": "SPARQL-star - Pattern - Variable for quoted triple",
           "assertions": [
             {
-              "@id": "_:b247",
+              "@id": "_:b138",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b248",
+                "@id": "_:b139",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b493",
+              "@id": "_:b707",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b168",
+                "@id": "_:b591",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b85",
+            "@id": "_:b438",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -4833,41 +8229,41 @@
           "title": "SPARQL-star - Pattern - No match",
           "assertions": [
             {
-              "@id": "_:b83",
+              "@id": "_:b436",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b84",
+                "@id": "_:b437",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b773",
+              "@id": "_:b660",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b554",
+                "@id": "_:b403",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b231",
+            "@id": "_:b357",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -4879,41 +8275,41 @@
           "title": "SPARQL-star - Pattern - match variables in triple terms",
           "assertions": [
             {
-              "@id": "_:b539",
+              "@id": "_:b877",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b540",
+                "@id": "_:b767",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b549",
+              "@id": "_:b867",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b536",
+                "@id": "_:b825",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b69",
+            "@id": "_:b39",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -4925,41 +8321,41 @@
           "title": "SPARQL-star - Pattern - Nesting 1",
           "assertions": [
             {
-              "@id": "_:b600",
+              "@id": "_:b37",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b601",
+                "@id": "_:b38",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b717",
+              "@id": "_:b365",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b573",
+                "@id": "_:b319",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b165",
+            "@id": "_:b213",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -4971,41 +8367,41 @@
           "title": "SPARQL-star - Pattern - Nesting - 2",
           "assertions": [
             {
-              "@id": "_:b834",
+              "@id": "_:b211",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b793",
+                "@id": "_:b212",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b175",
+              "@id": "_:b710",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b176",
+                "@id": "_:b711",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b18",
+            "@id": "_:b280",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-2.ttl"
             },
@@ -5017,41 +8413,41 @@
           "title": "SPARQL-star - Pattern - Match and nesting",
           "assertions": [
             {
-              "@id": "_:b758",
+              "@id": "_:b891",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b140",
+                "@id": "_:b761",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b837",
+              "@id": "_:b278",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b721",
+                "@id": "_:b279",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b543",
+            "@id": "_:b106",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-5.ttl"
             },
@@ -5063,41 +8459,41 @@
           "title": "SPARQL-star - Pattern - Same variable",
           "assertions": [
             {
-              "@id": "_:b919",
+              "@id": "_:b344",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b846",
+                "@id": "_:b85",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b686",
+              "@id": "_:b548",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b687",
+                "@id": "_:b549",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b441",
+            "@id": "_:b208",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
             },
@@ -5109,41 +8505,41 @@
           "title": "SPARQL-star - CONSTRUCT with constant template",
           "assertions": [
             {
-              "@id": "_:b912",
+              "@id": "_:b739",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b519",
+                "@id": "_:b242",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b618",
+              "@id": "_:b514",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b471",
+                "@id": "_:b29",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b350",
+            "@id": "_:b238",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
             },
@@ -5155,41 +8551,41 @@
           "title": "SPARQL-star - CONSTRUCT WHERE with constant template",
           "assertions": [
             {
-              "@id": "_:b843",
+              "@id": "_:b871",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b830",
+                "@id": "_:b687",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b349",
+              "@id": "_:b421",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b102",
+                "@id": "_:b422",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b530",
+            "@id": "_:b284",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
             },
@@ -5201,41 +8597,41 @@
           "title": "SPARQL-star - CONSTRUCT - about every triple",
           "assertions": [
             {
-              "@id": "_:b748",
+              "@id": "_:b647",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b145",
+                "@id": "_:b307",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b929",
+              "@id": "_:b878",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b822",
+                "@id": "_:b762",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b26",
+            "@id": "_:b28",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
             },
@@ -5247,41 +8643,41 @@
           "title": "SPARQL-star - CONSTRUCT with annotation syntax",
           "assertions": [
             {
-              "@id": "_:b708",
+              "@id": "_:b119",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b531",
+                "@id": "_:b120",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b24",
+              "@id": "_:b515",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b25",
+                "@id": "_:b400",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b348",
+            "@id": "_:b16",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-3.ttl"
             },
@@ -5293,41 +8689,41 @@
           "title": "SPARQL-star - CONSTRUCT WHERE with annotation syntax",
           "assertions": [
             {
-              "@id": "_:b824",
+              "@id": "_:b14",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b585",
+                "@id": "_:b15",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b346",
+              "@id": "_:b746",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b347",
+                "@id": "_:b366",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b324",
+            "@id": "_:b693",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
             },
@@ -5339,41 +8735,41 @@
           "title": "SPARQL-star - GRAPH",
           "assertions": [
             {
-              "@id": "_:b604",
+              "@id": "_:b744",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b529",
+                "@id": "_:b398",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b322",
+              "@id": "_:b691",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b323",
+                "@id": "_:b692",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b118",
+            "@id": "_:b328",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
             },
@@ -5385,41 +8781,41 @@
           "title": "SPARQL-star - GRAPHs with blank node",
           "assertions": [
             {
-              "@id": "_:b745",
+              "@id": "_:b756",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b746",
+                "@id": "_:b757",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b852",
+              "@id": "_:b585",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b648",
+                "@id": "_:b586",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b5",
+            "@id": "_:b198",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-4.trig"
             },
@@ -5431,41 +8827,41 @@
           "title": "SPARQL-star - Embedded triple - BIND - CONSTRUCT",
           "assertions": [
             {
-              "@id": "_:b657",
+              "@id": "_:b396",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b658",
+                "@id": "_:b397",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b3",
+              "@id": "_:b699",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b4",
+                "@id": "_:b522",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b362",
+            "@id": "_:b264",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/empty.nq"
             },
@@ -5477,41 +8873,41 @@
           "title": "SPARQL-star - Embedded triple - Functions",
           "assertions": [
             {
-              "@id": "_:b612",
+              "@id": "_:b262",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b494",
+                "@id": "_:b263",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b360",
+              "@id": "_:b685",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b361",
+                "@id": "_:b86",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b146",
+            "@id": "_:b135",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
             },
@@ -5523,41 +8919,41 @@
           "title": "SPARQL-star - Embedded triple - sameTerm",
           "assertions": [
             {
-              "@id": "_:b527",
+              "@id": "_:b232",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b292",
+                "@id": "_:b233",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b754",
+              "@id": "_:b133",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b755",
+                "@id": "_:b134",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b268",
+            "@id": "_:b61",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
             },
@@ -5569,41 +8965,41 @@
           "title": "SPARQL-star - Embedded triple - value-equality",
           "assertions": [
             {
-              "@id": "_:b820",
+              "@id": "_:b59",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b67",
+                "@id": "_:b60",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b907",
+              "@id": "_:b777",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b260",
+                "@id": "_:b778",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b184",
+            "@id": "_:b7",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
             },
@@ -5615,41 +9011,41 @@
           "title": "SPARQL-star - Embedded triple - value-inequality",
           "assertions": [
             {
-              "@id": "_:b763",
+              "@id": "_:b929",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b464",
+                "@id": "_:b580",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b914",
+              "@id": "_:b736",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b915",
+                "@id": "_:b737",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b76",
+            "@id": "_:b252",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-7.ttl"
             },
@@ -5661,41 +9057,41 @@
           "title": "SPARQL-star - Embedded triple - value-inequality",
           "assertions": [
             {
-              "@id": "_:b595",
+              "@id": "_:b552",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b446",
+                "@id": "_:b322",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b74",
+              "@id": "_:b532",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b75",
+                "@id": "_:b434",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b433",
+            "@id": "_:b34",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-order-kind.ttl"
             },
@@ -5707,41 +9103,41 @@
           "title": "SPARQL-star - Embedded triple - ORDER BY",
           "assertions": [
             {
-              "@id": "_:b700",
+              "@id": "_:b881",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b535",
+                "@id": "_:b658",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b854",
+              "@id": "_:b32",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b851",
+                "@id": "_:b33",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
           "@type": [
+            "mf:QueryEvaluationTest",
             "TestCriterion",
-            "TestCase",
-            "mf:QueryEvaluationTest"
+            "TestCase"
           ],
           "testAction": {
-            "@id": "_:b217",
+            "@id": "_:b249",
             "http://www.w3.org/2001/sw/DataAccess/tests/test-query#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/data-order.ttl"
             },
@@ -5753,41 +9149,41 @@
           "title": "SPARQL-star - Embedded triple - ordering",
           "assertions": [
             {
-              "@id": "_:b215",
+              "@id": "_:b786",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b216",
+                "@id": "_:b787",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b821",
+              "@id": "_:b833",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b819",
+                "@id": "_:b543",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:UpdateEvaluationTest"
+            "mf:UpdateEvaluationTest",
+            "TestCriterion"
           ],
           "testAction": {
-            "@id": "_:b14",
+            "@id": "_:b216",
             "http://www.w3.org/2009/sparql/tests/test-update#request": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-1.ru"
             },
@@ -5796,7 +9192,7 @@
             }
           },
           "testResult": {
-            "@id": "_:b15",
+            "@id": "_:b217",
             "http://www.w3.org/2009/sparql/tests/test-update#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-1.trig"
             }
@@ -5804,41 +9200,41 @@
           "title": "SPARQL-star - Update",
           "assertions": [
             {
-              "@id": "_:b12",
+              "@id": "_:b587",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b13",
+                "@id": "_:b588",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b58",
+              "@id": "_:b214",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b59",
+                "@id": "_:b215",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:UpdateEvaluationTest"
+            "mf:UpdateEvaluationTest",
+            "TestCriterion"
           ],
           "testAction": {
-            "@id": "_:b0",
+            "@id": "_:b338",
             "http://www.w3.org/2009/sparql/tests/test-update#request": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-2.ru"
             },
@@ -5847,7 +9243,7 @@
             }
           },
           "testResult": {
-            "@id": "_:b1",
+            "@id": "_:b339",
             "http://www.w3.org/2009/sparql/tests/test-update#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-2.trig"
             }
@@ -5855,41 +9251,41 @@
           "title": "SPARQL-star - Update - annotation",
           "assertions": [
             {
-              "@id": "_:b187",
+              "@id": "_:b716",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
-              "subject": "https://rubygems.org/gems/rdf-trig",
               "result": {
-                "@id": "_:b82",
+                "@id": "_:b408",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
+              "subject": "https://rubygems.org/gems/rdf-trig",
               "assertedBy": null
             },
             {
-              "@id": "_:b916",
+              "@id": "_:b922",
               "@type": "Assertion",
               "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2",
+              "mode": "earl:automatic",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b774",
+                "@id": "_:b538",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
+              }
             }
           ]
         },
         {
           "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
           "@type": [
-            "TestCriterion",
             "TestCase",
-            "mf:UpdateEvaluationTest"
+            "mf:UpdateEvaluationTest",
+            "TestCriterion"
           ],
           "testAction": {
-            "@id": "_:b202",
+            "@id": "_:b209",
             "http://www.w3.org/2009/sparql/tests/test-update#request": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-update-3.ru"
             },
@@ -5898,7 +9294,7 @@
             }
           },
           "testResult": {
-            "@id": "_:b203",
+            "@id": "_:b210",
             "http://www.w3.org/2009/sparql/tests/test-update#data": {
               "@id": "https://w3c.github.io/rdf-star/tests/sparql/eval/update-result-3.trig"
             }
@@ -5906,3230 +9302,84 @@
           "title": "SPARQL-star - Update - data",
           "assertions": [
             {
-              "@id": "_:b200",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b201",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b775",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b776",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "rdfs:label": "TriG-star Syntax Tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig",
-          "title": "TriG-star - subject quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b752",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b325",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b503",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b177",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig",
-          "title": "TriG-star - object quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b689",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b690",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b796",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b546",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig",
-          "title": "TriG-star - quoted triple inside blankNodePropertyList",
-          "assertions": [
-            {
-              "@id": "_:b457",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b458",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b319",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b320",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig",
-          "title": "TriG-star - quoted triple inside collection",
-          "assertions": [
-            {
-              "@id": "_:b728",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b688",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b544",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b281",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig",
-          "title": "TriG-star - nested quoted triple, subject position",
-          "assertions": [
-            {
-              "@id": "_:b505",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b506",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b163",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b164",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig",
-          "title": "TriG-star - nested quoted triple, object position",
-          "assertions": [
-            {
-              "@id": "_:b722",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b358",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b472",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b473",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig",
-          "title": "TriG-star - compound forms",
-          "assertions": [
-            {
-              "@id": "_:b30",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b31",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b750",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b91",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig",
-          "title": "TriG-star - blank node subject",
-          "assertions": [
-            {
-              "@id": "_:b751",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b584",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b832",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b650",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig",
-          "title": "TriG-star - blank node object",
-          "assertions": [
-            {
-              "@id": "_:b765",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b766",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b885",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b866",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig",
-          "title": "TriG-star - blank node",
-          "assertions": [
-            {
-              "@id": "_:b680",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b572",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b283",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b284",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig",
-          "title": "TriG-star - bad - quoted triple as predicate",
-          "assertions": [
-            {
-              "@id": "_:b341",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b342",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b892",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b295",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig",
-          "title": "TriG-star - bad - quoted triple outside triple",
-          "assertions": [
-            {
-              "@id": "_:b239",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b240",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b858",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b783",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig",
-          "title": "TriG-star - bad - collection list in quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b285",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b286",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b576",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b516",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig",
-          "title": "TriG-star - bad - literal in subject position of quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b553",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b70",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b724",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b725",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig",
-          "title": "TriG-star - bad - blank node  as predicate in quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b836",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b62",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b913",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b117",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig",
-          "title": "TriG-star - bad - compound blank node expression",
-          "assertions": [
-            {
-              "@id": "_:b649",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b68",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b804",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b222",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig",
-          "title": "TriG-star - bad - incomplete quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b667",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b668",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b397",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b398",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig",
-          "title": "TriG-star - bad - over-long quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b269",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b167",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b225",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b226",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig",
-          "title": "TriG-star - Annotation form",
-          "assertions": [
-            {
-              "@id": "_:b732",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b639",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b151",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b128",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig",
-          "title": "TriG-star - Annotation example",
-          "assertions": [
-            {
-              "@id": "_:b887",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b710",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b528",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b218",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig",
-          "title": "TriG-star - bad - empty annotation",
-          "assertions": [
-            {
-              "@id": "_:b50",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b51",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b431",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b432",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig",
-          "title": "TriG-star - bad - triple as annotation",
-          "assertions": [
-            {
-              "@id": "_:b669",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b498",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b928",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b707",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "rdfs:label": "TriG-star Evaluation Tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq",
-          "title": "TriG-star - subject quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b467",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b468",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b602",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b603",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq",
-          "title": "TriG-star - object quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b105",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b106",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b122",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b123",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq",
-          "title": "TriG-star - blank node label",
-          "assertions": [
-            {
-              "@id": "_:b735",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b524",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b599",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b504",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq",
-          "title": "TriG-star - blank node labels",
-          "assertions": [
-            {
-              "@id": "_:b764",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b354",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b898",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b439",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq",
-          "title": "TriG-star - Annotation form",
-          "assertions": [
-            {
-              "@id": "_:b437",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b438",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b422",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b423",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq",
-          "title": "TriG-star - Annotation example",
-          "assertions": [
-            {
-              "@id": "_:b136",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b137",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b73",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b43",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq",
-          "title": "TriG-star - Annotation - predicate and object lists",
-          "assertions": [
-            {
-              "@id": "_:b789",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b790",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b864",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b426",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq",
-          "title": "TriG-star - Annotation - nested",
-          "assertions": [
-            {
-              "@id": "_:b152",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b153",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b882",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b497",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq",
-          "title": "TriG-star - Annotation object list",
-          "assertions": [
-            {
-              "@id": "_:b99",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b100",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b367",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b368",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.nq",
-          "title": "TriG-star - Annotation with quoting",
-          "assertions": [
-            {
-              "@id": "_:b142",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b143",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b208",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b209",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.nq",
-          "title": "TriG-star - Annotation on triple with quoted subject",
-          "assertions": [
-            {
-              "@id": "_:b665",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b666",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b453",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b454",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTrigEval",
-            "TestCase",
-            "TestCriterion"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.trig",
-          "testResult": "https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.nq",
-          "title": "TriG-star - Annotation on triple with quoted object",
-          "assertions": [
-            {
-              "@id": "_:b63",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b64",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b881",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b792",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/semantics#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
-      ],
-      "rdfs:seeAlso": {
-        "@id": "https://w3c.github.io/rdf-star/tests/semantics/README"
-      },
-      "rdfs:label": "RDF-star Semantics tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl",
-          "rdfs:comment": "Multiple occurences of the same quoted triples are undistinguishable in the abstract model.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "all-identical-quoted-triples-are-the-same",
-          "assertions": [
-            {
-              "@id": "_:b610",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b611",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b877",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b445",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test005.ttl",
-          "rdfs:comment": "This test ensures that other entailments are not spurious.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "quoted-triples-no-spurious",
-          "assertions": [
-            {
-              "@id": "_:b744",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b213",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b339",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b340",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl",
-          "rdfs:comment": "Terms in quoted triples can be replaced by fresh bnodes.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "bnodes-in-quoted-subject",
-          "assertions": [
-            {
-              "@id": "_:b893",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b791",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b871",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b637",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
-          "rdfs:comment": "Terms in quoted triples can be replaced by fresh bnodes.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "bnodes-in-quoted-object",
-          "assertions": [
-            {
-              "@id": "_:b779",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b459",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b726",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b727",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
-          "rdfs:comment": "Terms in quoted triples can be replaced by fresh bnodes.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "bnodes-in-quoted-subject-and-object",
-          "assertions": [
-            {
-              "@id": "_:b405",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b206",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b675",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b448",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
-          "rdfs:comment": "The same bnode can not match different quoted terms.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "bnodes-in-quoted-subject-and-object-fail",
-          "assertions": [
-            {
-              "@id": "_:b96",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b97",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
               "@id": "_:b491",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail",
-              "subject": "https://rubygems.org/gems/sparql",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
               "result": {
                 "@id": "_:b492",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl",
-          "rdfs:comment": "Identical quoted term can be replaced by the same fresh bnode multiple times.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "same-bnode-same-quoted-term",
-          "assertions": [
-            {
-              "@id": "_:b249",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term",
               "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b144",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
               "assertedBy": null
             },
             {
-              "@id": "_:b816",
+              "@id": "_:b740",
               "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term",
+              "test": "https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3",
+              "mode": "earl:automatic",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
               "subject": "https://rubygems.org/gems/sparql",
               "result": {
-                "@id": "_:b731",
+                "@id": "_:b202",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl",
-          "rdfs:comment": "Different bnodes can match identical quoted terms.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "different-bnodes-same-quoted-term",
-          "assertions": [
-            {
-              "@id": "_:b679",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b280",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b78",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b79",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl",
-          "rdfs:comment": "Terms in quoted triples and outside can be replaced by fresh bnodes",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "constrained-bnodes-in-quoted-subject",
-          "assertions": [
-            {
-              "@id": "_:b415",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b161",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b404",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b190",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl",
-          "rdfs:comment": "Terms in quoted triples and outside can be replaced by fresh bnodes.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "constrained-bnodes-in-quoted-object",
-          "assertions": [
-            {
-              "@id": "_:b698",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b670",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b581",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b582",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl",
-          "rdfs:comment": "Embedded bnode identifiers share the same scope as non-quoted ones. A bnode occuring both in quoted triples and in asserted triples must statisfy them all at the same time.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "constrained-bnodes-in-quoted-fail",
-          "assertions": [
-            {
-              "@id": "_:b895",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b336",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b289",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b290",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl",
-          "rdfs:comment": "Literals in quoted triples and outside can be replaced by fresh bnodes.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "constrained-bnodes-on-literal",
-          "assertions": [
-            {
-              "@id": "_:b219",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b220",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b840",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b841",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl",
-          "mf:result": {
-            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-            "@value": "false"
-          },
-          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                "outcome": "earl:passed"
               }
-            ]
-          },
-          "title": "malformed-literal-control",
-          "assertions": [
-            {
-              "@id": "_:b241",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b242",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b926",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b878",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "mf:result": {
-            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-            "@value": "false"
-          },
-          "rdfs:comment": "Malformed literals are allowed when quoted.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "title": "malformed-literal",
-          "assertions": [
-            {
-              "@id": "_:b9",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b10",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b35",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b34",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "rdfs:comment": "Malformed literals are allowed when quoted.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "title": "malformed-literal-accepted",
-          "assertions": [
-            {
-              "@id": "_:b48",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b49",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b621",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b114",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl",
-          "rdfs:comment": "Embedded malformed literals do not lead to spurious entailment.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "title": "malformed-literal-no-spurious",
-          "assertions": [
-            {
-              "@id": "_:b890",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b562",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b868",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b474",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl",
-          "rdfs:comment": "Malformed literals can not be replaced by blank nodes.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "title": "malformed-literal-bnode",
-          "assertions": [
-            {
-              "@id": "_:b484",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b485",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b860",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b761",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl",
-          "rdfs:comment": "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "title": "opaque-literal-control",
-          "assertions": [
-            {
-              "@id": "_:b250",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b251",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b390",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b391",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl",
-          "rdfs:comment": "Embedded literals are opaque, even when their datatype is recognized.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-              {
-                "@id": "http://www.w3.org/2001/XMLSchema#integer"
-              }
-            ]
-          },
-          "title": "opaque-literal",
-          "assertions": [
-            {
-              "@id": "_:b507",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b420",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b173",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-literal",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b174",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl",
-          "rdfs:comment": "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "opaque-language-string-control",
-          "assertions": [
-            {
-              "@id": "_:b568",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b569",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b115",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b116",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl",
-          "rdfs:comment": "Embedded literals (including language strings) are opaque, even when their datatype is recognized.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDF",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "opaque-language-string",
-          "assertions": [
-            {
-              "@id": "_:b921",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b869",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b541",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b542",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl",
-          "rdfs:comment": "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDFS-Plus",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "opaque-iri-control",
-          "assertions": [
-            {
-              "@id": "_:b815",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b772",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b579",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b580",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/superman.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl",
-          "rdfs:comment": "Embedded IRIs are opaque.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "RDFS-Plus",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "opaque-iri",
-          "assertions": [
-            {
-              "@id": "_:b850",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b847",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b642",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#opaque-iri",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b643",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted",
-          "@type": [
-            "mf:NegativeEntailmentTest",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl",
-          "rdfs:comment": "Embedded triples are not asserted.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "quoted-not-asserted",
-          "assertions": [
-            {
-              "@id": "_:b381",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b382",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b889",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b805",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl",
-          "rdfs:comment": "Annotated triples are asserted.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "annotated-asserted",
-          "assertions": [
-            {
-              "@id": "_:b918",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b609",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b781",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b782",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl",
-          "rdfs:comment": "Annotation are about the annotated triple.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "annotation",
-          "assertions": [
-            {
-              "@id": "_:b561",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b80",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b534",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b345",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "mf:PositiveEntailmentTest"
-          ],
-          "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval": {
-            "@id": "http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified"
-          },
-          "testAction": "https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl",
-          "rdfs:comment": "Annotation is the same as separate assertions.",
-          "mf:unrecognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "mf:entailmentRegime": "simple",
-          "mf:recognizedDatatypes": {
-            "@list": [
-
-            ]
-          },
-          "title": "annotation-unfolded",
-          "assertions": [
-            {
-              "@id": "_:b410",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b400",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
-              "@id": "_:b131",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b132",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
             }
           ]
         }
-      ]
-    },
-    {
-      "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#manifest",
-      "@type": [
-        "mf:Manifest",
-        "Report"
       ],
-      "rdfs:label": "Turtle-star Evaluation Tests",
-      "entries": [
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt",
-          "title": "Turtle-star - subject quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b712",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b311",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b718",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b719",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt",
-          "title": "Turtle-star - object quoted triple",
-          "assertions": [
-            {
-              "@id": "_:b891",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b879",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b811",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b812",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt",
-          "title": "Turtle-star - blank node label",
-          "assertions": [
-            {
-              "@id": "_:b901",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b797",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b257",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b171",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt",
-          "title": "Turtle-star - blank node labels",
-          "assertions": [
-            {
-              "@id": "_:b905",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b857",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b647",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b328",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt",
-          "title": "Turtle-star - Annotation form",
-          "assertions": [
-            {
-              "@id": "_:b706",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b677",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b904",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b366",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt",
-          "title": "Turtle-star - Annotation example",
-          "assertions": [
-            {
-              "@id": "_:b747",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b538",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b371",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b372",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt",
-          "title": "Turtle-star - Annotation - predicate and object lists",
-          "assertions": [
-            {
-              "@id": "_:b853",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b46",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b833",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b41",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt",
-          "title": "Turtle-star - Annotation - nested",
-          "assertions": [
-            {
-              "@id": "_:b900",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b896",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b71",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b72",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt",
-          "title": "Turtle-star - Annotation object list",
-          "assertions": [
-            {
-              "@id": "_:b337",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b338",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b886",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b318",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.nt",
-          "title": "Turtle-star - Annotation with quoting",
-          "assertions": [
-            {
-              "@id": "_:b198",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b199",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b480",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b481",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.nt",
-          "title": "Turtle-star - Annotation on triple with quoted subject",
-          "assertions": [
-            {
-              "@id": "_:b589",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b578",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b723",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b716",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        },
-        {
-          "@id": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3",
-          "@type": [
-            "http://www.w3.org/ns/rdftest#TestTurtleEval",
-            "TestCriterion",
-            "TestCase"
-          ],
-          "testAction": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.ttl",
-          "testResult": "https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.nt",
-          "title": "Turtle-star - Annotation on triple with quoted object",
-          "assertions": [
-            {
-              "@id": "_:b552",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3",
-              "assertedBy": "https://greggkellogg.net/foaf#me",
-              "subject": "https://rubygems.org/gems/rdf-trig",
-              "result": {
-                "@id": "_:b38",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              },
-              "mode": "earl:automatic"
-            },
-            {
-              "@id": "_:b235",
-              "@type": "Assertion",
-              "test": "https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3",
-              "subject": "https://rubygems.org/gems/sparql",
-              "result": {
-                "@id": "_:b236",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            }
-          ]
-        }
-      ]
+      "dc:creator": {
+        "@id": "_:b157",
+        "foaf:name": " RDF-star Interest Group within the W3C RDF-DEV Community Group",
+        "foaf:homepage": "https://w3c.github.io/rdf-star/"
+      },
+      "dc:licence": {
+        "@id": "https://www.w3.org/Consortium/Legal/2008/03-bsd-license"
+      },
+      "rdfs:label": {
+        "@language": "en",
+        "@value": "SPARQL-star Evaluation Tests"
+      },
+      "dc:modified": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-07-18"
+      }
     }
   ],
-  "assertions": [
-    "ruby-trig.ttl",
-    "ruby-sparql.ttl"
-  ]
+  "generatedBy": {
+    "@id": "https://rubygems.org/gems/earl-report",
+    "@type": [
+      "Software",
+      "doap:Project"
+    ],
+    "homepage": "https://github.com/gkellogg/earl-report",
+    "name": "earl-report",
+    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
+    "language": "Ruby",
+    "license": "http://unlicense.org",
+    "shortdesc": "Earl Report summary generator",
+    "release": {
+      "@id": "https://github.com/gkellogg/earl-report/tree/0.7.0",
+      "@type": "doap:Version",
+      "doap:created": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2021-11-07"
+      },
+      "name": "earl-report-0.7.0",
+      "revision": "0.7.0"
+    },
+    "developer": [
+      {
+        "@id": "https://greggkellogg.net/foaf#me",
+        "@type": [
+          "Assertor",
+          "foaf:Person"
+        ],
+        "foaf:name": "Gregg Kellogg",
+        "foaf:homepage": "https://greggkellogg.net/"
+      }
+    ]
+  },
+  "bibRef": "[[rdf-star]]"
 }

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -8,25 +8,1310 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <> a earl:Software, doap:Project ;
+  mf:report earl:ruby-sparql.ttl,
+    earl:ruby-trig.ttl ;
+  doap:name "RDF-star" ;
   earl:testSubjects <https://rubygems.org/gems/rdf-trig>,
     <https://rubygems.org/gems/sparql> ;
-  earl:generatedBy <https://rubygems.org/gems/earl-report> ;
-  dc:bibliographicCitation "[[rdf-star]]" ;
-  doap:name "RDF-star" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#manifest>
+  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#manifest>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#manifest>
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#manifest>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#manifest>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#manifest>
     <https://w3c.github.io/rdf-star/tests/trig/eval#manifest>
-    <https://w3c.github.io/rdf-star/tests/semantics#manifest>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#manifest>) ;
-  mf:report earl:ruby-trig.ttl,
-    earl:ruby-sparql.ttl .
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#manifest>
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#manifest>) ;
+  earl:generatedBy <https://rubygems.org/gems/earl-report> ;
+  dc:bibliographicCitation "[[rdf-star]]" .
 
 # Manifests
+<https://w3c.github.io/rdf-star/tests/semantics#manifest> a mf:Manifest, earl:Report ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/semantics/README> ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Conjunto de pruebas para la semántica de RDF-star"@es,
+    "La suite des tests pour la sémantique de RDF-star"@fr ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same>
+    <https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail>
+    <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term>
+    <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail>
+    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious>
+    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control>
+    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri>
+    <https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotation>
+    <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded>) ;
+  dc:creator _:b109 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "RDF-star Semantics tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
+
+<https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Multiple occurences of the same quoted triples are undistinguishable in the abstract model." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "all-identical-quoted-triples-are-the-same" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "This test ensures that other entailments are not spurious." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test005.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "quoted-triples-no-spurious" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-quoted-subject" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-quoted-object" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-quoted-subject-and-object" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "The same bnode can not match different quoted terms." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "bnodes-in-quoted-subject-and-object-fail" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Identical quoted term can be replaced by the same fresh bnode multiple times." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "same-bnode-same-quoted-term" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Different bnodes can match identical quoted terms." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "different-bnodes-same-quoted-term" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Terms inside and outside quoted triples can be replaced by fresh bnodes" ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-in-quoted-subject" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Terms inside and outside quoted triples can be replaced by fresh bnodes." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-in-quoted-object" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside quoted triples and inside asserted triples must satisfy all occurrences at the same time." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-in-quoted-fail" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Literals inside and outside quoted triples can be replaced by fresh bnodes." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "constrained-bnodes-on-literal" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously." ;
+  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-control" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Malformed literals are allowed when quoted." ;
+  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Malformed literals are allowed when quoted." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-accepted" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Quoted malformed literals do not lead to spurious entailment." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-no-spurious" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Malformed literals can not be replaced by blank nodes." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "malformed-literal-bnode" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-literal-control" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Quoted literals are opaque, even when their datatype is recognized." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-literal" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-language-string-control" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Quoted literals (including language strings) are opaque, even when their datatype is recognized." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-language-string" ;
+  mf:entailmentRegime "RDF" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-iri-control" ;
+  mf:entailmentRegime "RDFS-Plus" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Quoted IRIs are opaque." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "opaque-iri" ;
+  mf:entailmentRegime "RDFS-Plus" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/superman.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted> a mf:NegativeEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Quoted triples are not asserted." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "quoted-not-asserted" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Annotated triples are asserted." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "annotated-asserted" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#annotation> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Annotation are about the annotated triple." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "annotation" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> a mf:PositiveEntailmentTest, earl:TestCase, earl:TestCriterion ;
+  rdfs:comment "Annotation is the same as separate assertions." ;
+  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
+  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
+  mf:name "annotation-unfolded" ;
+  mf:entailmentRegime "simple" ;
+  mf:recognizedDatatypes () ;
+  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl> ;
+  mf:unrecognizedDatatypes () ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#manifest> a mf:Manifest, earl:Report ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Conjunto de pruebas para la sintaxis de Trig-star"@es,
+    "La suite des tests pour la syntaxe de TriG-star"@fr ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1>
+    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2>) ;
+  dc:creator _:b507 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "TriG-star Syntax Tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig> ;
+  mf:name "TriG-star - subject quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig> ;
+  mf:name "TriG-star - object quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig> ;
+  mf:name "TriG-star - quoted triple inside blankNodePropertyList" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig> ;
+  mf:name "TriG-star - quoted triple inside collection" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig> ;
+  mf:name "TriG-star - nested quoted triple, subject position" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig> ;
+  mf:name "TriG-star - nested quoted triple, object position" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig> ;
+  mf:name "TriG-star - compound forms" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig> ;
+  mf:name "TriG-star - blank node subject" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig> ;
+  mf:name "TriG-star - blank node object" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig> ;
+  mf:name "TriG-star - blank node" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig> ;
+  mf:name "TriG-star - bad - quoted triple as predicate" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig> ;
+  mf:name "TriG-star - bad - quoted triple outside triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig> ;
+  mf:name "TriG-star - bad - collection list in quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig> ;
+  mf:name "TriG-star - bad - literal in subject position of quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig> ;
+  mf:name "TriG-star - bad - blank node  as predicate in quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig> ;
+  mf:name "TriG-star - bad - compound blank node expression" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig> ;
+  mf:name "TriG-star - bad - incomplete quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig> ;
+  mf:name "TriG-star - bad - over-long quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig> ;
+  mf:name "TriG-star - Annotation form" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax> ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig> ;
+  mf:name "TriG-star - Annotation example" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig> ;
+  mf:name "TriG-star - bad - empty annotation" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> a <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig> ;
+  mf:name "TriG-star - bad - triple as annotation" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
 <https://w3c.github.io/rdf-star/tests/nt/syntax#manifest> a mf:Manifest, earl:Report ;
-  rdfs:label "N-Triples-star Syntax Tests" ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/nt/syntax/README> ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Conjunto de pruebas para N-Triples-star"@es,
+    "La suite des tests pour N-Triples-star"@fr ;
   mf:entries (<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1>
     <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2>
     <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3>
@@ -39,9 +1324,13 @@
     <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1>
     <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2>
     <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3>
-    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4>) .
+    <https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4>) ;
+  dc:creator _:b0 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "N-Triples-star Syntax Tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-1.nt> ;
   mf:name "N-Triples-star - subject quoted triple" ;
   earl:assertions [
@@ -63,7 +1352,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-2.nt> ;
   mf:name "N-Triples-star - object quoted triple" ;
   earl:assertions [
@@ -85,7 +1374,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-3> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-3.nt> ;
   mf:name "N-Triples-star - subject and object quoted triples" ;
   earl:assertions [
@@ -107,7 +1396,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-4> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-4.nt> ;
   mf:name "N-Triples-star - whitespace and terms" ;
   earl:assertions [
@@ -129,7 +1418,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-5> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-syntax-5.nt> ;
   mf:name "N-Triples-star - Nested, no whitespace" ;
   earl:assertions [
@@ -151,7 +1440,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-1.nt> ;
   mf:name "N-Triples-star - Blank node subject" ;
   earl:assertions [
@@ -173,7 +1462,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bnode-2.nt> ;
   mf:name "N-Triples-star - Blank node object" ;
   earl:assertions [
@@ -195,7 +1484,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-1> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-1.nt> ;
   mf:name "N-Triples-star - Nested subject term" ;
   earl:assertions [
@@ -217,7 +1506,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-nested-2> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-nested-2.nt> ;
   mf:name "N-Triples-star - Nested object term" ;
   earl:assertions [
@@ -239,7 +1528,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-1> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-1.nt> ;
   mf:name "N-Triples-star - Bad - quoted triple as predicate" ;
   earl:assertions [
@@ -261,7 +1550,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-2> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-2.nt> ;
   mf:name "N-Triples-star - Bad - quoted triple, literal subject" ;
   earl:assertions [
@@ -283,7 +1572,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-3> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-3.nt> ;
   mf:name "N-Triples-star - Bad - quoted triple, literal predicate" ;
   earl:assertions [
@@ -305,7 +1594,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/nt/syntax#ntriples-star-bad-4> a earl:TestCase, earl:TestCriterion, <http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax> ;
   mf:action <https://w3c.github.io/rdf-star/tests/nt/syntax/ntriples-star-bad-syntax-4.nt> ;
   mf:name "N-Triples-star - Bad - quoted triple, blank node predicate" ;
   earl:assertions [
@@ -328,7 +1617,9 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/turtle/syntax#manifest> a mf:Manifest, earl:Report ;
-  rdfs:label "Turtle-star Syntax Tests" ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "La suite des tests pour la syntaxe Turtle-star"@fr,
+    "Conjunto de pruebas para la sintaxis Turtle-star"@es ;
   mf:entries (<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1>
@@ -363,9 +1654,13 @@
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2>
     <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3>
-    <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4>) .
+    <https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4>) ;
+  dc:creator _:b346 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "Turtle-star Syntax Tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-01.ttl> ;
   mf:name "Turtle-star - subject quoted triple" ;
   earl:assertions [
@@ -387,7 +1682,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-basic-02.ttl> ;
   mf:name "Turtle-star - object quoted triple" ;
   earl:assertions [
@@ -409,7 +1704,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-01.ttl> ;
   mf:name "Turtle-star - quoted triple inside blankNodePropertyList" ;
   earl:assertions [
@@ -431,7 +1726,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-inside-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-inside-02.ttl> ;
   mf:name "Turtle-star - quoted triple inside collection" ;
   earl:assertions [
@@ -453,7 +1748,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-01.ttl> ;
   mf:name "Turtle-star - nested quoted triple, subject position" ;
   earl:assertions [
@@ -475,7 +1770,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-nested-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-nested-02.ttl> ;
   mf:name "Turtle-star - nested quoted triple, object position" ;
   earl:assertions [
@@ -497,7 +1792,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-compound-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-compound.ttl> ;
   mf:name "Turtle-star - compound forms" ;
   earl:assertions [
@@ -519,7 +1814,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-01.ttl> ;
   mf:name "Turtle-star - blank node subject" ;
   earl:assertions [
@@ -541,7 +1836,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-02.ttl> ;
   mf:name "Turtle-star - blank node object" ;
   earl:assertions [
@@ -563,7 +1858,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bnode-3> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bnode-03.ttl> ;
   mf:name "Turtle-star - blank node" ;
   earl:assertions [
@@ -585,7 +1880,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-1> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-01.ttl> ;
   mf:name "Turtle-star - bad - quoted triple as predicate" ;
   earl:assertions [
@@ -607,7 +1902,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-2> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-02.ttl> ;
   mf:name "Turtle-star - bad - quoted triple outside triple" ;
   earl:assertions [
@@ -629,7 +1924,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-3> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-03.ttl> ;
   mf:name "Turtle-star - bad - collection list in quoted triple" ;
   earl:assertions [
@@ -651,7 +1946,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-4> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-04.ttl> ;
   mf:name "Turtle-star - bad - literal in subject position of quoted triple" ;
   earl:assertions [
@@ -673,7 +1968,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-5> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-05.ttl> ;
   mf:name "Turtle-star - bad - blank node  as predicate in quoted triple" ;
   earl:assertions [
@@ -695,7 +1990,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-6> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-06.ttl> ;
   mf:name "Turtle-star - bad - compound blank node expression" ;
   earl:assertions [
@@ -717,7 +2012,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-7> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-07.ttl> ;
   mf:name "Turtle-star - bad - incomplete quoted triple" ;
   earl:assertions [
@@ -739,7 +2034,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-8> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-08.ttl> ;
   mf:name "Turtle-star - bad - over-long quoted triple" ;
   earl:assertions [
@@ -761,7 +2056,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-1.ttl> ;
   mf:name "Turtle-star - Annotation form" ;
   earl:assertions [
@@ -783,7 +2078,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-ann-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-annotation-2.ttl> ;
   mf:name "Turtle-star - Annotation example" ;
   earl:assertions [
@@ -805,7 +2100,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-1> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-1.ttl> ;
   mf:name "Turtle-star - bad - empty annotation" ;
   earl:assertions [
@@ -827,7 +2122,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#turtle-star-bad-ann-2> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/turtle-star-syntax-bad-ann-2.ttl> ;
   mf:name "Turtle-star - bad - triple as annotation" ;
   earl:assertions [
@@ -849,7 +2144,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-1.ttl> ;
   mf:name "N-Triples-star as Turtle-star - subject quoted triple" ;
   earl:assertions [
@@ -871,7 +2166,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-2.ttl> ;
   mf:name "N-Triples-star as Turtle-star - object quoted triple" ;
   earl:assertions [
@@ -893,7 +2188,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-3> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-3.ttl> ;
   mf:name "N-Triples-star as Turtle-star - subject and object quoted triples" ;
   earl:assertions [
@@ -915,7 +2210,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-4> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-4.ttl> ;
   mf:name "N-Triples-star as Turtle-star - whitespace and terms" ;
   earl:assertions [
@@ -937,7 +2232,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5> a <http://www.w3.org/ns/rdftest#TestNTriplesPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-5> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-syntax-5.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Nested, no whitespace" ;
   earl:assertions [
@@ -959,7 +2254,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-1.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Blank node subject" ;
   earl:assertions [
@@ -981,7 +2276,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bnode-2.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Blank node object" ;
   earl:assertions [
@@ -1003,7 +2298,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-1> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-1.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Nested subject term" ;
   earl:assertions [
@@ -1025,7 +2320,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-nested-2> a <http://www.w3.org/ns/rdftest#TestTurtlePositiveSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-nested-2.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Nested object term" ;
   earl:assertions [
@@ -1047,7 +2342,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-1> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-1.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Bad - quoted triple as predicate" ;
   earl:assertions [
@@ -1069,7 +2364,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-2> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-2.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Bad - quoted triple, literal subject" ;
   earl:assertions [
@@ -1091,7 +2386,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-3> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-3.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Bad - quoted triple, literal predicate" ;
   earl:assertions [
@@ -1113,7 +2408,7 @@
     ] ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax> ;
+<https://w3c.github.io/rdf-star/tests/turtle/syntax#nt-ttl-star-bad-4> a <http://www.w3.org/ns/rdftest#TestTurtleNegativeSyntax>, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/turtle/syntax/nt-ttl-star-bad-syntax-4.ttl> ;
   mf:name "N-Triples-star as Turtle-star - Bad - quoted triple, blank node predicate" ;
   earl:assertions [
@@ -1136,7 +2431,10 @@
   ] .
 
 <https://w3c.github.io/rdf-star/tests/sparql/syntax#manifest> a mf:Manifest, earl:Report ;
-  rdfs:label "SPARQL-star Syntax Tests" ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "La suite des tests pour SPARQL-star"@fr,
+    "Conjunto de pruebas para SPARQL-star"@es ;
   mf:entries (<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3>
@@ -1199,9 +2497,13 @@
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2>
     <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3>
-    <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4>) .
+    <https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4>) ;
+  dc:creator _:b1 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "SPARQL-star Syntax Tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-1> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-01.rq> ;
   mf:name "SPARQL-star - subject quoted triple" ;
   earl:assertions [
@@ -1223,7 +2525,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-2> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-02.rq> ;
   mf:name "SPARQL-star - object quoted triple" ;
   earl:assertions [
@@ -1245,7 +2547,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-3> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-03.rq> ;
   mf:name "SPARQL-star - subject quoted triple - vars" ;
   earl:assertions [
@@ -1267,7 +2569,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-4> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-04.rq> ;
   mf:name "SPARQL-star - object quoted triple - vars" ;
   earl:assertions [
@@ -1289,7 +2591,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-5> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-05.rq> ;
   mf:name "SPARQL-star - Embedded triple in VALUES" ;
   earl:assertions [
@@ -1311,7 +2613,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-6> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-06.rq> ;
   mf:name "SPARQL-star - Embedded triple in CONSTRUCT" ;
   earl:assertions [
@@ -1333,7 +2635,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-7> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-basic-07.rq> ;
   mf:name "SPARQL-star - Embedded triples in CONSTRUCT WHERE" ;
   earl:assertions [
@@ -1355,7 +2657,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-1> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-01.rq> ;
   mf:name "SPARQL-star - quoted triple inside blankNodePropertyList" ;
   earl:assertions [
@@ -1377,7 +2679,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-inside-2> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-inside-02.rq> ;
   mf:name "SPARQL-star - quoted triple inside collection" ;
   earl:assertions [
@@ -1399,7 +2701,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-1> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-01.rq> ;
   mf:name "SPARQL-star - nested quoted triple, subject position" ;
   earl:assertions [
@@ -1421,7 +2723,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-nested-2> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-nested-02.rq> ;
   mf:name "SPARQL-star - nested quoted triple, object position" ;
   earl:assertions [
@@ -1443,7 +2745,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-compound-1> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-compound.rq> ;
   mf:name "SPARQL-star - compound forms" ;
   earl:assertions [
@@ -1465,7 +2767,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-1> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-01.rq> ;
   mf:name "SPARQL-star - blank node subject" ;
   earl:assertions [
@@ -1487,7 +2789,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-2> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-02.rq> ;
   mf:name "SPARQL-star - blank node object" ;
   earl:assertions [
@@ -1509,7 +2811,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bnode-3> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bnode-03.rq> ;
   mf:name "SPARQL-star - blank node" ;
   earl:assertions [
@@ -1531,7 +2833,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-01> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-01.rq> ;
   mf:name "SPARQL-star - Annotation form" ;
   earl:assertions [
@@ -1553,7 +2855,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-02> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-02.rq> ;
   mf:name "SPARQL-star - Annotation example" ;
   earl:assertions [
@@ -1575,7 +2877,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-03> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-03.rq> ;
   mf:name "SPARQL-star - Annotation example" ;
   earl:assertions [
@@ -1597,7 +2899,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-04> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-04.rq> ;
   mf:name "SPARQL-star - Annotation with quoting" ;
   earl:assertions [
@@ -1619,7 +2921,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-05> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-05.rq> ;
   mf:name "SPARQL-star - Annotation on triple with quoted object" ;
   earl:assertions [
@@ -1641,7 +2943,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-06> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-06.rq> ;
   mf:name "SPARQL-star - Annotation with path" ;
   earl:assertions [
@@ -1663,7 +2965,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-07> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-07.rq> ;
   mf:name "SPARQL-star - Annotation with nested path" ;
   earl:assertions [
@@ -1685,7 +2987,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-08> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-08.rq> ;
   mf:name "SPARQL-star - Annotation in CONSTRUCT " ;
   earl:assertions [
@@ -1707,7 +3009,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-ann-09> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-annotation-09.rq> ;
   mf:name "SPARQL-star - Annotation in CONSTRUCT WHERE" ;
   earl:assertions [
@@ -1729,7 +3031,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-1> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-01.rq> ;
   mf:name "SPARQL-star - Expressions - Embedded triple" ;
   earl:assertions [
@@ -1751,7 +3053,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-2> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-02.rq> ;
   mf:name "SPARQL-star - Expressions - Embedded triple" ;
   earl:assertions [
@@ -1773,7 +3075,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-3> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-03.rq> ;
   mf:name "SPARQL-star - Expressions - Functions" ;
   earl:assertions [
@@ -1795,7 +3097,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-4> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-04.rq> ;
   mf:name "SPARQL-star - Expressions - TRIPLE" ;
   earl:assertions [
@@ -1817,7 +3119,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-5> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-05.rq> ;
   mf:name "SPARQL-star - Expressions - Functions" ;
   earl:assertions [
@@ -1839,7 +3141,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> a mf:PositiveSyntaxTest11, earl:TestCriterion, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-expr-6> a mf:PositiveSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-expr-06.rq> ;
   mf:name "SPARQL-star - Expressions - BIND - CONSTRUCT" ;
   earl:assertions [
@@ -1861,7 +3163,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-01.rq> ;
   mf:name "SPARQL-star - bad - quoted triple as predicate" ;
   earl:assertions [
@@ -1883,7 +3185,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-02.rq> ;
   mf:name "SPARQL-star - bad - quoted triple outside triple" ;
   earl:assertions [
@@ -1905,7 +3207,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-3> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-03.rq> ;
   mf:name "SPARQL-star - bad - collection list in quoted triple" ;
   earl:assertions [
@@ -1927,7 +3229,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-4> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-04.rq> ;
   mf:name "SPARQL-star - bad - literal in subject position of quoted triple" ;
   earl:assertions [
@@ -1949,7 +3251,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-5> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-05.rq> ;
   mf:name "SPARQL-star - bad - blank node  as predicate in quoted triple" ;
   earl:assertions [
@@ -1971,7 +3273,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-6> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-06.rq> ;
   mf:name "SPARQL-star - bad - compound blank node expression" ;
   earl:assertions [
@@ -1993,7 +3295,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-7> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-07.rq> ;
   mf:name "SPARQL-star - bad - incomplete quoted triple" ;
   earl:assertions [
@@ -2015,7 +3317,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-8> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-08.rq> ;
   mf:name "SPARQL-star - bad - quad quoted triple" ;
   earl:assertions [
@@ -2037,7 +3339,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-9> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-09.rq> ;
   mf:name "SPARQL-star - bad - variable in quoted triple in VALUES " ;
   earl:assertions [
@@ -2059,7 +3361,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-10> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-10.rq> ;
   mf:name "SPARQL-star - bad - blank node in quoted triple in VALUES " ;
   earl:assertions [
@@ -2081,7 +3383,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-11> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-11.rq> ;
   mf:name "SPARQL-star - bad - blank node in quoted triple in FILTER" ;
   earl:assertions [
@@ -2103,7 +3405,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-12> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-12.rq> ;
   mf:name "SPARQL-star - bad - blank node in quoted triple in BIND" ;
   earl:assertions [
@@ -2125,7 +3427,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-1.rq> ;
   mf:name "SPARQL-star - bad - empty annotation" ;
   earl:assertions [
@@ -2147,7 +3449,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-2.rq> ;
   mf:name "SPARQL-star - bad - triples in annotation" ;
   earl:assertions [
@@ -2169,7 +3471,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-1> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-1.rq> ;
   mf:name "SPARQL-star - bad - path - seq" ;
   earl:assertions [
@@ -2191,7 +3493,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-2> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq> ;
   mf:name "SPARQL-star - bad - path - alt" ;
   earl:assertions [
@@ -2213,7 +3515,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-3> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq> ;
   mf:name "SPARQL-star - bad - path - p*" ;
   earl:assertions [
@@ -2235,7 +3537,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-4> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq> ;
   mf:name "SPARQL-star - bad - path - p+" ;
   earl:assertions [
@@ -2257,7 +3559,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-5> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq> ;
   mf:name "SPARQL-star - bad - path - p?" ;
   earl:assertions [
@@ -2279,7 +3581,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-6> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq> ;
   mf:name "SPARQL-star - bad - path in CONSTRUCT" ;
   earl:assertions [
@@ -2301,7 +3603,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> a earl:TestCriterion, earl:TestCase, mf:NegativeSyntaxTest11 ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-ann-path-7> a mf:NegativeSyntaxTest11, earl:TestCriterion, earl:TestCase ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-7.rq> ;
   mf:name "SPARQL-star - bad - path in CONSTRUCT" ;
   earl:assertions [
@@ -2323,7 +3625,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-1> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-1.ru> ;
   mf:name "SPARQL-star - update" ;
   earl:assertions [
@@ -2345,7 +3647,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-2> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-2.ru> ;
   mf:name "SPARQL-star - update" ;
   earl:assertions [
@@ -2367,7 +3669,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-3> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-3.ru> ;
   mf:name "SPARQL-star - update" ;
   earl:assertions [
@@ -2389,7 +3691,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-4> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-4.ru> ;
   mf:name "SPARQL-star - update with quoting" ;
   earl:assertions [
@@ -2411,7 +3713,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-5> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-5.ru> ;
   mf:name "SPARQL-star - update with quoted object" ;
   earl:assertions [
@@ -2433,7 +3735,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-6> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-6.ru> ;
   mf:name "SPARQL-star - update with annotation template" ;
   earl:assertions [
@@ -2455,7 +3757,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-7> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-7.ru> ;
   mf:name "SPARQL-star - update with annotation, template and pattern" ;
   earl:assertions [
@@ -2477,7 +3779,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> a earl:TestCriterion, mf:PositiveUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-update-8> a mf:PositiveUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-update-8.ru> ;
   mf:name "SPARQL-star - update DATA with annotation" ;
   earl:assertions [
@@ -2499,7 +3801,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-1> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-1.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
   earl:assertions [
@@ -2521,7 +3823,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-2> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-2.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
   earl:assertions [
@@ -2543,7 +3845,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-3> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-3.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
   earl:assertions [
@@ -2565,7 +3867,7 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> a earl:TestCriterion, mf:NegativeUpdateSyntaxTest11, earl:TestCase ;
+<https://w3c.github.io/rdf-star/tests/sparql/syntax#sparql-star-bad-update-4> a mf:NegativeUpdateSyntaxTest11, earl:TestCase, earl:TestCriterion ;
   mf:action <https://w3c.github.io/rdf-star/tests/sparql/syntax/sparql-star-syntax-bad-update-4.ru> ;
   mf:name "SPARQL-star - update - bad syntax" ;
   earl:assertions [
@@ -2587,8 +3889,607 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
+<https://w3c.github.io/rdf-star/tests/trig/eval#manifest> a mf:Manifest, earl:Report ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "La suite des tests pour évaluation de TriG-star"@fr,
+    "Conjunto de pruebas para evaluar Trig-star"@es ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3>) ;
+  dc:creator _:b420 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "TriG-star Evaluation Tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq> ;
+  mf:name "TriG-star - subject quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq> ;
+  mf:name "TriG-star - object quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq> ;
+  mf:name "TriG-star - blank node label" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq> ;
+  mf:name "TriG-star - blank node labels" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq> ;
+  mf:name "TriG-star - Annotation form" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq> ;
+  mf:name "TriG-star - Annotation example" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq> ;
+  mf:name "TriG-star - Annotation - predicate and object lists" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq> ;
+  mf:name "TriG-star - Annotation - nested" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq> ;
+  mf:name "TriG-star - Annotation object list" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.nq> ;
+  mf:name "TriG-star - Annotation with quoting" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.nq> ;
+  mf:name "TriG-star - Annotation on triple with quoted subject" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3> a earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.trig> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.nq> ;
+  mf:name "TriG-star - Annotation on triple with quoted object" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#manifest> a mf:Manifest, earl:Report ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Conjunto de pruebas para Turtle-star"@es,
+    "La suite des tests pour Turtle-star"@fr ;
+  mf:entries (<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2>
+    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3>) ;
+  dc:creator _:b681 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "Turtle-star Evaluation Tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt> ;
+  mf:name "Turtle-star - subject quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt> ;
+  mf:name "Turtle-star - object quoted triple" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt> ;
+  mf:name "Turtle-star - blank node label" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt> ;
+  mf:name "Turtle-star - blank node labels" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt> ;
+  mf:name "Turtle-star - Annotation form" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt> ;
+  mf:name "Turtle-star - Annotation example" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt> ;
+  mf:name "Turtle-star - Annotation - predicate and object lists" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt> ;
+  mf:name "Turtle-star - Annotation - nested" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt> ;
+  mf:name "Turtle-star - Annotation object list" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.nt> ;
+  mf:name "Turtle-star - Annotation with quoting" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.nt> ;
+  mf:name "Turtle-star - Annotation on triple with quoted subject" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
+<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCase, earl:TestCriterion ;
+  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.ttl> ;
+  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.nt> ;
+  mf:name "Turtle-star - Annotation on triple with quoted object" ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/rdf-trig> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ], [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3> ;
+    earl:subject <https://rubygems.org/gems/sparql> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:untested
+    ] ;
+  ] .
+
 <https://w3c.github.io/rdf-star/tests/sparql/eval#manifest> a mf:Manifest, earl:Report ;
-  rdfs:label "SPARQL-star Evaluation Tests" ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/sparql/eval/README> ;
+  dc:issued "2021-06-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "La suite des tests d'évaluation de SPARQL-star"@fr,
+    "Conjunto de pruebas para evaluar SPARQL-star"@es ;
   mf:entries (<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j>
     <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x>
     <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2>
@@ -2622,10 +4523,14 @@
     <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2>
     <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1>
     <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2>
-    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3>) .
+    <https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3>) ;
+  dc:creator _:b157 ;
+  dc:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  rdfs:label "SPARQL-star Evaluation Tests"@en ;
+  dc:modified "2021-07-18"^^<http://www.w3.org/2001/XMLSchema#date> .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b427 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1j> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b127 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srj> ;
   mf:name "SPARQL-star - all graph triples (JSON results)" ;
   earl:assertions [
@@ -2647,8 +4552,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b195 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-results-1x> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b345 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-results-1.srx> ;
   mf:name "SPARQL-star - all graph triples (XML results)" ;
   earl:assertions [
@@ -2670,8 +4575,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b55 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b150 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-2.srj> ;
   mf:name "SPARQL-star - match constant quoted triple" ;
   earl:assertions [
@@ -2693,8 +4598,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b23 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b114 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-3.srj> ;
   mf:name "SPARQL-star - match quoted triple, var subject" ;
   earl:assertions [
@@ -2716,8 +4621,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b121 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b87 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-4.srj> ;
   mf:name "SPARQL-star - match quoted triple, var predicate" ;
   earl:assertions [
@@ -2739,8 +4644,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b305 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b165 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-5.srj> ;
   mf:name "SPARQL-star - match quoted triple, var object" ;
   earl:assertions [
@@ -2762,8 +4667,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b261 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-basic-6> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b277 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-basic-6.srj> ;
   mf:name "SPARQL-star - no match of quoted triple" ;
   earl:assertions [
@@ -2785,8 +4690,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b157 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b416 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-01.srj> ;
   mf:name "SPARQL-star - Asserted and quoted triple" ;
   earl:assertions [
@@ -2808,8 +4713,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b110 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b154 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-02.srj> ;
   mf:name "SPARQL-star -  Asserted and quoted triple" ;
   earl:assertions [
@@ -2831,8 +4736,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b230 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b140 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-03.srj> ;
   mf:name "SPARQL-star - Pattern - Variable for quoted triple" ;
   earl:assertions [
@@ -2854,8 +4759,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b85 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b438 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-04.srj> ;
   mf:name "SPARQL-star - Pattern - No match" ;
   earl:assertions [
@@ -2877,8 +4782,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b231 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b357 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-05.srj> ;
   mf:name "SPARQL-star - Pattern - match variables in triple terms" ;
   earl:assertions [
@@ -2900,8 +4805,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b69 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-6> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b39 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-06.srj> ;
   mf:name "SPARQL-star - Pattern - Nesting 1" ;
   earl:assertions [
@@ -2923,8 +4828,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b165 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-7> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b213 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-07.srj> ;
   mf:name "SPARQL-star - Pattern - Nesting - 2" ;
   earl:assertions [
@@ -2946,8 +4851,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b18 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-8> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b280 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-08.srj> ;
   mf:name "SPARQL-star - Pattern - Match and nesting" ;
   earl:assertions [
@@ -2969,8 +4874,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b543 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-pattern-9> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b106 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-pattern-09.srj> ;
   mf:name "SPARQL-star - Pattern - Same variable" ;
   earl:assertions [
@@ -2992,8 +4897,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b441 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b208 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-1.ttl> ;
   mf:name "SPARQL-star - CONSTRUCT with constant template" ;
   earl:assertions [
@@ -3015,8 +4920,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b350 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b238 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-2.ttl> ;
   mf:name "SPARQL-star - CONSTRUCT WHERE with constant template" ;
   earl:assertions [
@@ -3038,8 +4943,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b530 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b284 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-3.ttl> ;
   mf:name "SPARQL-star - CONSTRUCT - about every triple" ;
   earl:assertions [
@@ -3061,8 +4966,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b26 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b28 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-4.ttl> ;
   mf:name "SPARQL-star - CONSTRUCT with annotation syntax" ;
   earl:assertions [
@@ -3084,8 +4989,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b348 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-construct-5> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b16 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-construct-5.ttl> ;
   mf:name "SPARQL-star - CONSTRUCT WHERE with annotation syntax" ;
   earl:assertions [
@@ -3107,8 +5012,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b324 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b693 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-1.srj> ;
   mf:name "SPARQL-star - GRAPH" ;
   earl:assertions [
@@ -3130,8 +5035,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b118 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-graphs-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b328 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-graphs-2.srj> ;
   mf:name "SPARQL-star - GRAPHs with blank node" ;
   earl:assertions [
@@ -3153,8 +5058,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b5 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b198 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-01.ttl> ;
   mf:name "SPARQL-star - Embedded triple - BIND - CONSTRUCT" ;
   earl:assertions [
@@ -3176,8 +5081,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b362 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b264 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-expr-02.srj> ;
   mf:name "SPARQL-star - Embedded triple - Functions" ;
   earl:assertions [
@@ -3199,8 +5104,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b146 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b135 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-1.srj> ;
   mf:name "SPARQL-star - Embedded triple - sameTerm" ;
   earl:assertions [
@@ -3222,8 +5127,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b268 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b61 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-2.srj> ;
   mf:name "SPARQL-star - Embedded triple - value-equality" ;
   earl:assertions [
@@ -3245,8 +5150,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b184 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-3> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b7 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-3.srj> ;
   mf:name "SPARQL-star - Embedded triple - value-inequality" ;
   earl:assertions [
@@ -3268,8 +5173,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b76 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-op-4> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b252 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-op-4.srj> ;
   mf:name "SPARQL-star - Embedded triple - value-inequality" ;
   earl:assertions [
@@ -3291,8 +5196,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b433 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-1> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b34 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-1.srj> ;
   mf:name "SPARQL-star - Embedded triple - ORDER BY" ;
   earl:assertions [
@@ -3314,8 +5219,8 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> a earl:TestCriterion, earl:TestCase, mf:QueryEvaluationTest ;
-  mf:action _:b217 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-order-2> a mf:QueryEvaluationTest, earl:TestCriterion, earl:TestCase ;
+  mf:action _:b249 ;
   mf:result <https://w3c.github.io/rdf-star/tests/sparql/eval/sparql-star-order-2.srj> ;
   mf:name "SPARQL-star - Embedded triple - ordering" ;
   earl:assertions [
@@ -3337,9 +5242,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> a earl:TestCriterion, earl:TestCase, mf:UpdateEvaluationTest ;
-  mf:action _:b14 ;
-  mf:result _:b15 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1> a earl:TestCase, mf:UpdateEvaluationTest, earl:TestCriterion ;
+  mf:action _:b216 ;
+  mf:result _:b217 ;
   mf:name "SPARQL-star - Update" ;
   earl:assertions [
     a earl:Assertion ;
@@ -3360,9 +5265,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> a earl:TestCriterion, earl:TestCase, mf:UpdateEvaluationTest ;
-  mf:action _:b0 ;
-  mf:result _:b1 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-2> a earl:TestCase, mf:UpdateEvaluationTest, earl:TestCriterion ;
+  mf:action _:b338 ;
+  mf:result _:b339 ;
   mf:name "SPARQL-star - Update - annotation" ;
   earl:assertions [
     a earl:Assertion ;
@@ -3383,9 +5288,9 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> a earl:TestCriterion, earl:TestCase, mf:UpdateEvaluationTest ;
-  mf:action _:b202 ;
-  mf:result _:b203 ;
+<https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-3> a earl:TestCase, mf:UpdateEvaluationTest, earl:TestCriterion ;
+  mf:action _:b209 ;
+  mf:result _:b210 ;
   mf:name "SPARQL-star - Update - data" ;
   earl:assertions [
     a earl:Assertion ;
@@ -3406,1876 +5311,25 @@
     earl:assertedBy <https://greggkellogg.net/foaf#me> ;
   ] .
 
-<https://w3c.github.io/rdf-star/tests/trig/syntax#manifest> a mf:Manifest, earl:Report ;
-  rdfs:label "TriG-star Syntax Tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1>
-    <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2>) .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-01.trig> ;
-  mf:name "TriG-star - subject quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-basic-02.trig> ;
-  mf:name "TriG-star - object quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-01.trig> ;
-  mf:name "TriG-star - quoted triple inside blankNodePropertyList" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-inside-02.trig> ;
-  mf:name "TriG-star - quoted triple inside collection" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-inside-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-01.trig> ;
-  mf:name "TriG-star - nested quoted triple, subject position" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-nested-02.trig> ;
-  mf:name "TriG-star - nested quoted triple, object position" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-nested-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-compound.trig> ;
-  mf:name "TriG-star - compound forms" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-compound-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-01.trig> ;
-  mf:name "TriG-star - blank node subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-02.trig> ;
-  mf:name "TriG-star - blank node object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bnode-03.trig> ;
-  mf:name "TriG-star - blank node" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bnode-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-01.trig> ;
-  mf:name "TriG-star - bad - quoted triple as predicate" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-02.trig> ;
-  mf:name "TriG-star - bad - quoted triple outside triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-03.trig> ;
-  mf:name "TriG-star - bad - collection list in quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-04.trig> ;
-  mf:name "TriG-star - bad - literal in subject position of quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-05.trig> ;
-  mf:name "TriG-star - bad - blank node  as predicate in quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-06.trig> ;
-  mf:name "TriG-star - bad - compound blank node expression" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-6> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-07.trig> ;
-  mf:name "TriG-star - bad - incomplete quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-7> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-08.trig> ;
-  mf:name "TriG-star - bad - over-long quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-8> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-1.trig> ;
-  mf:name "TriG-star - Annotation form" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> a <http://www.w3.org/ns/rdftest#TestTrigPositiveSyntax>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-annotation-2.trig> ;
-  mf:name "TriG-star - Annotation example" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-ann-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-1.trig> ;
-  mf:name "TriG-star - bad - empty annotation" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> a earl:TestCriterion, earl:TestCase, <http://www.w3.org/ns/rdftest#TestTrigNegativeSyntax> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/syntax/trig-star-syntax-bad-ann-2.trig> ;
-  mf:name "TriG-star - bad - triple as annotation" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/syntax#trig-star-bad-ann-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#manifest> a mf:Manifest, earl:Report ;
-  rdfs:label "TriG-star Evaluation Tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3>) .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-01.nq> ;
-  mf:name "TriG-star - subject quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-02.nq> ;
-  mf:name "TriG-star - object quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-1.nq> ;
-  mf:name "TriG-star - blank node label" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-bnode-2.nq> ;
-  mf:name "TriG-star - blank node labels" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-1.nq> ;
-  mf:name "TriG-star - Annotation form" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-2.nq> ;
-  mf:name "TriG-star - Annotation example" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-3.nq> ;
-  mf:name "TriG-star - Annotation - predicate and object lists" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-4.nq> ;
-  mf:name "TriG-star - Annotation - nested" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-annotation-5.nq> ;
-  mf:name "TriG-star - Annotation object list" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-1.nq> ;
-  mf:name "TriG-star - Annotation with quoting" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-2.nq> ;
-  mf:name "TriG-star - Annotation on triple with quoted subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3> a <http://www.w3.org/ns/rdftest#TestTrigEval>, earl:TestCase, earl:TestCriterion ;
-  mf:action <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.trig> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/trig/eval/trig-star-eval-quoted-annotation-3.nq> ;
-  mf:name "TriG-star - Annotation on triple with quoted object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/trig/eval#trig-star-quoted-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#manifest> a mf:Manifest, earl:Report ;
-  rdfs:seeAlso <https://w3c.github.io/rdf-star/tests/semantics/README> ;
-  rdfs:label "RDF-star Semantics tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same>
-    <https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail>
-    <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term>
-    <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail>
-    <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious>
-    <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control>
-    <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri>
-    <https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotation>
-    <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded>) .
-
-<https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test001a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test001r.ttl> ;
-  rdfs:comment "Multiple occurences of the same quoted triples are undistinguishable in the abstract model." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "all-identical-quoted-triples-are-the-same" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#all-identical-quoted-triples-are-the-same> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test005.ttl> ;
-  rdfs:comment "This test ensures that other entailments are not spurious." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "quoted-triples-no-spurious" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-triples-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sr.ttl> ;
-  rdfs:comment "Terms in quoted triples can be replaced by fresh bnodes." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "bnodes-in-quoted-subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
-  rdfs:comment "Terms in quoted triples can be replaced by fresh bnodes." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "bnodes-in-quoted-object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-object> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
-  rdfs:comment "Terms in quoted triples can be replaced by fresh bnodes." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "bnodes-in-quoted-subject-and-object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
-  rdfs:comment "The same bnode can not match different quoted terms." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "bnodes-in-quoted-subject-and-object-fail" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#bnodes-in-quoted-subject-and-object-fail> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sbr.ttl> ;
-  rdfs:comment "Identical quoted term can be replaced by the same fresh bnode multiple times." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "same-bnode-same-quoted-term" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#same-bnode-same-quoted-term> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test003a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002sor.ttl> ;
-  rdfs:comment "Different bnodes can match identical quoted terms." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "different-bnodes-same-quoted-term" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#different-bnodes-same-quoted-term> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004sr.ttl> ;
-  rdfs:comment "Terms in quoted triples and outside can be replaced by fresh bnodes" ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "constrained-bnodes-in-quoted-subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-subject> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004or.ttl> ;
-  rdfs:comment "Terms in quoted triples and outside can be replaced by fresh bnodes." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "constrained-bnodes-in-quoted-object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-object> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test004a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test004fr.ttl> ;
-  rdfs:comment "Embedded bnode identifiers share the same scope as non-quoted ones. A bnode occuring both in quoted triples and in asserted triples must statisfy them all at the same time." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "constrained-bnodes-in-quoted-fail" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-in-quoted-fail> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test006a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test006r.ttl> ;
-  rdfs:comment "Literals in quoted triples and outside can be replaced by fresh bnodes." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "constrained-bnodes-on-literal" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#constrained-bnodes-on-literal> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-control.ttl> ;
-  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:name "malformed-literal-control" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-control> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  mf:result "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-  rdfs:comment "Malformed literals are allowed when quoted." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:name "malformed-literal" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  rdfs:comment "Malformed literals are allowed when quoted." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:name "malformed-literal-accepted" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-accepted> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal-other.ttl> ;
-  rdfs:comment "Embedded malformed literals do not lead to spurious entailment." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:name "malformed-literal-no-spurious" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-no-spurious> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/malformed-literal.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002or.ttl> ;
-  rdfs:comment "Malformed literals can not be replaced by blank nodes." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:name "malformed-literal-bnode" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#malformed-literal-bnode-neg> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal-control.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal-control.ttl> ;
-  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:name "opaque-literal-control" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal-control> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/non-canonical-literal.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/canonical-literal.ttl> ;
-  rdfs:comment "Embedded literals are opaque, even when their datatype is recognized." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes (<http://www.w3.org/2001/XMLSchema#integer>) ;
-  mf:name "opaque-literal" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-literal> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string-control.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string-control.ttl> ;
-  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes () ;
-  mf:name "opaque-language-string-control" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string-control> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/lowercase-language-string.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/upercase-language-string.ttl> ;
-  rdfs:comment "Embedded literals (including language strings) are opaque, even when their datatype is recognized." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDF" ;
-  mf:recognizedDatatypes () ;
-  mf:name "opaque-language-string" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-language-string> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/control-sameas-r.ttl> ;
-  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDFS-Plus" ;
-  mf:recognizedDatatypes () ;
-  mf:name "opaque-iri-control" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri-control> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/superman.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/superman_undesired_entailment.ttl> ;
-  rdfs:comment "Embedded IRIs are opaque." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "RDFS-Plus" ;
-  mf:recognizedDatatypes () ;
-  mf:name "opaque-iri" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#opaque-iri> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted> a mf:NegativeEntailmentTest, earl:TestCriterion, earl:TestCase ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test002a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test002pgr.ttl> ;
-  rdfs:comment "Embedded triples are not asserted." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "quoted-not-asserted" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#quoted-not-asserted> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r1.ttl> ;
-  rdfs:comment "Annotated triples are asserted." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "annotated-asserted" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotated-asserted> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#annotation> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007r2.ttl> ;
-  rdfs:comment "Annotation are about the annotated triple." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "annotation" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> a earl:TestCriterion, earl:TestCase, mf:PositiveEntailmentTest ;
-  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#approval> <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#NotClassified> ;
-  mf:action <https://w3c.github.io/rdf-star/tests/semantics/test007a2.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/semantics/test007a.ttl> ;
-  rdfs:comment "Annotation is the same as separate assertions." ;
-  mf:unrecognizedDatatypes () ;
-  mf:entailmentRegime "simple" ;
-  mf:recognizedDatatypes () ;
-  mf:name "annotation-unfolded" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/semantics#annotation-unfolded> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#manifest> a mf:Manifest, earl:Report ;
-  rdfs:label "Turtle-star Evaluation Tests" ;
-  mf:entries (<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2>
-    <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3>) .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-01.nt> ;
-  mf:name "Turtle-star - subject quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-02.nt> ;
-  mf:name "Turtle-star - object quoted triple" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-1.nt> ;
-  mf:name "Turtle-star - blank node label" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-bnode-2.nt> ;
-  mf:name "Turtle-star - blank node labels" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-bnode-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-1.nt> ;
-  mf:name "Turtle-star - Annotation form" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-2.nt> ;
-  mf:name "Turtle-star - Annotation example" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-3.nt> ;
-  mf:name "Turtle-star - Annotation - predicate and object lists" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-4.nt> ;
-  mf:name "Turtle-star - Annotation - nested" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-4> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-annotation-5.nt> ;
-  mf:name "Turtle-star - Annotation object list" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-annotation-5> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-1.nt> ;
-  mf:name "Turtle-star - Annotation with quoting" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-1> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-2.nt> ;
-  mf:name "Turtle-star - Annotation on triple with quoted subject" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-2> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3> a <http://www.w3.org/ns/rdftest#TestTurtleEval>, earl:TestCriterion, earl:TestCase ;
-  mf:action <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.ttl> ;
-  mf:result <https://w3c.github.io/rdf-star/tests/turtle/eval/turtle-star-eval-quoted-annotation-3.nt> ;
-  mf:name "Turtle-star - Annotation on triple with quoted object" ;
-  earl:assertions [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/rdf-trig> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:passed
-    ] ;
-    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
-  ], [
-    a earl:Assertion ;
-    earl:test <https://w3c.github.io/rdf-star/tests/turtle/eval#turtle-star-quoted-annotation-3> ;
-    earl:subject <https://rubygems.org/gems/sparql> ;
-    earl:result [
-      a earl:TestResult ;
-      earl:outcome earl:untested
-    ] ;
-  ] .
-
-<https://rubygems.org/gems/rdf-trig> a earl:Software, doap:Project, earl:TestSubject ;
-  doap:release [doap:revision "3.1.2"] ;
-  doap:description "TriG reader/writer for RDF.rb" ;
-  doap:programming-language "Ruby" ;
-  doap:developer <https://greggkellogg.net/foaf#me> ;
+<https://rubygems.org/gems/rdf-trig> a earl:Software, earl:TestSubject, doap:Project ;
+  doap:homepage <https://github.com/ruby-rdf/rdf-trig> ;
   doap:name "RDF::TriG" ;
-  doap:homepage <https://github.com/ruby-rdf/rdf-trig> .
+  doap:developer <https://greggkellogg.net/foaf#me> ;
+  doap:programming-language "Ruby" ;
+  doap:release [doap:revision "3.1.2"] ;
+  doap:description "TriG reader/writer for RDF.rb" .
 
 <https://greggkellogg.net/foaf#me> a earl:Assertor, foaf:Person ;
   foaf:name "Gregg Kellogg" ;
   foaf:homepage <https://greggkellogg.net/> .
 
-<https://rubygems.org/gems/sparql> a earl:Software, doap:Project, earl:TestSubject ;
-  doap:release [doap:revision "3.1.7"] ;
-  doap:description "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite."@en ;
-  doap:programming-language "Ruby" ;
-  doap:developer <https://greggkellogg.net/foaf#me> ;
+<https://rubygems.org/gems/sparql> a earl:Software, earl:TestSubject, doap:Project ;
+  doap:homepage <https://github.com/ruby-rdf/sparql> ;
   doap:name "Ruby SPARQL" ;
-  doap:homepage <https://github.com/ruby-rdf/sparql> .
+  doap:developer <https://greggkellogg.net/foaf#me> ;
+  doap:programming-language "Ruby" ;
+  doap:release [doap:revision "3.1.7"] ;
+  doap:description "SPARQL Implements SPARQL 1.1 Query, Update and result formats for the Ruby RDF.rb library suite."@en .
 
 <https://greggkellogg.net/foaf#me> a earl:Assertor, foaf:Person ;
   foaf:name "Gregg Kellogg" ;
@@ -5295,5 +5349,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.7.0> a doap:Version;
   doap:name "earl-report-0.7.0";
-  doap:created "2021-05-05"^^xsd:date;
+  doap:created "2021-11-07"^^xsd:date;
   doap:revision "0.7.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -5,8 +5,8 @@
 <link href='earl.ttl' rel='alternate' type='text/turtle' />
 <link href='earl.jsonld' rel='alternate' type='application/ld+json' />
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
-<link href='ruby-trig.ttl' rel='related' />
 <link href='ruby-sparql.ttl' rel='related' />
+<link href='ruby-trig.ttl' rel='related' />
 <title>
 RDF-star Processor Conformance
 </title>
@@ -93,8 +93,8 @@ RDF-star Processor Conformance
 EARL results from the RDF-star Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2021-07-07' property='dc:issued'>
-07 July 2021
+<time class='dt-published' datetime='2021-12-02' property='dc:issued'>
+02 December 2021
 </time>
 </h2>
 <dl>
@@ -2351,10 +2351,10 @@ Individual test results used to construct this report are available here:
 </p>
 <ul>
 <li>
-<a class='source' href='ruby-trig.ttl'>ruby-trig.ttl</a>
+<a class='source' href='ruby-sparql.ttl'>ruby-sparql.ttl</a>
 </li>
 <li>
-<a class='source' href='ruby-sparql.ttl'>ruby-sparql.ttl</a>
+<a class='source' href='ruby-trig.ttl'>ruby-trig.ttl</a>
 </li>
 </ul>
 </section>

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -8,7 +8,7 @@
 !!! 5
 %html
   - subjects = tests['testSubjects']
-  - tests['entries'].each {|m| m['title'] ||= m['rdfs:label'] || m['rdfs:comment']}
+  - tests['entries'].each {|m| m['title'] ||= m.fetch('rdfs:label', {})['@value'] || m['rdfs:comment']}
   %head
     %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
     %link{rel: "alternate", type: "text/turtle", href: "earl.ttl"}

--- a/tests/semantics/manifest.ttl
+++ b/tests/semantics/manifest.ttl
@@ -7,7 +7,7 @@ PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX trs:    <https://w3c.github.io/rdf-star/tests#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/semantics#>
 PREFIX dct:    <http://purl.org/dc/terms/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 PREFIX foaf:    <http://xmlns.com/foaf/0.1/>

--- a/tests/trig/syntax/manifest.ttl
+++ b/tests/trig/syntax/manifest.ttl
@@ -7,7 +7,7 @@ PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX trs:    <https://w3c.github.io/rdf-star/tests#>
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/trig/syntax#>
 PREFIX dct:    <http://purl.org/dc/terms/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 PREFIX foaf:   <http://xmlns.com/foaf/0.1/>

--- a/tests/turtle/syntax/manifest.ttl
+++ b/tests/turtle/syntax/manifest.ttl
@@ -7,7 +7,7 @@ PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#> 
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> 
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#> 
-PREFIX trs:    <https://w3c.github.io/rdf-star/tests#> 
+PREFIX trs:    <https://w3c.github.io/rdf-star/tests/turtle/syntax#> 
 PREFIX dct:    <http://purl.org/dc/terms/> 
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#> 
 PREFIX foaf:   <http://xmlns.com/foaf/0.1/> 


### PR DESCRIPTION
This fixes a problem with Semantics, Turtle Syntax and TriG Syntax manifests that incorrectly set the "trs" prefix used for the test entry IRIs.