### PR TITLE
change opacity `:on` to `:measuredOn`

### DIFF
--- a/cg-spec/editors_draft.html
+++ b/cg-spec/editors_draft.html
@@ -3129,13 +3129,13 @@ style="color:black;font-weight:bold">sameTerm</code></dfn></b>
         >
         <!--
         << dbr:Linköping dbo:populationTotal "104232"^^xsd::nonNegativeInteger >>
-          :on "2010-12-31"^^xsd:date ;
+          :measuredOn "2010-12-31"^^xsd:date ;
           :source <https://dbpedia.org/data/Linköping.ttl> .
 
         ### Candidate entailment #1
 
         << dbr:Linköping dbo:populationTotal "000104232"^^xsd::nonNegativeInteger >>
-          :on "2010-12-31"^^xsd:date .
+          :measuredOn "2010-12-31"^^xsd:date .
 
         ### Candidate entailment #2
 
@@ -3146,9 +3146,9 @@ style="color:black;font-weight:bold">sameTerm</code></dfn></b>
         -->
         </pre>
 
-        <p>One could argue that the candidate entailment #1 is desirable because the property `:on` is understood to be about the <em>statement</em> made by the subject triple (that statement was true on the given date, regardless of its RDF expression, in this case using an object value equivalent to `104232`). On the other hand, the candidate entailment #2 may be considered not desirable because the predicate `:source` is about the triple itself (that specific triple was parsed from the given Turtle file).</p>
+        <p>One could argue that the candidate entailment #1 is desirable because the property `:measuredOn` is understood to be about the <em>statement</em> made by the subject triple (that statement was true on the given date, regardless of its RDF expression, in this case using an object value equivalent to `104232`). On the other hand, the candidate entailment #2 may be considered not desirable because the predicate `:source` is about the triple itself (that specific triple was parsed from the given Turtle file).</p>
 
-        <p>In Section <a href="#rdf-star-vocabulary"></a>, we introduce the notion of <dfn data-lt="TEP">transparency-enabling property (TEP)</dfn>, for selectively enabling this kind of entailment on specific properties. The basis of the idea is that each such property&nbsp;|p| is identified by adding to the RDF-star graph a triple of the form (|p|, `rdf:type`, `rdf-star:TransparencyEnablingProperty`); i.e., for the previous example, this triple would be (`:on`, `rdf:type`, `rdf-star:TransparencyEnablingProperty`).
+        <p>In Section <a href="#rdf-star-vocabulary"></a>, we introduce the notion of <dfn data-lt="TEP">transparency-enabling property (TEP)</dfn>, for selectively enabling this kind of entailment on specific properties. The basis of the idea is that each such property&nbsp;|p| is identified by adding to the RDF-star graph a triple of the form (|p|, `rdf:type`, `rdf-star:TransparencyEnablingProperty`); i.e., for the previous example, this triple would be (`:measuredOn`, `rdf:type`, `rdf-star:TransparencyEnablingProperty`).
         This would make candidate entailment #1 above valid. The semantics of such TEPs is formally defined in Section <a href="#vocabulary-semantics"></a>.</p>
 
         <p>Notice that enabling referential transparency based on such TEPs is only local to the RDF-star graph(s) in which the property is stated to be a TEP (or where this statement can be inferred as per the entailment regime considered). In other words, for every graph&nbsp;|G| in which a property is <em>not</em> stated to be transparency enabling, all quoted triples appearing in |G| as subject or object of that property are stilled considered as referentially opaque, even if there may exist some other graph in which the property is stated to be transparency enabling.</p>


### PR DESCRIPTION
`:on` could also apply to the date it was extracted from dbpedia, which isn't the point of the example.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/pull/227.html" title="Last updated on Dec 3, 2021, 8:06 AM UTC (4375e79)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-star/227/302abfa...4375e79.html" title="Last updated on Dec 3, 2021, 8:06 AM UTC (4375e79)">Diff</a>