### PR TITLE
Highlight the final report

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,9 @@
           <a href="https://www.w3.org/community/rdf-dev/">RDF-DEV community group.</a>
         </p>
 
+        <p style="font-weight: bold"
+           >** <a href="https://www.w3.org/2021/12/rdf-star.html">Final Community Group Report</a> **</p>
+
         <p>Community:</p>
         <ul>
           <li><a href="https://github.com/w3c/rdf-star/issues/">Github issues list</a></li>


### PR DESCRIPTION
Put a link to the final community group report near the top of the home page.