### PR TITLE
Add missing objects in `sparql-star-syntax-bad-ann-path-*.rq` tests

### DIFF
--- a/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq
+++ b/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-2.rq
@@ -1,5 +1,5 @@
 PREFIX : <http://example.com/ns#>
 
 SELECT * {
-  :x (:p|:q) {| ?p ?o |}
+  :x (:p|:q) :o {| ?p ?o |}
 }

--- a/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq
+++ b/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-3.rq
@@ -1,5 +1,5 @@
 PREFIX : <http://example.com/ns#>
 
 SELECT * {
-  :x :p* {| ?p ?o |}
+  :x :p* :o {| ?p ?o |}
 }

--- a/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq
+++ b/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-4.rq
@@ -1,5 +1,5 @@
 PREFIX : <http://example.com/ns#>
 
 SELECT * {
-  :x :p+ {| ?p ?o |}
+  :x :p+ :o {| ?p ?o |}
 }

--- a/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq
+++ b/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-5.rq
@@ -1,5 +1,5 @@
 PREFIX : <http://example.com/ns#>
 
 SELECT * {
-  ?X :p? {| ?p ?o |} 
+  ?X :p? :o {| ?p ?o |}
 }

--- a/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq
+++ b/tests/sparql/syntax/sparql-star-syntax-bad-ann-path-6.rq
@@ -1,7 +1,7 @@
 PREFIX : <http://example.com/ns#>
 
 CONSTRUCT {
-  ?s :p {| (:q1|:q2) :o |} 
+  ?s :p :o {| (:q1|:q2) :o |}
 } WHERE
   ?s :p ?o 
 }


### PR DESCRIPTION
Object parts are missing in the patterns in tests

    sparql-star-syntax-bad-ann-path-2.rq
    sparql-star-syntax-bad-ann-path-3.rq
    sparql-star-syntax-bad-ann-path-4.rq
    sparql-star-syntax-bad-ann-path-5.rq
    sparql-star-syntax-bad-ann-path-6.rq

This makes a correct SPARQL-star parser fail the tests as intended,
but for a different reason.